### PR TITLE
use urllib.parse.urljoin to join urls

### DIFF
--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -81,8 +81,10 @@ class IliCache(QObject):
     def file_url(self, url, file):
         if url is None:
             return file
-        else:
+        elif os.path.isdir(url):
             return os.path.join(url, file)
+        else:
+            return urllib.parse.urljoin(url + "/", file)
 
     def file_path(self, netloc, url, file):
         if url is None:


### PR DESCRIPTION
and append a / in the end to handle the path as a directory in any case.

This reverts https://github.com/opengisch/QgisModelBaker/commit/101c9a1b378476a400c17ac01d8418e37493c852 because in windows backslashes are appended on `os.path.join`.