### PR TITLE
Get the values from the ili2db settings table

### DIFF
--- a/.docker/docker-compose.gh.yml
+++ b/.docker/docker-compose.gh.yml
@@ -10,6 +10,14 @@ services:
     environment:
       - ALLOW_IP_RANGE="172.0.0.0/8"
 
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2019-CU11-ubuntu-20.04
+    environment:
+      ACCEPT_EULA: Y
+      SA_PASSWORD: <YourStrong!Passw0rd>
+    ports:
+      - "1433:1433"
+
   qgis:
     build:
       context: ..
@@ -22,3 +30,4 @@ services:
     links:
       - postgres11
       - postgres12
+      - mssql

--- a/.docker/docker-compose.gh.yml
+++ b/.docker/docker-compose.gh.yml
@@ -10,14 +10,6 @@ services:
     environment:
       - ALLOW_IP_RANGE="172.0.0.0/8"
 
-  mssql:
-    image: mcr.microsoft.com/mssql/server:2019-CU11-ubuntu-20.04
-    environment:
-      ACCEPT_EULA: Y
-      SA_PASSWORD: <YourStrong!Passw0rd>
-    ports:
-      - "1433:1433"
-
   qgis:
     build:
       context: ..
@@ -30,4 +22,3 @@ services:
     links:
       - postgres11
       - postgres12
-      - mssql

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 __pycache__
 /modelbaker/iliwrapper/bin
+/modelbaker/libs
 *.orig
 i18n
 .DS_Store

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -319,7 +319,13 @@ class DBConnector(QObject):
         Returns `True` if a tid handling is enabled according to the settings table (when the database has been created with `--createTidCol`).
         If t_ili_tids are used only because of a stable id definition in the model (with `OID as` in the topic or the class definition), this parameter is not set and this function will return `False`.
         """
-        return False
+        return {}
+
+    def get_ili2db_settings(self):
+        """
+        Returns the settings like they are without any name mapping etc.
+        """
+        return {}
 
 
 class DBConnectorError(Exception):

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -317,7 +317,7 @@ class DBConnector(QObject):
     def get_tid_handling(self):
         """
         Returns `True` if a tid handling is enabled according to the settings table (when the database has been created with `--createTidCol`).
-        If t_ili_tids are used only because of a stable id definition in the model (with `OID as` in the topic or the class definition), this parameter is not set and this function will return `False`.
+        If t_ili_tids are used only because of a stable id definition in the model (with `OID as` in the topic or the class definition), this parameter is not set and this function will return `{}`.
         """
         return {}
 

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -807,6 +807,21 @@ class GPKGConnector(DBConnector):
                 return content[0] == "property"
         return False
 
+    def get_ili2db_settings(self):
+        result = {}
+        if self._table_exists(GPKG_SETTINGS_TABLE):
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """SELECT *
+                            FROM {}
+                            """.format(
+                    GPKG_SETTINGS_TABLE
+                )
+            )
+            result = cursor.fetchall()
+            cursor.close()
+        return result
+
     def _fetch_and_increment_key_object(self, field_name):
         next_id = 0
         if self._table_exists("T_KEY_OBJECT"):

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -848,3 +848,17 @@ WHERE TABLE_SCHEMA='{schema}'
             if content:
                 return content[0] == "property"
         return False
+
+    def get_ili2db_settings(self):
+        result = {}
+        if self._table_exists(SETTINGS_TABLE):
+            cur = self.conn.cursor()
+            cur.execute(
+                """SELECT tag, setting
+                            FROM {schema}.{table}
+                            """.format(
+                    schema=self.schema, table=SETTINGS_TABLE
+                )
+            )
+            result = self._get_dict_result(cur)
+        return result

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -951,3 +951,17 @@ class PGConnector(DBConnector):
             if content:
                 return content[0] == "property"
         return False
+
+    def get_ili2db_settings(self):
+        result = {}
+        if self._table_exists(PG_SETTINGS_TABLE):
+            cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+            cur.execute(
+                sql.SQL(
+                    """SELECT tag, setting
+                           FROM {}.{}
+                            """
+                ).format(sql.Identifier(self.schema), sql.Identifier(PG_SETTINGS_TABLE))
+            )
+            result = cur.fetchall()
+        return result

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -130,13 +130,19 @@ class Ili2DbCommandConfiguration(object):
         self.db_ili_version = None
 
     def append_args(self, args, values, consider_metaconfig=False):
-        # since passing metaconfig is not supported yet. see https://github.com/claeis/ili2db/issues/392 we disable the functionality by setting consider_metaconfig to false
-        consider_metaconfig = False
+
         if consider_metaconfig and self.metaconfig and values:
             if "ch.ehi.ili2db" in self.metaconfig.sections():
                 metaconfig_ili2db_params = self.metaconfig["ch.ehi.ili2db"]
                 if values[0][2:] in metaconfig_ili2db_params.keys():
-                    return
+                    # since passing metaconfig is not supported yet. see https://github.com/claeis/ili2db/issues/392 we do not avoid adding the value to the args
+                    print(
+                        self.tr(
+                            "Value {} from metaconfiguration file not considered. ".format(
+                                values[0][2:]
+                            )
+                        )
+                    )
         args += values
 
     def to_ili2db_args(self):

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -130,6 +130,8 @@ class Ili2DbCommandConfiguration(object):
         self.db_ili_version = None
 
     def append_args(self, args, values, consider_metaconfig=False):
+        # since passing metaconfig is not supported yet. see https://github.com/claeis/ili2db/issues/392 we disable the functionality by setting consider_metaconfig to false
+        consider_metaconfig = False
         if consider_metaconfig and self.metaconfig and values:
             if "ch.ehi.ili2db" in self.metaconfig.sections():
                 metaconfig_ili2db_params = self.metaconfig["ch.ehi.ili2db"]


### PR DESCRIPTION
Function to get the values from the ili2db settings.

And in ili2db config the function to concern a metaconfig file in the ili2db command disables the removing of the parameter set (when they are set in the metaconfig file) because otherwise it leads to problem, when we pass a metaconfig file to modelbaker with parameters ili2db cannot handle. 