### PR TITLE
Fix crash on accessing layer of QgsNodeTreeNode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,6 @@ repos:
 
   # Black formatting
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black

--- a/modelbaker/utils/qgis_utils.py
+++ b/modelbaker/utils/qgis_utils.py
@@ -17,7 +17,13 @@
  ***************************************************************************/
 """
 
-from qgis.core import Qgis, QgsLayerTreeNode, QgsMapLayer, QgsWkbTypes
+from qgis.core import (
+    Qgis,
+    QgsLayerTreeLayer,
+    QgsLayerTreeNode,
+    QgsMapLayer,
+    QgsWkbTypes,
+)
 
 layer_order = [
     "point",  # QgsWkbTypes.PointGeometry
@@ -56,9 +62,12 @@ def get_first_index_for_layer_type(layer_type, group, ignore_node_names=None):
             # We've reached the lowest index in the layer tree before a group
             return current
 
-        layer = tree_node.layer()
-        if get_layer_type(layer) == layer_type:
-            return current
+        # Make this check because children() sometimes returns nodes of type QgsLayerTreeNode instead.
+        # This is a workaround for a weird behavior of QGIS.
+        if isinstance(tree_node, QgsLayerTreeLayer):
+            layer = tree_node.layer()
+            if get_layer_type(layer) == layer_type:
+                return current
 
     return None
 


### PR DESCRIPTION
I would like to have this "workaround" fix of a problem from QGIS core to avoid getting an error.

Users still report this issue (with QGIS 3.22). To fix it in QGIS I would need some more investigations because it's hard to reproduce.

More information in this (closed) PR https://github.com/opengisch/QgisModelBaker/pull/514