### PR TITLE
Support combination of pg service conf params and manual settings (and auth conf)

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -25,6 +25,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Package PyPI Packages
+        run: |
+          sudo ./scripts/package_pip_packages.sh
       - name: Test on QGIS
         run: docker-compose -f .docker/docker-compose.gh.yml run qgis /usr/src/.docker/run-docker-tests.sh
       - name: Test on QGIS with PG
@@ -40,6 +43,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.9
+    - name: Package PyPI Packages
+      run: |
+        sudo ./scripts/package_pip_packages.sh
     - name: Get version number
       id: v
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,6 @@ repos:
 
   # Black formatting
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black

--- a/README.md
+++ b/README.md
@@ -75,3 +75,28 @@ pip install modelbaker
 
 ### ili2db
 In the current release we use ili2db version 4.6.1
+
+## Infos for Devs
+
+### Code style
+
+Is enforced with pre-commit. To use, make:
+```
+pip install pre-commit
+pre-commit install
+```
+And to run it over all the files (with infile changes):
+```
+pre-commit run --color=always --all-file
+```
+
+### Needed packages from PyPI
+
+Needed packages from PyPI are downloaded and packaged on deployment to the plugin's libs folder.
+
+Run the script to download and unpack them or install them to your system.
+
+Script:
+```
+./scripts/package_pip_packages.sh
+```

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+LIBS_DIR="modelbaker/libs"
+
+PGSERVICEPARSER=("pgserviceparser" "1.0.2")
+
+PACKAGES=(
+  PGSERVICEPARSER[@]
+)
+
+#create lib folder
+mkdir -p $LIBS_DIR
+
+for PACKAGE in ${PACKAGES[@]}; do
+  echo download and unpack ${!PACKAGE:0:1} with version ${!PACKAGE:1:1}
+  #create temp folder
+  mkdir -p temp
+  #download the wheel
+  pip download -v ${!PACKAGE:0:1}==${!PACKAGE:1:1} --only-binary :all: -d temp/
+  #unpack the wheel
+  unzip -o temp/${!PACKAGE:0:1}*.whl -d $LIBS_DIR
+  #remove temp folder
+  rm -r temp
+  #set write rights to group (because qgis-plugin-ci needs it)
+  chmod -R g+w $LIBS_DIR
+done

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 LIBS_DIR="modelbaker/libs"
 
-PGSERVICEPARSER=("pgserviceparser" "1.0.2")
+PGSERVICEPARSER=("pgserviceparser" "1.1.0")
 
 PACKAGES=(
   PGSERVICEPARSER[@]

--- a/tests/test_pgservice.py
+++ b/tests/test_pgservice.py
@@ -1,0 +1,189 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+    begin                :    22/06/2022
+    git sha              :    :%H$
+    copyright            :    (C) 2022 by Dave Signer (took base from) Damiano Lombardi
+    email                :    david@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+import os
+
+from qgis.testing import start_app, unittest
+
+from modelbaker.iliwrapper.ili2dbconfig import Ili2DbCommandConfiguration
+from modelbaker.utils.globals import DbActionType
+from tests.utils import get_pg_connection_string, iliimporter_config, testdata_path
+
+start_app()
+
+
+class TestPgservice(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.pgservicefile = os.environ.get("PGSERVICEFILE", None)
+        os.environ["PGSERVICEFILE"] = testdata_path("pgservice/pg_service.conf")
+
+    def test_pure_service(self):
+        """
+        Set up connection with service configuration without authentification.
+        In the uri the connection parameters are taken from the service conf and the username password from the seperate parameters.
+        """
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbschema = "roads_simple_pure{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+
+        importer.configuration.dbservice = "freddys_service"
+        # needs superuser since credentials from service are not valid
+        importer.configuration.db_use_super_login = True
+
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            "smart2",
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # check layer uri if dbname/user/password are not in the manual params but from service conf: user and password are freddy
+
+    def test_manual_service(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbschema = "roads_simple_pure{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+
+        importer.configuration.dbservice = "onlydb_service"
+        # needs superuser since credentials from service are not valid
+        importer.configuration.db_use_super_login = True
+
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            "smart2",
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # check layer uri if dbname are not in the manual but user password are (docker)
+
+    def test_authconf_service(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbschema = "roads_simple_pure{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+
+        importer.configuration.dbservice = "freddys_service"
+        # needs superuser since credentials from service are not valid
+        importer.configuration.db_use_super_login = True
+
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            "smart2",
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # check layer uri if dbname are not in the manual and neither password and user but authdb instead
+
+    def test_pgservice_pg_config_panel(self):
+
+        pg_config_panel = PgConfigPanel(None, DbActionType.EXPORT)
+        pg_config_panel.show()
+
+        index_postgis_test = pg_config_panel.pg_service_combo_box.findData(
+            "postgis_test", PgConfigPanel._SERVICE_COMBOBOX_ROLE.DBSERVICE
+        )
+        self.assertIsNot(index_postgis_test, -1)
+
+        configuration = Ili2DbCommandConfiguration()
+        configuration.dbservice = "postgis_test"
+        pg_config_panel.set_fields(configuration)
+        pg_config_panel.get_fields(configuration)
+
+        self.assertEqual(configuration.dbhost, "db.test.com")
+        self.assertEqual(configuration.dbport, "5433")
+        self.assertEqual(configuration.dbusr, "postgres")
+        self.assertEqual(configuration.dbpwd, "secret")
+        self.assertEqual(configuration.sslmode, "verify-ca")
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests."""
+        if cls.pgservicefile:
+            os.environ["PGSERVICEFILE"] = cls.pgservicefile

--- a/tests/testdata/pgservice/pg_service.conf
+++ b/tests/testdata/pgservice/pg_service.conf
@@ -1,8 +1,8 @@
 # comment
-[freddys_service]
+[sevys_service]
 dbname=gis
-user=freddy
-password=freddy
+user=sevy
+password=sevys_password
 
-[onlydb_service]
+[manis_service]
 dbname=gis

--- a/tests/testdata/pgservice/pg_service.conf
+++ b/tests/testdata/pgservice/pg_service.conf
@@ -1,9 +1,0 @@
-
-[postgis_test]
-host=db.test.com
-port=5433
-user=postgres
-password=secret
-dbname=postgres
-
-sslmode=verify-ca

--- a/tests/testdata/pgservice/pg_service.conf
+++ b/tests/testdata/pgservice/pg_service.conf
@@ -1,0 +1,8 @@
+# comment
+[freddys_service]
+dbname=gis
+user=freddy
+password=freddy
+
+[onlydb_service]
+dbname=gis


### PR DESCRIPTION
When having a pg service conf file the following needs to be done:
- _When a "service" chosen in the GUI it should disable the option to change settings, that are set in the conf file. But it should keep available the ones that are not configured in the conf file. (not part of this pr. See https://github.com/opengisch/QgisModelBaker/pull/703)_
- When creating the URI there should be contained the service and all the settings that are manually set - and not the ones read from the conf file.
- When getting the connection parameters from a layer source (e.g. by the validator) it should read them from the conf file, if not available directly in the source.

For this implementation we need to pack the package `pgserviceparser` (from pypi) into this package.

To do:
- [x] Fix the tests

Resolves https://github.com/opengisch/QgisModelBaker/issues/668