### PR TITLE
IliToppingMaker: use semicolons as deliminiter instead of commas 

### DIFF
--- a/modelbaker/ilitoppingmaker/metaconfig.py
+++ b/modelbaker/ilitoppingmaker/metaconfig.py
@@ -85,7 +85,7 @@ class MetaConfig(object):
 
         if self.referencedata_paths:
             # generate toppingfiles of the reference data
-            referencedata_links = ",".join(
+            referencedata_links = ";".join(
                 [
                     self._generate_toppingfile_link(
                         target, MetaConfig.REFERENCEDATA_TYPE, path
@@ -98,7 +98,7 @@ class MetaConfig(object):
         ili2db_section = {}
 
         # append models and the ili2db parameters
-        ili2db_section["models"] = ",".join(self.ili2db_settings.models)
+        ili2db_section["models"] = ";".join(self.ili2db_settings.models)
         ili2db_section.update(self.ili2db_settings.parameters)
 
         # generate metaattr and prescript / postscript files


### PR DESCRIPTION
like defined here https://github.com/claeis/iox-ili/issues/91 fixes https://github.com/opengisch/QgisModelBaker/issues/757