### PR TITLE
use only the model+topic as default basket identificator 

### DIFF
--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -338,25 +338,10 @@ class Generator(QObject):
                     ]
 
                 if self.basket_handling and column_name in BASKET_FIELDNAMES:
-                    if self.tool in [
-                        DbIliMode.pg,
-                        DbIliMode.ili2pg,
-                        DbIliMode.mssql,
-                        DbIliMode.ili2mssql,
-                    ]:
-                        schema_topic_identificator = slugify(
-                            f"{layer.source().host()}_{layer.source().database()}_{layer.source().schema()}_{layer.model_topic_name}"
-                        )
-                        field.default_value_expression = (
-                            f"@{schema_topic_identificator}"
-                        )
-                    elif self.tool in [DbIliMode.ili2gpkg, DbIliMode.gpkg]:
-                        schema_topic_identificator = slugify(
-                            f"@{layer.source().uri().split('|')[0].strip()}_{layer.model_topic_name}"
-                        )
-                        field.default_value_expression = (
-                            f"@{schema_topic_identificator}"
-                        )
+                    default_basket_topic = slugify(
+                        f"default_basket{'_' if layer.model_topic_name else ''}{layer.model_topic_name}"
+                    )
+                    field.default_value_expression = f"@{default_basket_topic}"
 
                 if "enum_domain" in fielddef and fielddef["enum_domain"]:
                     field.enum_domain = fielddef["enum_domain"]


### PR DESCRIPTION
because otherwise imported QMLs break the functionality. Having different schemas with the same models / topics in the same project does not work anymore, but I think we can live with it.