### PR TITLE
Fallback on name, when layer has no alias (Layertree Topping)

### DIFF
--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -206,7 +206,7 @@ class Generator(QObject):
             )
             coordinate_precision = None
             if coord_decimals:
-                coordinate_precision = 1 / (10 ** coord_decimals)
+                coordinate_precision = 1 / (10**coord_decimals)
 
             layer = Layer(
                 layer_uri.provider,
@@ -519,6 +519,13 @@ class Generator(QObject):
                     # get the layer according to the alias
                     for layer in layers:
                         if layer.alias == current_node_name:
+                            current_node = layer
+                            break
+
+                if not current_node:
+                    # get the layer according to the name
+                    for layer in layers:
+                        if layer.name == current_node_name:
                             current_node = layer
                             break
 

--- a/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_iliname_KbS_LV95_V1_4.yaml
+++ b/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_iliname_KbS_LV95_V1_4.yaml
@@ -16,3 +16,10 @@ layertree:
                 tablename: "parzellenidentifikation"
                 iliname: "KbS_Basis_V1_4.Parzellenidentifikation"
                 qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_005_parzellenidentifikation.qml"
+    - "System Layers":
+        group: true
+        child-nodes:
+            - "t_ili2db_dataset":
+                #alias is empty, so it should find the layer name
+            - "t_ili2db_basket":
+                #alias is empty, so it should find the layer name


### PR DESCRIPTION
Fallback when layer has no alias (yet) it looks up the name for the layertree topping, like e.g. t_ili2db_baskets.

Fixes https://github.com/opengisch/QgisModelBaker/issues/701