### PR TITLE
Avoid using of QgsDataSourceUri:uri

### DIFF
--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 LIBS_DIR="modelbaker/libs"
 
+DEPRECATION=("deprecation" "2.1.0")
 PGSERVICEPARSER=("pgserviceparser" "1.1.0")
 TOPPINGMAKER=("toppingmaker" "1.0.2")
 
 PACKAGES=(
+  DEPRECATION[@]
   PGSERVICEPARSER[@]
   TOPPINGMAKER[@]
 )


### PR DESCRIPTION
Because it returns a invalid data path when there are spaces in it. And this functions are anyway more clear when just passing the layers `dataProvider()`.