### PR TITLE
Disable area topology check when geometry errors should be skipped

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -412,6 +412,7 @@ class ValidateConfiguration(Ili2DbCommandConfiguration):
 
         if self.skip_geometry_errors:
             self.append_args(args, ["--skipGeometryErrors"])
+            self.append_args(args, ["--disableAreaValidation"])
 
         if self.valid_config:
             self.append_args(args, ["--validConfig", self.valid_config])


### PR DESCRIPTION
User expects that this is disabled as well. I'll update the tooltip in the gui as well.