### PR TITLE
Avoid receiving structures containing enums back as topics

### DIFF
--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -297,7 +297,8 @@ class DBConnector(QObject):
 
     def get_topics_info(self):
         """
-        Returns all the topics found in the table t_ili2db_classname
+        Returns all the topics found in the table t_ili2db_classname as long as they contain tables found in t_ili2db_table_prop and are there not defined as ENUM.
+        This avoids to get structures back, containing enumerations and not being in a topic, having the structure <modelname>.<structurename>.<enumerationname>.
         Return:
             Iterable allowing to access rows, each row should allow to access
             specific columns by name (e.g., a list of dicts {column_name:value})

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -704,10 +704,12 @@ class GPKGConnector(DBConnector):
             cur = self.conn.cursor()
             cur.execute(
                 """
-                    SELECT DISTINCT substr(IliName, 0, instr(IliName, '.')) as model,
-                    substr(substr(IliName, instr(IliName, '.')+1),0, instr(substr(IliName, instr(IliName, '.')+1),'.')) as topic
-                    FROM T_ILI2DB_CLASSNAME
-					WHERE topic != ''
+                    SELECT DISTINCT substr(CN.IliName, 0, instr(CN.IliName, '.')) as model,
+                    substr(substr(CN.IliName, instr(CN.IliName, '.')+1),0, instr(substr(CN.IliName, instr(CN.IliName, '.')+1),'.')) as topic
+                    FROM T_ILI2DB_CLASSNAME as CN
+                    JOIN T_ILI2DB_TABLE_PROP as TP
+                    ON CN.sqlname = TP.tablename
+					WHERE topic != '' and TP.setting != 'ENUM'
                 """
             )
             contents = cur.fetchall()

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -402,7 +402,9 @@ class MssqlConnector(DBConnector):
                 stmt += ln + "    AND enum_domain.tag = 'ch.ehi.ili2db.enumDomain'"
                 stmt += ln + "LEFT JOIN {schema}.t_ili2db_column_prop oid_domain"
                 stmt += ln + "    ON c.table_name = oid_domain.tablename"
-                stmt += ln + "    AND LOWER(c.column_name) = LOWER(oid_domain.columnname)"
+                stmt += (
+                    ln + "    AND LOWER(c.column_name) = LOWER(oid_domain.columnname)"
+                )
                 stmt += ln + "    AND oid_domain.tag = 'ch.ehi.ili2db.oidDomain'"
                 if metaattrs_exists:
                     stmt += ln + "LEFT JOIN {schema}.t_ili2db_meta_attrs form_order"
@@ -773,10 +775,12 @@ WHERE TABLE_SCHEMA='{schema}'
             cur = self.conn.cursor()
             cur.execute(
                 """
-                    SELECT DISTINCT PARSENAME(iliname,1) as model,
-                    PARSENAME(iliname,2) as topic
-                    FROM {schema}.t_ili2db_classname
-					WHERE PARSENAME(iliname,3) != ''
+                    SELECT DISTINCT PARSENAME(cn.iliname,1) as model,
+                    PARSENAME(cn.iliname,2) as topic
+                    FROM {schema}.t_ili2db_classname as cn
+                    JOIN {schema}.t_ili2db_table_prop as tp
+                    ON cn.sqlname = tp.tablename
+					WHERE PARSENAME(cn.iliname,3) != '' and tp.setting != 'ENUM'
                 """.format(
                     schema=self.schema
                 )

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -876,10 +876,12 @@ class PGConnector(DBConnector):
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
             cur.execute(
                 """
-                    SELECT DISTINCT (string_to_array(iliname, '.'))[1] as model,
-                    (string_to_array(iliname, '.'))[2] as topic
-                    FROM {schema}.t_ili2db_classname
-					WHERE array_length(string_to_array(iliname, '.'),1) > 2
+                    SELECT DISTINCT (string_to_array(cn.iliname, '.'))[1] as model,
+                    (string_to_array(cn.iliname, '.'))[2] as topic
+                    FROM {schema}.t_ili2db_classname as cn
+                    JOIN {schema}.t_ili2db_table_prop as tp
+                    ON cn.sqlname = tp.tablename
+					WHERE array_length(string_to_array(cn.iliname, '.'),1) > 2 and tp.setting != 'ENUM'
                 """.format(
                     schema=self.schema
                 )

--- a/tests/testdata/ilimodels/PipeBasketTest_V1.ili
+++ b/tests/testdata/ilimodels/PipeBasketTest_V1.ili
@@ -5,6 +5,7 @@ AT "https://signedav.github.io/usabilitydave/models"
 VERSION "2020-06-22" =
 
   STRUCTURE Address =
+    JustARandomEnum: (One, Two, Three);
     Street: TEXT;
     Number: TEXT;
   END Address;


### PR DESCRIPTION
In get_topics_info only consider topics of tables that exist in the schema (means in t_ili2db_table, that does not contain abstract classes) and not consider tables with setting ENUM.

This avoids to get structures back, containing enumerations and not being in a topic, having the structure <modelname>.<structurename>.<enumerationname>.

Like e.g. 
```
MODEL PipeBasketTest (en)=

  STRUCTURE Address =
    JustARandomEnum: (One, Two, Three);
    Street: TEXT;
    Number: TEXT;
  END Address;
```

Returned before a topic called `PipeBasketTest.Address`. This is fixed now.