### PR TITLE
Support Layer Styles in UsabILIty Hub (projecttopping)

### DIFF
--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -57,6 +57,7 @@ class Layer(object):
         ili_name=None,
         definitionfile=None,
         qmlstylefile=None,
+        styles={},
     ):
         self.provider = provider
         self.uri = uri
@@ -101,6 +102,7 @@ class Layer(object):
 
         self.definitionfile = definitionfile
         self.qmlstylefile = qmlstylefile
+        self.styles = styles
 
         self.__form = Form()
 
@@ -124,6 +126,7 @@ class Layer(object):
         definition["ili_name"] = self.ili_name
         definition["definitionfile"] = self.definitionfile
         definition["qmlstylefile"] = self.qmlstylefile
+        definition["styles"] = self.styles
         definition["form"] = self.__form.dump()
         return definition
 
@@ -141,6 +144,7 @@ class Layer(object):
         self.ili_name = definition["ili_name"]
         self.definitionfile = definition["definitionfile"]
         self.qmlstylefile = definition["qmlstylefile"]
+        self.styles = definition["styles"]
         self.__form.load(definition["form"])
 
     def create(self):
@@ -197,9 +201,20 @@ class Layer(object):
         edit_form = self.__form.create(self, self.__layer, project)
         self.__layer.setEditFormConfig(edit_form)
 
-    def load_style(self):
+    def load_styles(self):
         if self.qmlstylefile:
             self.__layer.loadNamedStyle(self.qmlstylefile)
+        if self.styles:
+            for style_name in self.styles.keys():
+                # add the new style (because otherwise we overwrite the previous one)
+                self.__layer.styleManager().addStyleFromLayer(style_name)
+                self.__layer.styleManager().setCurrentStyle(style_name)
+                style_properties = self.styles[style_name]
+                style_qmlstylefile = style_properties.get("qmlstylefile")
+                if style_qmlstylefile:
+                    self.__layer.loadNamedStyle(style_qmlstylefile)
+            # set the default style
+            self.__layer.styleManager().setCurrentStyle("default")
 
     def _create_layer(self, uri, layer_name, provider):
         if provider and provider.lower() == "wms":

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -221,7 +221,7 @@ class Project(QObject):
             if layer.layer.type() == QgsMapLayer.VectorLayer:
                 # even when a style will be loaded we create the form because not sure if the style contains form settngs
                 layer.create_form(self)
-                layer.load_style()
+                layer.load_styles()
 
         if self.legend:
             self.legend.create(qgis_project, group)

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -549,6 +549,16 @@ class Generator(QObject):
                 current_node.qmlstylefile = path_resolver(
                     item_properties.get("qmlstylefile")
                 )
+                styles = {}
+                if "styles" in item_properties:
+                    for style_name in item_properties["styles"].keys():
+                        style_properties = item_properties["styles"][style_name]
+                        style_qmlstylefile = path_resolver(
+                            style_properties.get("qmlstylefile")
+                        )
+                        styles[style_name] = {"qmlstylefile": style_qmlstylefile}
+                current_node.styles = styles
+
         return current_node
 
     def legend(

--- a/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_default_style.qml
+++ b/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_default_style.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Forms">
+<qgis version="3.22.11-Białowieża" readOnly="0" styleCategories="LayerConfiguration|Fields|Forms">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -7,173 +7,173 @@
     <Private>0</Private>
   </flags>
   <fieldConfiguration>
-    <field name="t_id">
+    <field name="t_id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="t_basket">
+    <field name="t_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="true" name="AllowNULL" type="bool"/>
-            <Option value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
-            <Option name="FilterFields"/>
-            <Option value="true" name="OrderByValue" type="bool"/>
-            <Option value="belasteter_standort_t_basket_fkey_1" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="Relation" type="QString" value="belasteter_standort_t_basket_fkey_1"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="t_ili_tid">
+    <field name="t_ili_tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="katasternummer">
+    <field name="katasternummer" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="url_standort">
+    <field name="url_standort" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="geo_lage_polygon">
+    <field name="geo_lage_polygon" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="standorttyp">
+    <field name="standorttyp" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="inbetrieb">
+    <field name="inbetrieb" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="nachsorge">
+    <field name="nachsorge" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="statusaltlv">
+    <field name="statusaltlv" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="ersteintrag">
+    <field name="ersteintrag" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="M/d/yy" name="display_format" type="QString"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="M/d/yy"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="letzteanpassung">
+    <field name="letzteanpassung" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="M/d/yy" name="display_format" type="QString"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="M/d/yy"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="url_kbs_auszug">
+    <field name="url_kbs_auszug" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung">
+    <field name="bemerkung" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_de">
+    <field name="bemerkung_de" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_fr">
+    <field name="bemerkung_fr" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_rm">
+    <field name="bemerkung_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_it">
+    <field name="bemerkung_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_en">
+    <field name="bemerkung_en" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="zustaendigkeitkataster">
+    <field name="zustaendigkeitkataster" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -181,6 +181,95 @@
       </editWidget>
     </field>
   </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="t_id"/>
+    <alias name="" index="1" field="t_basket"/>
+    <alias name="" index="2" field="t_ili_tid"/>
+    <alias name="Katasternummer" index="3" field="katasternummer"/>
+    <alias name="URL_Standort" index="4" field="url_standort"/>
+    <alias name="Geo_Lage_Polygon" index="5" field="geo_lage_polygon"/>
+    <alias name="Standorttyp" index="6" field="standorttyp"/>
+    <alias name="InBetrieb" index="7" field="inbetrieb"/>
+    <alias name="Nachsorge" index="8" field="nachsorge"/>
+    <alias name="StatusAltlV" index="9" field="statusaltlv"/>
+    <alias name="Ersteintrag" index="10" field="ersteintrag"/>
+    <alias name="LetzteAnpassung" index="11" field="letzteanpassung"/>
+    <alias name="URL_KbS_Auszug" index="12" field="url_kbs_auszug"/>
+    <alias name="Bemerkung" index="13" field="bemerkung"/>
+    <alias name="" index="14" field="bemerkung_de"/>
+    <alias name="" index="15" field="bemerkung_fr"/>
+    <alias name="Bemerkung Romanisch" index="16" field="bemerkung_rm"/>
+    <alias name="Bemerkung Italienisch" index="17" field="bemerkung_it"/>
+    <alias name="" index="18" field="bemerkung_en"/>
+    <alias name="ZustaendigkeitKataster" index="19" field="zustaendigkeitkataster"/>
+  </aliases>
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="t_id"/>
+    <default expression="" applyOnUpdate="0" field="t_basket"/>
+    <default expression="" applyOnUpdate="0" field="t_ili_tid"/>
+    <default expression="" applyOnUpdate="0" field="katasternummer"/>
+    <default expression="" applyOnUpdate="0" field="url_standort"/>
+    <default expression="" applyOnUpdate="0" field="geo_lage_polygon"/>
+    <default expression="" applyOnUpdate="0" field="standorttyp"/>
+    <default expression="" applyOnUpdate="0" field="inbetrieb"/>
+    <default expression="" applyOnUpdate="0" field="nachsorge"/>
+    <default expression="" applyOnUpdate="0" field="statusaltlv"/>
+    <default expression="" applyOnUpdate="0" field="ersteintrag"/>
+    <default expression="" applyOnUpdate="0" field="letzteanpassung"/>
+    <default expression="" applyOnUpdate="0" field="url_kbs_auszug"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_de"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_fr"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_rm"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_it"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_en"/>
+    <default expression="" applyOnUpdate="0" field="zustaendigkeitkataster"/>
+  </defaults>
+  <constraints>
+    <constraint exp_strength="0" constraints="3" notnull_strength="1" field="t_id" unique_strength="1"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="t_basket" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="t_ili_tid" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="katasternummer" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="url_standort" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="geo_lage_polygon" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="standorttyp" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="inbetrieb" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="nachsorge" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="statusaltlv" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="ersteintrag" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="letzteanpassung" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="url_kbs_auszug" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_de" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_fr" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_rm" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_it" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_en" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="zustaendigkeitkataster" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="t_id"/>
+    <constraint desc="" exp="" field="t_basket"/>
+    <constraint desc="" exp="" field="t_ili_tid"/>
+    <constraint desc="" exp="" field="katasternummer"/>
+    <constraint desc="" exp="" field="url_standort"/>
+    <constraint desc="" exp="" field="geo_lage_polygon"/>
+    <constraint desc="" exp="" field="standorttyp"/>
+    <constraint desc="" exp="" field="inbetrieb"/>
+    <constraint desc="" exp="" field="nachsorge"/>
+    <constraint desc="" exp="" field="statusaltlv"/>
+    <constraint desc="" exp="" field="ersteintrag"/>
+    <constraint desc="" exp="" field="letzteanpassung"/>
+    <constraint desc="" exp="" field="url_kbs_auszug"/>
+    <constraint desc="" exp="" field="bemerkung"/>
+    <constraint desc="" exp="" field="bemerkung_de"/>
+    <constraint desc="" exp="" field="bemerkung_fr"/>
+    <constraint desc="" exp="" field="bemerkung_rm"/>
+    <constraint desc="" exp="" field="bemerkung_it"/>
+    <constraint desc="" exp="" field="bemerkung_en"/>
+    <constraint desc="" exp="" field="zustaendigkeitkataster"/>
+  </constraintExpressions>
+  <expressionfields/>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
@@ -205,7 +294,7 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Allgemein" columnCount="2" groupBox="0">
+    <attributeEditorContainer showLabel="1" name="Allgemein" visibilityExpressionEnabled="0" columnCount="2" groupBox="0" visibilityExpression="">
       <attributeEditorField showLabel="1" name="bemerkung" index="13"/>
       <attributeEditorField showLabel="1" name="bemerkung_de" index="14"/>
       <attributeEditorField showLabel="1" name="bemerkung_en" index="18"/>
@@ -225,56 +314,56 @@ def my_form_open(dialog, layer, feature):
       <attributeEditorField showLabel="1" name="url_standort" index="4"/>
       <attributeEditorField showLabel="1" name="zustaendigkeitkataster" index="19"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Parzellenidentifikation" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Parzellenidentifikation" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Deponie" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Deponie" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Egrid" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="egrid__belasteter_standort_egrid_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="egrid__belasteter_standort_egrid_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Egrid" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="egrid__belasteter_standort_egrid_fkey_1" relation="egrid__belasteter_standort_egrid_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Untersuchungsmassnahmen" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Untersuchungsmassnahmen" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="bemerkung"/>
-    <field editable="1" name="bemerkung_de"/>
-    <field editable="1" name="bemerkung_en"/>
-    <field editable="1" name="bemerkung_fr"/>
-    <field editable="1" name="bemerkung_it"/>
-    <field editable="1" name="bemerkung_rm"/>
-    <field editable="1" name="ersteintrag"/>
-    <field editable="1" name="geo_lage_polygon"/>
-    <field editable="1" name="inbetrieb"/>
-    <field editable="1" name="katasternummer"/>
-    <field editable="1" name="letzteanpassung"/>
-    <field editable="1" name="nachsorge"/>
-    <field editable="1" name="standorttyp"/>
-    <field editable="1" name="statusaltlv"/>
-    <field editable="1" name="t_basket"/>
-    <field editable="1" name="t_id"/>
-    <field editable="1" name="t_ili_tid"/>
-    <field editable="1" name="url_kbs_auszug"/>
-    <field editable="1" name="url_standort"/>
-    <field editable="1" name="zustaendigkeitkataster"/>
+    <field name="bemerkung" editable="1"/>
+    <field name="bemerkung_de" editable="1"/>
+    <field name="bemerkung_en" editable="1"/>
+    <field name="bemerkung_fr" editable="1"/>
+    <field name="bemerkung_it" editable="1"/>
+    <field name="bemerkung_rm" editable="1"/>
+    <field name="ersteintrag" editable="1"/>
+    <field name="geo_lage_polygon" editable="1"/>
+    <field name="inbetrieb" editable="1"/>
+    <field name="katasternummer" editable="1"/>
+    <field name="letzteanpassung" editable="1"/>
+    <field name="nachsorge" editable="1"/>
+    <field name="standorttyp" editable="1"/>
+    <field name="statusaltlv" editable="1"/>
+    <field name="t_basket" editable="1"/>
+    <field name="t_id" editable="1"/>
+    <field name="t_ili_tid" editable="1"/>
+    <field name="url_kbs_auszug" editable="1"/>
+    <field name="url_standort" editable="1"/>
+    <field name="zustaendigkeitkataster" editable="1"/>
   </editable>
   <labelOnTop>
     <field name="bemerkung" labelOnTop="0"/>

--- a/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_default_style.qml
+++ b/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_default_style.qml
@@ -1,0 +1,327 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Forms">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <fieldConfiguration>
+    <field name="t_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="t_basket">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="belasteter_standort_t_basket_fkey_1" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="t_ili_tid">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="katasternummer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="url_standort">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geo_lage_polygon">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="standorttyp">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="inbetrieb">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="nachsorge">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="statusaltlv">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ersteintrag">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="M/d/yy" name="display_format" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="letzteanpassung">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="M/d/yy" name="display_format" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="url_kbs_auszug">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_de">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_fr">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_rm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_it">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_en">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zustaendigkeitkataster">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Allgemein" columnCount="2" groupBox="0">
+      <attributeEditorField showLabel="1" name="bemerkung" index="13"/>
+      <attributeEditorField showLabel="1" name="bemerkung_de" index="14"/>
+      <attributeEditorField showLabel="1" name="bemerkung_en" index="18"/>
+      <attributeEditorField showLabel="1" name="bemerkung_fr" index="15"/>
+      <attributeEditorField showLabel="1" name="bemerkung_it" index="17"/>
+      <attributeEditorField showLabel="1" name="bemerkung_rm" index="16"/>
+      <attributeEditorField showLabel="1" name="ersteintrag" index="10"/>
+      <attributeEditorField showLabel="1" name="geo_lage_polygon" index="5"/>
+      <attributeEditorField showLabel="1" name="geo_lage_punkt" index="-1"/>
+      <attributeEditorField showLabel="1" name="inbetrieb" index="7"/>
+      <attributeEditorField showLabel="1" name="katasternummer" index="3"/>
+      <attributeEditorField showLabel="1" name="letzteanpassung" index="11"/>
+      <attributeEditorField showLabel="1" name="nachsorge" index="8"/>
+      <attributeEditorField showLabel="1" name="standorttyp" index="6"/>
+      <attributeEditorField showLabel="1" name="statusaltlv" index="9"/>
+      <attributeEditorField showLabel="1" name="url_kbs_auszug" index="12"/>
+      <attributeEditorField showLabel="1" name="url_standort" index="4"/>
+      <attributeEditorField showLabel="1" name="zustaendigkeitkataster" index="19"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Parzellenidentifikation" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Deponie" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Egrid" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="egrid__belasteter_standort_egrid_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="egrid__belasteter_standort_egrid_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Untersuchungsmassnahmen" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="bemerkung"/>
+    <field editable="1" name="bemerkung_de"/>
+    <field editable="1" name="bemerkung_en"/>
+    <field editable="1" name="bemerkung_fr"/>
+    <field editable="1" name="bemerkung_it"/>
+    <field editable="1" name="bemerkung_rm"/>
+    <field editable="1" name="ersteintrag"/>
+    <field editable="1" name="geo_lage_polygon"/>
+    <field editable="1" name="inbetrieb"/>
+    <field editable="1" name="katasternummer"/>
+    <field editable="1" name="letzteanpassung"/>
+    <field editable="1" name="nachsorge"/>
+    <field editable="1" name="standorttyp"/>
+    <field editable="1" name="statusaltlv"/>
+    <field editable="1" name="t_basket"/>
+    <field editable="1" name="t_id"/>
+    <field editable="1" name="t_ili_tid"/>
+    <field editable="1" name="url_kbs_auszug"/>
+    <field editable="1" name="url_standort"/>
+    <field editable="1" name="zustaendigkeitkataster"/>
+  </editable>
+  <labelOnTop>
+    <field name="bemerkung" labelOnTop="0"/>
+    <field name="bemerkung_de" labelOnTop="0"/>
+    <field name="bemerkung_en" labelOnTop="0"/>
+    <field name="bemerkung_fr" labelOnTop="0"/>
+    <field name="bemerkung_it" labelOnTop="0"/>
+    <field name="bemerkung_rm" labelOnTop="0"/>
+    <field name="ersteintrag" labelOnTop="0"/>
+    <field name="geo_lage_polygon" labelOnTop="0"/>
+    <field name="inbetrieb" labelOnTop="0"/>
+    <field name="katasternummer" labelOnTop="0"/>
+    <field name="letzteanpassung" labelOnTop="0"/>
+    <field name="nachsorge" labelOnTop="0"/>
+    <field name="standorttyp" labelOnTop="0"/>
+    <field name="statusaltlv" labelOnTop="0"/>
+    <field name="t_basket" labelOnTop="0"/>
+    <field name="t_id" labelOnTop="0"/>
+    <field name="t_ili_tid" labelOnTop="0"/>
+    <field name="url_kbs_auszug" labelOnTop="0"/>
+    <field name="url_standort" labelOnTop="0"/>
+    <field name="zustaendigkeitkataster" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field name="bemerkung" reuseLastValue="0"/>
+    <field name="bemerkung_de" reuseLastValue="0"/>
+    <field name="bemerkung_en" reuseLastValue="0"/>
+    <field name="bemerkung_fr" reuseLastValue="0"/>
+    <field name="bemerkung_it" reuseLastValue="0"/>
+    <field name="bemerkung_rm" reuseLastValue="0"/>
+    <field name="ersteintrag" reuseLastValue="0"/>
+    <field name="geo_lage_polygon" reuseLastValue="0"/>
+    <field name="inbetrieb" reuseLastValue="0"/>
+    <field name="katasternummer" reuseLastValue="0"/>
+    <field name="letzteanpassung" reuseLastValue="0"/>
+    <field name="nachsorge" reuseLastValue="0"/>
+    <field name="standorttyp" reuseLastValue="0"/>
+    <field name="statusaltlv" reuseLastValue="0"/>
+    <field name="t_basket" reuseLastValue="0"/>
+    <field name="t_id" reuseLastValue="0"/>
+    <field name="t_ili_tid" reuseLastValue="0"/>
+    <field name="url_kbs_auszug" reuseLastValue="0"/>
+    <field name="url_standort" reuseLastValue="0"/>
+    <field name="zustaendigkeitkataster" reuseLastValue="0"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>'Default: '||standorttyp ||' - '||katasternummer</previewExpression>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_french_style.qml
+++ b/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_french_style.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Forms">
+<qgis version="3.22.11-Białowieża" readOnly="0" styleCategories="LayerConfiguration|Fields|Forms">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -7,173 +7,186 @@
     <Private>0</Private>
   </flags>
   <fieldConfiguration>
-    <field name="t_id">
+    <field name="t_id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="t_basket">
+    <field name="t_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="true" name="AllowNULL" type="bool"/>
-            <Option value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
-            <Option name="FilterFields"/>
-            <Option value="true" name="OrderByValue" type="bool"/>
-            <Option value="belasteter_standort_t_basket_fkey_1" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="Relation" type="QString" value="belasteter_standort_t_basket_fkey_1"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="t_ili_tid">
+    <field name="t_ili_tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="katasternummer">
+    <field name="katasternummer" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="url_standort">
+    <field name="url_standort" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="geo_lage_polygon">
+    <field name="geo_lage_polygon" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="standorttyp">
+    <field name="standorttyp" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
-          <Option/>
+          <Option type="Map">
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="false"/>
+            <Option name="MapIdentification" type="bool" value="false"/>
+            <Option name="OrderByValue" type="bool" value="false"/>
+            <Option name="ReadOnly" type="bool" value="false"/>
+            <Option name="ReferencedLayerDataSource" type="QString" value="dbname='test data' host=localhost user='postgres' key='t_id' checkPrimaryKeyUnicity='1' table=&quot;kbs_test1126&quot;.&quot;standorttyp&quot;"/>
+            <Option name="ReferencedLayerId" type="QString" value="Standorttyp_c4e588ae_fdc1_49f2_b73b_72e9b0fe13bc"/>
+            <Option name="ReferencedLayerName" type="QString" value="Standorttyp"/>
+            <Option name="ReferencedLayerProviderKey" type="QString" value="postgres"/>
+            <Option name="Relation" type="QString" value="belasteter_standort_standorttyp_fkey_1"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="true"/>
+          </Option>
         </config>
       </editWidget>
     </field>
-    <field name="inbetrieb">
+    <field name="inbetrieb" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="nachsorge">
+    <field name="nachsorge" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="statusaltlv">
+    <field name="statusaltlv" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="ersteintrag">
+    <field name="ersteintrag" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="M/d/yy" name="display_format" type="QString"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="M/d/yy"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="letzteanpassung">
+    <field name="letzteanpassung" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="M/d/yy" name="display_format" type="QString"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="M/d/yy"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="url_kbs_auszug">
+    <field name="url_kbs_auszug" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung">
+    <field name="bemerkung" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_de">
+    <field name="bemerkung_de" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_fr">
+    <field name="bemerkung_fr" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_rm">
+    <field name="bemerkung_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_it">
+    <field name="bemerkung_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_en">
+    <field name="bemerkung_en" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="zustaendigkeitkataster">
+    <field name="zustaendigkeitkataster" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -181,6 +194,95 @@
       </editWidget>
     </field>
   </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="t_id"/>
+    <alias name="" index="1" field="t_basket"/>
+    <alias name="" index="2" field="t_ili_tid"/>
+    <alias name="Katasternummer" index="3" field="katasternummer"/>
+    <alias name="URL_Standort" index="4" field="url_standort"/>
+    <alias name="Geo_Lage_Polygon" index="5" field="geo_lage_polygon"/>
+    <alias name="Standorttyp" index="6" field="standorttyp"/>
+    <alias name="InBetrieb" index="7" field="inbetrieb"/>
+    <alias name="Nachsorge" index="8" field="nachsorge"/>
+    <alias name="StatusAltlV" index="9" field="statusaltlv"/>
+    <alias name="Ersteintrag" index="10" field="ersteintrag"/>
+    <alias name="LetzteAnpassung" index="11" field="letzteanpassung"/>
+    <alias name="URL_KbS_Auszug" index="12" field="url_kbs_auszug"/>
+    <alias name="Bemerkung" index="13" field="bemerkung"/>
+    <alias name="" index="14" field="bemerkung_de"/>
+    <alias name="" index="15" field="bemerkung_fr"/>
+    <alias name="Remarque en Romane" index="16" field="bemerkung_rm"/>
+    <alias name="Remarque en Italien" index="17" field="bemerkung_it"/>
+    <alias name="" index="18" field="bemerkung_en"/>
+    <alias name="ZustaendigkeitKataster" index="19" field="zustaendigkeitkataster"/>
+  </aliases>
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="t_id"/>
+    <default expression="" applyOnUpdate="0" field="t_basket"/>
+    <default expression="" applyOnUpdate="0" field="t_ili_tid"/>
+    <default expression="" applyOnUpdate="0" field="katasternummer"/>
+    <default expression="" applyOnUpdate="0" field="url_standort"/>
+    <default expression="" applyOnUpdate="0" field="geo_lage_polygon"/>
+    <default expression="" applyOnUpdate="0" field="standorttyp"/>
+    <default expression="" applyOnUpdate="0" field="inbetrieb"/>
+    <default expression="" applyOnUpdate="0" field="nachsorge"/>
+    <default expression="" applyOnUpdate="0" field="statusaltlv"/>
+    <default expression="" applyOnUpdate="0" field="ersteintrag"/>
+    <default expression="" applyOnUpdate="0" field="letzteanpassung"/>
+    <default expression="" applyOnUpdate="0" field="url_kbs_auszug"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_de"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_fr"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_rm"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_it"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_en"/>
+    <default expression="" applyOnUpdate="0" field="zustaendigkeitkataster"/>
+  </defaults>
+  <constraints>
+    <constraint exp_strength="0" constraints="3" notnull_strength="1" field="t_id" unique_strength="1"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="t_basket" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="t_ili_tid" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="katasternummer" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="url_standort" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="geo_lage_polygon" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="standorttyp" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="inbetrieb" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="nachsorge" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="statusaltlv" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="ersteintrag" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="letzteanpassung" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="url_kbs_auszug" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_de" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_fr" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_rm" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_it" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_en" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="zustaendigkeitkataster" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="t_id"/>
+    <constraint desc="" exp="" field="t_basket"/>
+    <constraint desc="" exp="" field="t_ili_tid"/>
+    <constraint desc="" exp="" field="katasternummer"/>
+    <constraint desc="" exp="" field="url_standort"/>
+    <constraint desc="" exp="" field="geo_lage_polygon"/>
+    <constraint desc="" exp="" field="standorttyp"/>
+    <constraint desc="" exp="" field="inbetrieb"/>
+    <constraint desc="" exp="" field="nachsorge"/>
+    <constraint desc="" exp="" field="statusaltlv"/>
+    <constraint desc="" exp="" field="ersteintrag"/>
+    <constraint desc="" exp="" field="letzteanpassung"/>
+    <constraint desc="" exp="" field="url_kbs_auszug"/>
+    <constraint desc="" exp="" field="bemerkung"/>
+    <constraint desc="" exp="" field="bemerkung_de"/>
+    <constraint desc="" exp="" field="bemerkung_fr"/>
+    <constraint desc="" exp="" field="bemerkung_rm"/>
+    <constraint desc="" exp="" field="bemerkung_it"/>
+    <constraint desc="" exp="" field="bemerkung_en"/>
+    <constraint desc="" exp="" field="zustaendigkeitkataster"/>
+  </constraintExpressions>
+  <expressionfields/>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
@@ -205,7 +307,7 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Général" columnCount="2" groupBox="0">
+    <attributeEditorContainer showLabel="1" name="Général" visibilityExpressionEnabled="0" columnCount="2" groupBox="0" visibilityExpression="">
       <attributeEditorField showLabel="1" name="bemerkung" index="13"/>
       <attributeEditorField showLabel="1" name="bemerkung_de" index="14"/>
       <attributeEditorField showLabel="1" name="bemerkung_en" index="18"/>
@@ -225,56 +327,56 @@ def my_form_open(dialog, layer, feature):
       <attributeEditorField showLabel="1" name="url_standort" index="4"/>
       <attributeEditorField showLabel="1" name="zustaendigkeitkataster" index="19"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Parzellenidentifikation" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Parzellenidentifikation" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Deponie" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Deponie" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Egrid" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="egrid__belasteter_standort_egrid_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="egrid__belasteter_standort_egrid_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Egrid" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="egrid__belasteter_standort_egrid_fkey_1" relation="egrid__belasteter_standort_egrid_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Untersuchungsmassnahmen" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Untersuchungsmassnahmen" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="bemerkung"/>
-    <field editable="1" name="bemerkung_de"/>
-    <field editable="1" name="bemerkung_en"/>
-    <field editable="1" name="bemerkung_fr"/>
-    <field editable="1" name="bemerkung_it"/>
-    <field editable="1" name="bemerkung_rm"/>
-    <field editable="1" name="ersteintrag"/>
-    <field editable="1" name="geo_lage_polygon"/>
-    <field editable="1" name="inbetrieb"/>
-    <field editable="1" name="katasternummer"/>
-    <field editable="1" name="letzteanpassung"/>
-    <field editable="1" name="nachsorge"/>
-    <field editable="1" name="standorttyp"/>
-    <field editable="1" name="statusaltlv"/>
-    <field editable="1" name="t_basket"/>
-    <field editable="1" name="t_id"/>
-    <field editable="1" name="t_ili_tid"/>
-    <field editable="1" name="url_kbs_auszug"/>
-    <field editable="1" name="url_standort"/>
-    <field editable="1" name="zustaendigkeitkataster"/>
+    <field name="bemerkung" editable="1"/>
+    <field name="bemerkung_de" editable="1"/>
+    <field name="bemerkung_en" editable="1"/>
+    <field name="bemerkung_fr" editable="1"/>
+    <field name="bemerkung_it" editable="1"/>
+    <field name="bemerkung_rm" editable="1"/>
+    <field name="ersteintrag" editable="1"/>
+    <field name="geo_lage_polygon" editable="1"/>
+    <field name="inbetrieb" editable="1"/>
+    <field name="katasternummer" editable="1"/>
+    <field name="letzteanpassung" editable="1"/>
+    <field name="nachsorge" editable="1"/>
+    <field name="standorttyp" editable="1"/>
+    <field name="statusaltlv" editable="1"/>
+    <field name="t_basket" editable="1"/>
+    <field name="t_id" editable="1"/>
+    <field name="t_ili_tid" editable="1"/>
+    <field name="url_kbs_auszug" editable="1"/>
+    <field name="url_standort" editable="1"/>
+    <field name="zustaendigkeitkataster" editable="1"/>
   </editable>
   <labelOnTop>
     <field name="bemerkung" labelOnTop="0"/>

--- a/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_french_style.qml
+++ b/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_french_style.qml
@@ -1,0 +1,327 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Forms">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <fieldConfiguration>
+    <field name="t_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="t_basket">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="belasteter_standort_t_basket_fkey_1" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="t_ili_tid">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="katasternummer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="url_standort">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geo_lage_polygon">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="standorttyp">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="inbetrieb">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="nachsorge">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="statusaltlv">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ersteintrag">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="M/d/yy" name="display_format" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="letzteanpassung">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="M/d/yy" name="display_format" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="url_kbs_auszug">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_de">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_fr">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_rm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_it">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_en">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zustaendigkeitkataster">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Général" columnCount="2" groupBox="0">
+      <attributeEditorField showLabel="1" name="bemerkung" index="13"/>
+      <attributeEditorField showLabel="1" name="bemerkung_de" index="14"/>
+      <attributeEditorField showLabel="1" name="bemerkung_en" index="18"/>
+      <attributeEditorField showLabel="1" name="bemerkung_fr" index="15"/>
+      <attributeEditorField showLabel="1" name="bemerkung_it" index="17"/>
+      <attributeEditorField showLabel="1" name="bemerkung_rm" index="16"/>
+      <attributeEditorField showLabel="1" name="ersteintrag" index="10"/>
+      <attributeEditorField showLabel="1" name="geo_lage_polygon" index="5"/>
+      <attributeEditorField showLabel="1" name="geo_lage_punkt" index="-1"/>
+      <attributeEditorField showLabel="1" name="inbetrieb" index="7"/>
+      <attributeEditorField showLabel="1" name="katasternummer" index="3"/>
+      <attributeEditorField showLabel="1" name="letzteanpassung" index="11"/>
+      <attributeEditorField showLabel="1" name="nachsorge" index="8"/>
+      <attributeEditorField showLabel="1" name="standorttyp" index="6"/>
+      <attributeEditorField showLabel="1" name="statusaltlv" index="9"/>
+      <attributeEditorField showLabel="1" name="url_kbs_auszug" index="12"/>
+      <attributeEditorField showLabel="1" name="url_standort" index="4"/>
+      <attributeEditorField showLabel="1" name="zustaendigkeitkataster" index="19"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Parzellenidentifikation" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Deponie" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Egrid" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="egrid__belasteter_standort_egrid_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="egrid__belasteter_standort_egrid_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Untersuchungsmassnahmen" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="bemerkung"/>
+    <field editable="1" name="bemerkung_de"/>
+    <field editable="1" name="bemerkung_en"/>
+    <field editable="1" name="bemerkung_fr"/>
+    <field editable="1" name="bemerkung_it"/>
+    <field editable="1" name="bemerkung_rm"/>
+    <field editable="1" name="ersteintrag"/>
+    <field editable="1" name="geo_lage_polygon"/>
+    <field editable="1" name="inbetrieb"/>
+    <field editable="1" name="katasternummer"/>
+    <field editable="1" name="letzteanpassung"/>
+    <field editable="1" name="nachsorge"/>
+    <field editable="1" name="standorttyp"/>
+    <field editable="1" name="statusaltlv"/>
+    <field editable="1" name="t_basket"/>
+    <field editable="1" name="t_id"/>
+    <field editable="1" name="t_ili_tid"/>
+    <field editable="1" name="url_kbs_auszug"/>
+    <field editable="1" name="url_standort"/>
+    <field editable="1" name="zustaendigkeitkataster"/>
+  </editable>
+  <labelOnTop>
+    <field name="bemerkung" labelOnTop="0"/>
+    <field name="bemerkung_de" labelOnTop="0"/>
+    <field name="bemerkung_en" labelOnTop="0"/>
+    <field name="bemerkung_fr" labelOnTop="0"/>
+    <field name="bemerkung_it" labelOnTop="0"/>
+    <field name="bemerkung_rm" labelOnTop="0"/>
+    <field name="ersteintrag" labelOnTop="0"/>
+    <field name="geo_lage_polygon" labelOnTop="0"/>
+    <field name="inbetrieb" labelOnTop="0"/>
+    <field name="katasternummer" labelOnTop="0"/>
+    <field name="letzteanpassung" labelOnTop="0"/>
+    <field name="nachsorge" labelOnTop="0"/>
+    <field name="standorttyp" labelOnTop="0"/>
+    <field name="statusaltlv" labelOnTop="0"/>
+    <field name="t_basket" labelOnTop="0"/>
+    <field name="t_id" labelOnTop="0"/>
+    <field name="t_ili_tid" labelOnTop="0"/>
+    <field name="url_kbs_auszug" labelOnTop="0"/>
+    <field name="url_standort" labelOnTop="0"/>
+    <field name="zustaendigkeitkataster" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field name="bemerkung" reuseLastValue="0"/>
+    <field name="bemerkung_de" reuseLastValue="0"/>
+    <field name="bemerkung_en" reuseLastValue="0"/>
+    <field name="bemerkung_fr" reuseLastValue="0"/>
+    <field name="bemerkung_it" reuseLastValue="0"/>
+    <field name="bemerkung_rm" reuseLastValue="0"/>
+    <field name="ersteintrag" reuseLastValue="0"/>
+    <field name="geo_lage_polygon" reuseLastValue="0"/>
+    <field name="inbetrieb" reuseLastValue="0"/>
+    <field name="katasternummer" reuseLastValue="0"/>
+    <field name="letzteanpassung" reuseLastValue="0"/>
+    <field name="nachsorge" reuseLastValue="0"/>
+    <field name="standorttyp" reuseLastValue="0"/>
+    <field name="statusaltlv" reuseLastValue="0"/>
+    <field name="t_basket" reuseLastValue="0"/>
+    <field name="t_id" reuseLastValue="0"/>
+    <field name="t_ili_tid" reuseLastValue="0"/>
+    <field name="url_kbs_auszug" reuseLastValue="0"/>
+    <field name="url_standort" reuseLastValue="0"/>
+    <field name="zustaendigkeitkataster" reuseLastValue="0"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>'French: '||standorttyp ||' - '||katasternummer</previewExpression>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_robot_style.qml
+++ b/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_robot_style.qml
@@ -1,0 +1,330 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Forms">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+    <Private>0</Private>
+  </flags>
+  <fieldConfiguration>
+    <field name="t_id">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="t_basket">
+      <editWidget type="RelationReference">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="AllowAddFeatures" type="bool"/>
+            <Option value="true" name="AllowNULL" type="bool"/>
+            <Option value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
+            <Option name="FilterFields"/>
+            <Option value="true" name="OrderByValue" type="bool"/>
+            <Option value="belasteter_standort_t_basket_fkey_1" name="Relation" type="QString"/>
+            <Option value="false" name="ShowForm" type="bool"/>
+            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="t_ili_tid">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="katasternummer">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="url_standort">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="geo_lage_polygon">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="standorttyp">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="inbetrieb">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="nachsorge">
+      <editWidget type="CheckBox">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="statusaltlv">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="ersteintrag">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="M/d/yy" name="display_format" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="letzteanpassung">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option value="true" name="calendar_popup" type="bool"/>
+            <Option value="M/d/yy" name="display_format" type="QString"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="url_kbs_auszug">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_de">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_fr">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_rm">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_it">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="bemerkung_en">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option value="false" name="IsMultiline" type="bool"/>
+            <Option value="false" name="UseHtml" type="bool"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="zustaendigkeitkataster">
+      <editWidget type="RelationReference">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <editform tolerant="1"></editform>
+  <editforminit/>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath></editforminitfilepath>
+  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
+"""
+QGIS forms can have a Python function that is called when the form is
+opened.
+
+Use this function to add extra logic to your forms.
+
+Enter the name of the function in the "Python Init function"
+field.
+An example follows:
+"""
+from qgis.PyQt.QtWidgets import QWidget
+
+def my_form_open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget, "MyLineEdit")
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="01000111 01100101 01101110 01100101 01110010 01100001 01101100" columnCount="2" groupBox="0">
+      <attributeEditorField showLabel="1" name="bemerkung" index="13"/>
+      <attributeEditorField showLabel="1" name="bemerkung_de" index="14"/>
+      <attributeEditorField showLabel="1" name="bemerkung_en" index="18"/>
+      <attributeEditorField showLabel="1" name="bemerkung_fr" index="15"/>
+      <attributeEditorField showLabel="1" name="bemerkung_it" index="17"/>
+      <attributeEditorField showLabel="1" name="bemerkung_rm" index="16"/>
+      <attributeEditorField showLabel="1" name="ersteintrag" index="10"/>
+      <attributeEditorField showLabel="1" name="geo_lage_polygon" index="5"/>
+      <attributeEditorField showLabel="1" name="geo_lage_punkt" index="-1"/>
+      <attributeEditorField showLabel="1" name="inbetrieb" index="7"/>
+      <attributeEditorField showLabel="1" name="katasternummer" index="3"/>
+      <attributeEditorField showLabel="1" name="letzteanpassung" index="11"/>
+      <attributeEditorField showLabel="1" name="nachsorge" index="8"/>
+      <attributeEditorField showLabel="1" name="standorttyp" index="6"/>
+      <attributeEditorField showLabel="1" name="statusaltlv" index="9"/>
+      <attributeEditorField showLabel="1" name="url_kbs_auszug" index="12"/>
+      <attributeEditorField showLabel="1" name="url_standort" index="4"/>
+      <attributeEditorField showLabel="1" name="zustaendigkeitkataster" index="19"/>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Parzellenidentifikation" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Deponie" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Egrid" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="egrid__belasteter_standort_egrid_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="egrid__belasteter_standort_egrid_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Untersuchungsmassnahmen" columnCount="1" groupBox="0">
+      <attributeEditorRelation showLabel="1" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" nmRelationId="">
+        <editor_configuration type="Map">
+          <Option value="AllButtons" name="buttons" type="QString"/>
+        </editor_configuration>
+      </attributeEditorRelation>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="bemerkung"/>
+    <field editable="1" name="bemerkung_de"/>
+    <field editable="1" name="bemerkung_en"/>
+    <field editable="1" name="bemerkung_fr"/>
+    <field editable="1" name="bemerkung_it"/>
+    <field editable="1" name="bemerkung_rm"/>
+    <field editable="1" name="ersteintrag"/>
+    <field editable="1" name="geo_lage_polygon"/>
+    <field editable="1" name="inbetrieb"/>
+    <field editable="1" name="katasternummer"/>
+    <field editable="1" name="letzteanpassung"/>
+    <field editable="1" name="nachsorge"/>
+    <field editable="1" name="standorttyp"/>
+    <field editable="1" name="statusaltlv"/>
+    <field editable="1" name="t_basket"/>
+    <field editable="1" name="t_id"/>
+    <field editable="1" name="t_ili_tid"/>
+    <field editable="1" name="url_kbs_auszug"/>
+    <field editable="1" name="url_standort"/>
+    <field editable="1" name="zustaendigkeitkataster"/>
+  </editable>
+  <labelOnTop>
+    <field name="bemerkung" labelOnTop="0"/>
+    <field name="bemerkung_de" labelOnTop="0"/>
+    <field name="bemerkung_en" labelOnTop="0"/>
+    <field name="bemerkung_fr" labelOnTop="0"/>
+    <field name="bemerkung_it" labelOnTop="0"/>
+    <field name="bemerkung_rm" labelOnTop="0"/>
+    <field name="ersteintrag" labelOnTop="0"/>
+    <field name="geo_lage_polygon" labelOnTop="0"/>
+    <field name="inbetrieb" labelOnTop="0"/>
+    <field name="katasternummer" labelOnTop="0"/>
+    <field name="letzteanpassung" labelOnTop="0"/>
+    <field name="nachsorge" labelOnTop="0"/>
+    <field name="standorttyp" labelOnTop="0"/>
+    <field name="statusaltlv" labelOnTop="0"/>
+    <field name="t_basket" labelOnTop="0"/>
+    <field name="t_id" labelOnTop="0"/>
+    <field name="t_ili_tid" labelOnTop="0"/>
+    <field name="url_kbs_auszug" labelOnTop="0"/>
+    <field name="url_standort" labelOnTop="0"/>
+    <field name="zustaendigkeitkataster" labelOnTop="0"/>
+  </labelOnTop>
+  <reuseLastValue>
+    <field name="bemerkung" reuseLastValue="0"/>
+    <field name="bemerkung_de" reuseLastValue="0"/>
+    <field name="bemerkung_en" reuseLastValue="0"/>
+    <field name="bemerkung_fr" reuseLastValue="0"/>
+    <field name="bemerkung_it" reuseLastValue="0"/>
+    <field name="bemerkung_rm" reuseLastValue="0"/>
+    <field name="ersteintrag" reuseLastValue="0"/>
+    <field name="geo_lage_polygon" reuseLastValue="0"/>
+    <field name="inbetrieb" reuseLastValue="0"/>
+    <field name="katasternummer" reuseLastValue="0"/>
+    <field name="letzteanpassung" reuseLastValue="0"/>
+    <field name="nachsorge" reuseLastValue="0"/>
+    <field name="standorttyp" reuseLastValue="0"/>
+    <field name="statusaltlv" reuseLastValue="0"/>
+    <field name="t_basket" reuseLastValue="0"/>
+    <field name="t_id" reuseLastValue="0"/>
+    <field name="t_ili_tid" reuseLastValue="0"/>
+    <field name="url_kbs_auszug" reuseLastValue="0"/>
+    <field name="url_standort" reuseLastValue="0"/>
+    <field name="zustaendigkeitkataster" reuseLastValue="0"/>
+  </reuseLastValue>
+  <dataDefinedFieldProperties/>
+  <widgets/>
+  <previewExpression>'Robot: '||standorttyp ||' - '||katasternummer</previewExpression>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_robot_style.qml
+++ b/tests/testdata/ilirepo/usabilityhub/layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_robot_style.qml
@@ -1,5 +1,5 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis readOnly="0" version="3.22.11-Białowieża" styleCategories="LayerConfiguration|Forms">
+<qgis version="3.22.11-Białowieża" readOnly="0" styleCategories="LayerConfiguration|Fields|Forms">
   <flags>
     <Identifiable>1</Identifiable>
     <Removable>1</Removable>
@@ -7,176 +7,176 @@
     <Private>0</Private>
   </flags>
   <fieldConfiguration>
-    <field name="t_id">
+    <field name="t_id" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="t_basket">
+    <field name="t_basket" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option type="Map">
-            <Option value="false" name="AllowAddFeatures" type="bool"/>
-            <Option value="true" name="AllowNULL" type="bool"/>
-            <Option value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'" name="FilterExpression" type="QString"/>
-            <Option name="FilterFields"/>
-            <Option value="true" name="OrderByValue" type="bool"/>
-            <Option value="belasteter_standort_t_basket_fkey_1" name="Relation" type="QString"/>
-            <Option value="false" name="ShowForm" type="bool"/>
-            <Option value="false" name="ShowOpenFormButton" type="bool"/>
+            <Option name="AllowAddFeatures" type="bool" value="false"/>
+            <Option name="AllowNULL" type="bool" value="true"/>
+            <Option name="FilterExpression" type="QString" value="&quot;topic&quot; = 'KbS_LV95_V1_4.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', &quot;dataset&quot;), 'datasetname') != 'Catalogueset'"/>
+            <Option name="FilterFields" type="invalid"/>
+            <Option name="OrderByValue" type="bool" value="true"/>
+            <Option name="Relation" type="QString" value="belasteter_standort_t_basket_fkey_1"/>
+            <Option name="ShowForm" type="bool" value="false"/>
+            <Option name="ShowOpenFormButton" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="t_ili_tid">
+    <field name="t_ili_tid" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="katasternummer">
+    <field name="katasternummer" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="url_standort">
+    <field name="url_standort" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="geo_lage_polygon">
+    <field name="geo_lage_polygon" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="standorttyp">
+    <field name="standorttyp" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="inbetrieb">
+    <field name="inbetrieb" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="nachsorge">
+    <field name="nachsorge" configurationFlags="None">
       <editWidget type="CheckBox">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="statusaltlv">
+    <field name="statusaltlv" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="ersteintrag">
+    <field name="ersteintrag" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="M/d/yy" name="display_format" type="QString"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="M/d/yy"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="letzteanpassung">
+    <field name="letzteanpassung" configurationFlags="None">
       <editWidget type="DateTime">
         <config>
           <Option type="Map">
-            <Option value="true" name="calendar_popup" type="bool"/>
-            <Option value="M/d/yy" name="display_format" type="QString"/>
+            <Option name="calendar_popup" type="bool" value="true"/>
+            <Option name="display_format" type="QString" value="M/d/yy"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="url_kbs_auszug">
+    <field name="url_kbs_auszug" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option/>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung">
+    <field name="bemerkung" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_de">
+    <field name="bemerkung_de" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_fr">
+    <field name="bemerkung_fr" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_rm">
+    <field name="bemerkung_rm" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_it">
+    <field name="bemerkung_it" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="bemerkung_en">
+    <field name="bemerkung_en" configurationFlags="None">
       <editWidget type="TextEdit">
         <config>
           <Option type="Map">
-            <Option value="false" name="IsMultiline" type="bool"/>
-            <Option value="false" name="UseHtml" type="bool"/>
+            <Option name="IsMultiline" type="bool" value="false"/>
+            <Option name="UseHtml" type="bool" value="false"/>
           </Option>
         </config>
       </editWidget>
     </field>
-    <field name="zustaendigkeitkataster">
+    <field name="zustaendigkeitkataster" configurationFlags="None">
       <editWidget type="RelationReference">
         <config>
           <Option/>
@@ -184,6 +184,95 @@
       </editWidget>
     </field>
   </fieldConfiguration>
+  <aliases>
+    <alias name="" index="0" field="t_id"/>
+    <alias name="" index="1" field="t_basket"/>
+    <alias name="" index="2" field="t_ili_tid"/>
+    <alias name="Katasternummer" index="3" field="katasternummer"/>
+    <alias name="URL_Standort" index="4" field="url_standort"/>
+    <alias name="Geo_Lage_Polygon" index="5" field="geo_lage_polygon"/>
+    <alias name="Standorttyp" index="6" field="standorttyp"/>
+    <alias name="InBetrieb" index="7" field="inbetrieb"/>
+    <alias name="Nachsorge" index="8" field="nachsorge"/>
+    <alias name="StatusAltlV" index="9" field="statusaltlv"/>
+    <alias name="Ersteintrag" index="10" field="ersteintrag"/>
+    <alias name="LetzteAnpassung" index="11" field="letzteanpassung"/>
+    <alias name="URL_KbS_Auszug" index="12" field="url_kbs_auszug"/>
+    <alias name="Bemerkung" index="13" field="bemerkung"/>
+    <alias name="" index="14" field="bemerkung_de"/>
+    <alias name="" index="15" field="bemerkung_fr"/>
+    <alias name="01100010 01100101 01101101 01100101 01110010 01101011 01110101 01101110 01100111 01011111 01110010 01101101" index="16" field="bemerkung_rm"/>
+    <alias name="01100010 01100101 01101101 01100101 01110010 01101011 01110101 01101110 01100111 01011111 01101001 01110100" index="17" field="bemerkung_it"/>
+    <alias name="" index="18" field="bemerkung_en"/>
+    <alias name="ZustaendigkeitKataster" index="19" field="zustaendigkeitkataster"/>
+  </aliases>
+  <defaults>
+    <default expression="" applyOnUpdate="0" field="t_id"/>
+    <default expression="" applyOnUpdate="0" field="t_basket"/>
+    <default expression="" applyOnUpdate="0" field="t_ili_tid"/>
+    <default expression="" applyOnUpdate="0" field="katasternummer"/>
+    <default expression="" applyOnUpdate="0" field="url_standort"/>
+    <default expression="" applyOnUpdate="0" field="geo_lage_polygon"/>
+    <default expression="" applyOnUpdate="0" field="standorttyp"/>
+    <default expression="" applyOnUpdate="0" field="inbetrieb"/>
+    <default expression="" applyOnUpdate="0" field="nachsorge"/>
+    <default expression="" applyOnUpdate="0" field="statusaltlv"/>
+    <default expression="" applyOnUpdate="0" field="ersteintrag"/>
+    <default expression="" applyOnUpdate="0" field="letzteanpassung"/>
+    <default expression="" applyOnUpdate="0" field="url_kbs_auszug"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_de"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_fr"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_rm"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_it"/>
+    <default expression="" applyOnUpdate="0" field="bemerkung_en"/>
+    <default expression="" applyOnUpdate="0" field="zustaendigkeitkataster"/>
+  </defaults>
+  <constraints>
+    <constraint exp_strength="0" constraints="3" notnull_strength="1" field="t_id" unique_strength="1"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="t_basket" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="t_ili_tid" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="katasternummer" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="url_standort" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="geo_lage_polygon" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="standorttyp" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="inbetrieb" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="nachsorge" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="statusaltlv" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="ersteintrag" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="letzteanpassung" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="url_kbs_auszug" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_de" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_fr" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_rm" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_it" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="0" notnull_strength="0" field="bemerkung_en" unique_strength="0"/>
+    <constraint exp_strength="0" constraints="1" notnull_strength="1" field="zustaendigkeitkataster" unique_strength="0"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="t_id"/>
+    <constraint desc="" exp="" field="t_basket"/>
+    <constraint desc="" exp="" field="t_ili_tid"/>
+    <constraint desc="" exp="" field="katasternummer"/>
+    <constraint desc="" exp="" field="url_standort"/>
+    <constraint desc="" exp="" field="geo_lage_polygon"/>
+    <constraint desc="" exp="" field="standorttyp"/>
+    <constraint desc="" exp="" field="inbetrieb"/>
+    <constraint desc="" exp="" field="nachsorge"/>
+    <constraint desc="" exp="" field="statusaltlv"/>
+    <constraint desc="" exp="" field="ersteintrag"/>
+    <constraint desc="" exp="" field="letzteanpassung"/>
+    <constraint desc="" exp="" field="url_kbs_auszug"/>
+    <constraint desc="" exp="" field="bemerkung"/>
+    <constraint desc="" exp="" field="bemerkung_de"/>
+    <constraint desc="" exp="" field="bemerkung_fr"/>
+    <constraint desc="" exp="" field="bemerkung_rm"/>
+    <constraint desc="" exp="" field="bemerkung_it"/>
+    <constraint desc="" exp="" field="bemerkung_en"/>
+    <constraint desc="" exp="" field="zustaendigkeitkataster"/>
+  </constraintExpressions>
+  <expressionfields/>
   <editform tolerant="1"></editform>
   <editforminit/>
   <editforminitcodesource>0</editforminitcodesource>
@@ -208,7 +297,7 @@ def my_form_open(dialog, layer, feature):
   <featformsuppress>0</featformsuppress>
   <editorlayout>tablayout</editorlayout>
   <attributeEditorForm>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="01000111 01100101 01101110 01100101 01110010 01100001 01101100" columnCount="2" groupBox="0">
+    <attributeEditorContainer showLabel="1" name="01000111 01100101 01101110 01100101 01110010 01100001 01101100" visibilityExpressionEnabled="0" columnCount="2" groupBox="0" visibilityExpression="">
       <attributeEditorField showLabel="1" name="bemerkung" index="13"/>
       <attributeEditorField showLabel="1" name="bemerkung_de" index="14"/>
       <attributeEditorField showLabel="1" name="bemerkung_en" index="18"/>
@@ -228,56 +317,56 @@ def my_form_open(dialog, layer, feature):
       <attributeEditorField showLabel="1" name="url_standort" index="4"/>
       <attributeEditorField showLabel="1" name="zustaendigkeitkataster" index="19"/>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Parzellenidentifikation" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Parzellenidentifikation" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" relation="parzellenidentifikation_belsttr_stndr_przllnvrweis_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Deponie" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Deponie" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="deponietyp__belasteter_standort_dpntyp_fkey_1" relation="deponietyp__belasteter_standort_dpntyp_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Egrid" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="egrid__belasteter_standort_egrid_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="egrid__belasteter_standort_egrid_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Egrid" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="egrid__belasteter_standort_egrid_fkey_1" relation="egrid__belasteter_standort_egrid_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
-    <attributeEditorContainer showLabel="1" visibilityExpressionEnabled="0" visibilityExpression="" name="Untersuchungsmassnahmen" columnCount="1" groupBox="0">
-      <attributeEditorRelation showLabel="1" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relationWidgetTypeId="" label="" forceSuppressFormPopup="0" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" nmRelationId="">
+    <attributeEditorContainer showLabel="1" name="Untersuchungsmassnahmen" visibilityExpressionEnabled="0" columnCount="1" groupBox="0" visibilityExpression="">
+      <attributeEditorRelation showLabel="1" nmRelationId="" label="" name="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" relation="untersmassn__belsttr_stndrchngsmssnhmen_fkey_1" forceSuppressFormPopup="0" relationWidgetTypeId="">
         <editor_configuration type="Map">
-          <Option value="AllButtons" name="buttons" type="QString"/>
+          <Option name="buttons" type="QString" value="AllButtons"/>
         </editor_configuration>
       </attributeEditorRelation>
     </attributeEditorContainer>
   </attributeEditorForm>
   <editable>
-    <field editable="1" name="bemerkung"/>
-    <field editable="1" name="bemerkung_de"/>
-    <field editable="1" name="bemerkung_en"/>
-    <field editable="1" name="bemerkung_fr"/>
-    <field editable="1" name="bemerkung_it"/>
-    <field editable="1" name="bemerkung_rm"/>
-    <field editable="1" name="ersteintrag"/>
-    <field editable="1" name="geo_lage_polygon"/>
-    <field editable="1" name="inbetrieb"/>
-    <field editable="1" name="katasternummer"/>
-    <field editable="1" name="letzteanpassung"/>
-    <field editable="1" name="nachsorge"/>
-    <field editable="1" name="standorttyp"/>
-    <field editable="1" name="statusaltlv"/>
-    <field editable="1" name="t_basket"/>
-    <field editable="1" name="t_id"/>
-    <field editable="1" name="t_ili_tid"/>
-    <field editable="1" name="url_kbs_auszug"/>
-    <field editable="1" name="url_standort"/>
-    <field editable="1" name="zustaendigkeitkataster"/>
+    <field name="bemerkung" editable="1"/>
+    <field name="bemerkung_de" editable="1"/>
+    <field name="bemerkung_en" editable="1"/>
+    <field name="bemerkung_fr" editable="1"/>
+    <field name="bemerkung_it" editable="1"/>
+    <field name="bemerkung_rm" editable="1"/>
+    <field name="ersteintrag" editable="1"/>
+    <field name="geo_lage_polygon" editable="1"/>
+    <field name="inbetrieb" editable="1"/>
+    <field name="katasternummer" editable="1"/>
+    <field name="letzteanpassung" editable="1"/>
+    <field name="nachsorge" editable="1"/>
+    <field name="standorttyp" editable="1"/>
+    <field name="statusaltlv" editable="1"/>
+    <field name="t_basket" editable="1"/>
+    <field name="t_id" editable="1"/>
+    <field name="t_ili_tid" editable="1"/>
+    <field name="url_kbs_auszug" editable="1"/>
+    <field name="url_standort" editable="1"/>
+    <field name="zustaendigkeitkataster" editable="1"/>
   </editable>
   <labelOnTop>
     <field name="bemerkung" labelOnTop="0"/>

--- a/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_multistyles_KbS_LV95_V1_4.yaml
+++ b/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_multistyles_KbS_LV95_V1_4.yaml
@@ -1,0 +1,11 @@
+layertree:
+    - "KbS_LV95_V1_4 Layers":
+        group: true
+        child-nodes:
+            - "Belasteter_Standort (Geo_Lage_Punkt)":
+                qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_default_style.qml"
+                styles:
+                    robot:
+                        qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_robot_style.qml"
+                    french:
+                        qmlstylefile: "../layerstyle/opengisch_KbS_LV95_V1_4_004_belasteterstandort_punkt_french_style.qml"


### PR DESCRIPTION
Load styles from projecttopping (YAML) and their qmlstylefiles.

```yaml
layertree:
  - "Buildings":
    featurecount: true
    #qmlstylefile of "default" style
    qmlstylefile: "ilidata:themedcity_default_buildings_qml"
    styles:
      mono:
        qmlstylefile: "ilidata:themedcity_mono_buildings_qml"
      fancy:
        qmlstylefile: "ilidata:themedcity_fancy_buildings_qml"
```

See the specification here: https://github.com/opengisch/QgisModelBaker/issues/645#issuecomment-1300699081