### PR TITLE
Support naming layers in the layertree with projecttopping file

### DIFF
--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -504,11 +504,22 @@ class Generator(QObject):
                         if node:
                             current_node.append(node)
             else:
-                # get layer
-                for layer in layers:
-                    if layer.alias == current_node_name:
-                        current_node = layer
-                        break
+                # get layer according to the ili name
+                if "iliname" in item_properties:
+                    for layer in layers:
+                        ili_name = item_properties.get("iliname")
+                        if layer.ili_name == ili_name:
+                            layer.alias = current_node_name
+                            current_node = layer
+                            break
+
+                if not current_node:
+                    # get the layer according to the alias
+                    for layer in layers:
+                        if layer.alias == current_node_name:
+                            current_node = layer
+                            break
+
                 if not current_node:
                     current_node = self.generate_node(
                         layers, current_node_name, item_properties

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -504,11 +504,24 @@ class Generator(QObject):
                         if node:
                             current_node.append(node)
             else:
-                # get layer according to the ili name
-                if "iliname" in item_properties:
+                # get layer according to the tablename or iliname
+                if "tablename" in item_properties or "iliname" in item_properties:
                     for layer in layers:
-                        ili_name = item_properties.get("iliname")
-                        if layer.ili_name == ili_name:
+                        tablename = item_properties.get("tablename")
+                        iliname = item_properties.get("iliname")
+                        if (
+                            layer.name == tablename
+                            or iliname
+                            and layer.ili_name == iliname
+                        ):
+                            # if a geometrycolumn is provided, then only consider layer if it's the right one
+                            geometry_column = item_properties.get("geometrycolumn")
+                            if (
+                                geometry_column
+                                and layer.geometry_column != geometry_column
+                            ):
+                                continue
+                            # otherwise consider the layer and change the alias
                             layer.alias = current_node_name
                             current_node = layer
                             break

--- a/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_iliname_KbS_LV95_V1_4.yaml
+++ b/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_iliname_KbS_LV95_V1_4.yaml
@@ -1,0 +1,18 @@
+layertree:
+    - "KbS_LV95_V1_4 Layers":
+        group: true
+        child-nodes:
+            - "Punkt Standort":
+                tablename: "belasteter_standort"
+                #iliname: "KbS_LV95_V1_4.Belastete_Standorte.Belasteter_Standort"
+                geometrycolumn: "geo_lage_punkt"
+                qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt.qml"
+            - "Polygon Standort":
+                #tablename: "belasteter_standort"
+                iliname: "KbS_LV95_V1_4.Belastete_Standorte.Belasteter_Standort"
+                geometrycolumn: "geo_lage_polygon"
+                qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_001_belasteterstandort_polygon.qml"
+            - "Parzellen":
+                tablename: "parzellenidentifikation"
+                iliname: "KbS_Basis_V1_4.Parzellenidentifikation"
+                qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_005_parzellenidentifikation.qml"


### PR DESCRIPTION
When passing a project topping file to the generator. The legend will be created accordingly. Until now an existing layer has been recognized by it's name. Because this leaded to  problems when models with base models are implemented with multiple layers having the same name, we are now able to recognize a layer by it's **tablename** or **iliname**. For tables with multiple geometries, the **geometrycolumn** is considered as well.

Example can be found in the test file.
```layertree:
    - "KbS_LV95_V1_4 Layers":
        group: true
        child-nodes:
            - "Punkt Standort":
                tablename: "belasteter_standort"
                #iliname: "KbS_LV95_V1_4.Belastete_Standorte.Belasteter_Standort"
                geometrycolumn: "geo_lage_punkt"
                qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt.qml"
            - "Polygon Standort":
                #tablename: "belasteter_standort"
                iliname: "KbS_LV95_V1_4.Belastete_Standorte.Belasteter_Standort"
                geometrycolumn: "geo_lage_polygon"
                qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_001_belasteterstandort_polygon.qml"
            - "Parzellen":
                tablename: "parzellenidentifikation"
                iliname: "KbS_Basis_V1_4.Parzellenidentifikation"
                qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_005_parzellenidentifikation.qml"
```

Fixes https://github.com/opengisch/QgisModelBaker/issues/662 concerning UsabILIty Hub.

At the moment it's not possible to add the same layer multiple times.