### PR TITLE
Ili2db 4.9.0

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list
 RUN apt-get update
-RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools unixodbc unixodbc-dev libqt5sql5-odbc
+RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools odbcinst1debian2 libodbc1 unixodbc unixodbc-dev libqt5sql5-odbc
 
 COPY ./requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt

--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && \
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list
 RUN apt-get update
-RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools odbcinst1debian2 libodbc1 unixodbc unixodbc-dev libqt5sql5-odbc
+RUN ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools unixodbc unixodbc-dev libqt5sql5-odbc
 
 COPY ./requirements.txt /tmp/
 RUN pip3 install -r /tmp/requirements.txt

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -212,8 +212,11 @@ class DBConnector(QObject):
                     static_tables.append(record["tablename"])
                     continue
             if "tablename" in record:
-                if record["tablename"] in IGNORED_TABLES and (
-                    ignore_basket_tables or record["tablename"] not in BASKET_TABLES
+                if self.is_spatial_index_table(record["tablename"]) or (
+                    record["tablename"] in IGNORED_TABLES
+                    and (
+                        ignore_basket_tables or record["tablename"] not in BASKET_TABLES
+                    )
                 ):
                     static_tables.append(record["tablename"])
                     continue
@@ -223,6 +226,10 @@ class DBConnector(QObject):
                 referencing_detected_tables.append(record["referencing_table"])
 
         return static_tables + detected_tables + referencing_detected_tables
+
+    def is_spatial_index_table(self, tablename=str) -> bool:
+        """Note: Checks if the table is a technical table used for spatial indexing"""
+        return False
 
     def get_iliname_dbname_mapping(self, sqlnames=list()):
         """Note: the parameter sqlnames is only used for ili2db version 3 relation creation"""

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -477,6 +477,12 @@ class GPKGConnector(DBConnector):
             cursor.close()
         return bags_of_info
 
+    def is_spatial_index_table(self, tablename=str) -> bool:
+        """Note: Checks if the table is a technical table used for spatial indexing"""
+        if tablename and tablename[0:6] == "rtree_":
+            return True
+        return False
+
     def get_iliname_dbname_mapping(self, sqlnames=list()):
         """Note: the parameter sqlnames is only used for ili2db version 3 relation creation"""
         # Map domain ili name with its correspondent sql name

--- a/modelbaker/iliwrapper/ili2dbtools.py
+++ b/modelbaker/iliwrapper/ili2dbtools.py
@@ -26,17 +26,17 @@ def get_tool_version(tool, db_ili_version):
         if db_ili_version == 3:
             return "3.11.3"
         else:
-            return "4.6.1"
+            return "4.9.0"
     elif tool == DbIliMode.ili2pg:
         if db_ili_version == 3:
             return "3.11.2"
         else:
-            return "4.6.1"
+            return "4.9.0"
     elif tool == DbIliMode.ili2mssql:
         if db_ili_version == 3:
             return "3.12.2"
         else:
-            return "4.6.1"
+            return "4.9.0"
 
     return "0"
 

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -1497,6 +1497,7 @@ class TestDomainClassRelation(unittest.TestCase):
         )
         importer.configuration.srs_code = 21781
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -1957,6 +1958,7 @@ class TestDomainClassRelation(unittest.TestCase):
         )
         importer.configuration.srs_code = 21781
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -3752,6 +3754,7 @@ class TestDomainClassRelation(unittest.TestCase):
         )
         importer.configuration.srs_code = 21781
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS

--- a/tests/test_gpkg_pk.py
+++ b/tests/test_gpkg_pk.py
@@ -129,6 +129,7 @@ class TestGpkgPrimaryKey(unittest.TestCase):
             ),
         )
         importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -293,12 +293,15 @@ class TestImport(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/PipeBasketTest_V1.ili")
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/PipeBasketTest_V1.ili"
+        )
         importer.configuration.ilimodels = "PipeBasketTest"
         importer.configuration.dbschema = "any_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -344,12 +347,15 @@ class TestImport(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
         importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/PipeBasketTest_V1.ili")
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/PipeBasketTest_V1.ili"
+        )
         importer.configuration.ilimodels = "PipeBasketTest"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, "tmp_basket_gpkg.gpkg"
         )
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -393,12 +399,15 @@ class TestImport(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
         importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/PipeBasketTest_V1.ili")
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/PipeBasketTest_V1.ili"
+        )
         importer.configuration.ilimodels = "PipeBasketTest"
         importer.configuration.dbschema = "baskets_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
 

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -386,29 +386,26 @@ class TestProjectGen(unittest.TestCase):
                         assert tab.columnCount() == 1
 
         assert count == 1
-        assert (
-            set(
-                [
-                    "statusaltlv",
-                    "multilingualtext",
-                    "untersmassn",
-                    "multilingualmtext",
-                    "languagecode_iso639_1",
-                    "deponietyp",
-                    "zustaendigkeitkataster",
-                    "standorttyp",
-                    "localisedtext",
-                    "localisedmtext",
-                    "belasteter_standort",
-                    "deponietyp_",
-                    "egrid_",
-                    "untersmassn_",
-                    "parzellenidentifikation",
-                    "belasteter_standort_geo_lage_punkt",
-                ]
-            )
-            == set([layer.name for layer in available_layers])
-        )
+        assert set(
+            [
+                "statusaltlv",
+                "multilingualtext",
+                "untersmassn",
+                "multilingualmtext",
+                "languagecode_iso639_1",
+                "deponietyp",
+                "zustaendigkeitkataster",
+                "standorttyp",
+                "localisedtext",
+                "localisedmtext",
+                "belasteter_standort",
+                "deponietyp_",
+                "egrid_",
+                "untersmassn_",
+                "parzellenidentifikation",
+                "belasteter_standort_geo_lage_punkt",
+            ]
+        ) == set([layer.name for layer in available_layers])
 
     def test_kbs_geopackage(self):
         importer = iliimporter.Importer()
@@ -494,29 +491,26 @@ class TestProjectGen(unittest.TestCase):
                         assert tab.columnCount() == 1
 
         assert count == 1
-        assert (
-            set(
-                [
-                    "statusaltlv",
-                    "multilingualtext",
-                    "untersmassn",
-                    "multilingualmtext",
-                    "languagecode_iso639_1",
-                    "deponietyp",
-                    "zustaendigkeitkataster",
-                    "standorttyp",
-                    "localisedtext",
-                    "localisedmtext",
-                    "belasteter_standort",
-                    "deponietyp_",
-                    "egrid_",
-                    "untersmassn_",
-                    "parzellenidentifikation",
-                    "belasteter_standort_geo_lage_punkt",
-                ]
-            )
-            == set([layer.name for layer in available_layers])
-        )
+        assert set(
+            [
+                "statusaltlv",
+                "multilingualtext",
+                "untersmassn",
+                "multilingualmtext",
+                "languagecode_iso639_1",
+                "deponietyp",
+                "zustaendigkeitkataster",
+                "standorttyp",
+                "localisedtext",
+                "localisedmtext",
+                "belasteter_standort",
+                "deponietyp_",
+                "egrid_",
+                "untersmassn_",
+                "parzellenidentifikation",
+                "belasteter_standort_geo_lage_punkt",
+            ]
+        ) == set([layer.name for layer in available_layers])
 
     def test_naturschutz_postgis(self):
         importer = iliimporter.Importer()
@@ -528,6 +522,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.dbschema = "naturschutz_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -560,6 +555,7 @@ class TestProjectGen(unittest.TestCase):
                 datetime.datetime.now()
             ),
         )
+        importer.configuration.create_basket_col = True
         importer.configuration.inheritance = "smart1"
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -574,7 +570,7 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 24
+        assert len(ignored_layers) == 64
         assert len(available_layers) == 23
         assert len(relations) == 13
 
@@ -588,6 +584,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.dbschema = "naturschutz_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
 
@@ -623,6 +620,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.dbschema = "naturschutz_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -656,6 +654,7 @@ class TestProjectGen(unittest.TestCase):
                 datetime.datetime.now()
             ),
         )
+        importer.configuration.create_basket_col = True
         importer.configuration.inheritance = "smart1"
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -672,7 +671,7 @@ class TestProjectGen(unittest.TestCase):
         legend = generator.legend(available_layers)
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 26
+        assert len(ignored_layers) == 66
         assert len(available_layers) == 21
         assert len(relations) == 12
 
@@ -700,6 +699,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.dbschema = "naturschutz_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
 
@@ -737,6 +737,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.dbschema = "naturschutz_nometa_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -770,6 +771,7 @@ class TestProjectGen(unittest.TestCase):
                 datetime.datetime.now()
             ),
         )
+        importer.configuration.create_basket_col = True
         importer.configuration.inheritance = "smart1"
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
@@ -784,7 +786,7 @@ class TestProjectGen(unittest.TestCase):
         available_layers = generator.layers([])
         relations, _ = generator.relations(available_layers)
 
-        assert len(ignored_layers) == 18
+        assert len(ignored_layers) == 30
         assert len(available_layers) == 29
         assert len(relations) == 23
 
@@ -2476,12 +2478,15 @@ class TestProjectGen(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/PipeBasketTest_V1.ili")
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/PipeBasketTest_V1.ili"
+        )
         importer.configuration.ilimodels = "PipeBasketTest"
         importer.configuration.dbschema = "tid_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -2513,7 +2518,7 @@ class TestProjectGen(unittest.TestCase):
                 # default expression since it's not defined in model
                 count += 1
                 fields = layer.layer.fields()
-                field_idx = fields.lookupField('t_ili_tid')
+                field_idx = fields.lookupField("t_ili_tid")
                 t_ili_tid_field = fields.field(field_idx)
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
@@ -2522,7 +2527,7 @@ class TestProjectGen(unittest.TestCase):
                 # no default expression since it's defined in model
                 count += 1
                 fields = layer.layer.fields()
-                field_idx = fields.lookupField('t_ili_tid')
+                field_idx = fields.lookupField("t_ili_tid")
                 t_ili_tid_field = fields.field(field_idx)
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
@@ -2539,12 +2544,15 @@ class TestProjectGen(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
         importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/PipeBasketTest_V1.ili")
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/PipeBasketTest_V1.ili"
+        )
         importer.configuration.ilimodels = "PipeBasketTest"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath, "tmp_tid_gpkg.gpkg"
         )
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
@@ -2553,7 +2561,10 @@ class TestProjectGen(unittest.TestCase):
         uri = config_manager.get_uri()
 
         generator = Generator(
-            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance, consider_basket_handling=True
+            DbIliMode.ili2gpkg,
+            uri,
+            importer.configuration.inheritance,
+            consider_basket_handling=True,
         )
 
         available_layers = generator.layers()
@@ -2575,7 +2586,7 @@ class TestProjectGen(unittest.TestCase):
                 # default expression since it's not defined in model
                 count += 1
                 fields = layer.layer.fields()
-                field_idx = fields.lookupField('T_Ili_Tid')
+                field_idx = fields.lookupField("T_Ili_Tid")
                 t_ili_tid_field = fields.field(field_idx)
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
@@ -2584,7 +2595,7 @@ class TestProjectGen(unittest.TestCase):
                 # default expression even when it's defined in model (since geopackage cannot create uuids)
                 count += 1
                 fields = layer.layer.fields()
-                field_idx = fields.lookupField('T_Ili_Tid')
+                field_idx = fields.lookupField("T_Ili_Tid")
                 t_ili_tid_field = fields.field(field_idx)
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
@@ -2601,13 +2612,16 @@ class TestProjectGen(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
         importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/PipeBasketTest_V1.ili")
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/PipeBasketTest_V1.ili"
+        )
         importer.configuration.ilimodels = "PipeBasketTest"
         importer.configuration.dbschema = "tid_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
         importer.configuration.srs_code = 2056
         importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
 
@@ -2622,7 +2636,10 @@ class TestProjectGen(unittest.TestCase):
         )
 
         generator = Generator(
-            DbIliMode.ili2mssql, uri, importer.configuration.inheritance, importer.configuration.dbschema
+            DbIliMode.ili2mssql,
+            uri,
+            importer.configuration.inheritance,
+            importer.configuration.dbschema,
         )
 
         available_layers = generator.layers()
@@ -2644,7 +2661,7 @@ class TestProjectGen(unittest.TestCase):
                 # default expression since it's not defined in model
                 count += 1
                 fields = layer.layer.fields()
-                field_idx = fields.lookupField('t_ili_tid')
+                field_idx = fields.lookupField("t_ili_tid")
                 t_ili_tid_field = fields.field(field_idx)
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
@@ -2653,7 +2670,7 @@ class TestProjectGen(unittest.TestCase):
                 # no default expression since it's defined in model
                 count += 1
                 fields = layer.layer.fields()
-                field_idx = fields.lookupField('t_ili_tid')
+                field_idx = fields.lookupField("t_ili_tid")
                 t_ili_tid_field = fields.field(field_idx)
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
@@ -3709,6 +3726,7 @@ class TestProjectGen(unittest.TestCase):
         importer.configuration.dbschema = "nue_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
+        importer.configuration.create_basket_col = True
         importer.configuration.srs_code = 21781
         importer.configuration.inheritance = "smart2"
         importer.stdout.connect(self.print_info)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -119,7 +119,7 @@ class TestExport(unittest.TestCase):
         assert result_model.rowCount() == 1
         assert (
             result_model.index(0, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )[0:36]
             == "Intersection coord1 (81.785, 99.314)"
         )
@@ -197,7 +197,7 @@ class TestExport(unittest.TestCase):
         assert result_model.rowCount() == 1
         assert (
             result_model.index(0, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )[0:36]
             == "Intersection coord1 (81.785, 99.314)"
         )
@@ -275,7 +275,7 @@ class TestExport(unittest.TestCase):
         assert result_model.rowCount() == 1
         assert (
             result_model.index(0, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )[0:36]
             == "Intersection coord1 (81.785, 99.314)"
         )
@@ -353,25 +353,25 @@ class TestExport(unittest.TestCase):
         )
         assert (
             result_model.index(0, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_geometry
         )
         assert (
             result_model.index(1, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_multiplicity_1
         )
         assert (
             result_model.index(2, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_multiplicity_2
         )
         assert (
             result_model.index(3, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_constraint
         )
@@ -386,19 +386,19 @@ class TestExport(unittest.TestCase):
         assert result_model.rowCount() == 3
         assert (
             result_model.index(0, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_multiplicity_1
         )
         assert (
             result_model.index(1, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_multiplicity_2
         )
         assert (
             result_model.index(2, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_constraint
         )
@@ -416,13 +416,13 @@ class TestExport(unittest.TestCase):
         assert result_model.rowCount() == 2
         assert (
             result_model.index(0, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_geometry
         )
         assert (
             result_model.index(1, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_constraint
         )
@@ -439,19 +439,19 @@ class TestExport(unittest.TestCase):
         assert result_model.rowCount() == 3
         assert (
             result_model.index(0, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_geometry
         )
         assert (
             result_model.index(1, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_multiplicity_1
         )
         assert (
             result_model.index(2, 0).data(
-                ilivalidator.ValidationResultModel.Roles.MESSAGE
+                int(ilivalidator.ValidationResultModel.Roles.MESSAGE)
             )
             == expected_error_multiplicity_2
         )


### PR DESCRIPTION
- [x] From GPKG it should not load "rtree_" tables used for spatialindexing.
- [x] Pass `--createBasketCol` on tests with models having a `BASKET OID`
- [x] Change tests on ignore table check  