### PR TITLE
ProjectTopping loading Variables and Layouts

### DIFF
--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -29,7 +29,8 @@ from qgis.core import (
     QgsProject,
     QgsReadWriteContext,
 )
-from qgis.PyQt.QtCore import QDomDocument, QObject, pyqtSignal
+from qgis.PyQt.QtCore import QObject, pyqtSignal
+from qgis.PyQt.QtXml import QDomDocument
 
 from .layers import Layer
 from .legend import LegendGroup
@@ -263,11 +264,11 @@ class Project(QObject):
     def load_custom_project_variables(self, qgis_project):
         for key in self.custom_project_variables.keys():
             QgsExpressionContextUtils.setProjectVariable(
-                qgis_project, self.custom_project_variables[key]
+                qgis_project, key, self.custom_project_variables[key]
             )
 
     def load_layouts(self, qgis_project):
-        for layout_name in self.layouts:
+        for layout_name in self.layouts.keys():
             # create the layout
             layout = QgsPrintLayout(qgis_project)
             # initializes default settings for blank print layout canvas

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -53,7 +53,7 @@ class Project(QObject):
         self.auto_transaction = auto_transaction
         self.evaluate_default_values = evaluate_default_values
         self.relations = List[Relation]
-        self.custom_project_variables = {}
+        self.custom_variables = {}
         self.layouts = {}
         self.mapthemes = {}
         self.context = context
@@ -82,7 +82,7 @@ class Project(QObject):
 
         definition["legend"] = legend
         definition["relations"] = relations
-        definition["custom_project_variables"] = self.custom_project_variables
+        definition["custom_variables"] = self.custom_variables
         definition["layouts"] = self.layouts
         definition["mapthemes"] = self.mapthemes
 
@@ -100,7 +100,7 @@ class Project(QObject):
             self.layers.append(layer)
 
         self.custom_layer_order_structure = definition["custom_layer_order_structure"]
-        self.custom_project_variables = definition["custom_project_variables"]
+        self.custom_variables = definition["custom_variables"]
         self.layouts = definition["layouts"]
         self.mapthemes = definition["mapthemes"]
 
@@ -247,7 +247,7 @@ class Project(QObject):
         
         self.load_mapthemes(qgis_project)
 
-        self.load_custom_project_variables(qgis_project)
+        self.load_custom_variables(qgis_project)
 
         self.load_layouts(qgis_project)
 
@@ -267,10 +267,10 @@ class Project(QObject):
             root.setCustomLayerOrder(custom_layer_order)
             root.setHasCustomLayerOrder(True)
 
-    def load_custom_project_variables(self, qgis_project):
-        for key in self.custom_project_variables.keys():
+    def load_custom_variables(self, qgis_project):
+        for key in self.custom_variables.keys():
             QgsExpressionContextUtils.setProjectVariable(
-                qgis_project, key, self.custom_project_variables[key]
+                qgis_project, key, self.custom_variables[key]
             )
 
     def load_layouts(self, qgis_project):

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -625,7 +625,7 @@ class Generator(QObject):
 
         return legend
 
-    def resolve_layouts(
+    def resolved_layouts(
         self,
         layouts={},
         path_resolver=lambda path: path,
@@ -636,6 +636,7 @@ class Generator(QObject):
             resolved_layouts[layout_name]["templatefile"] = path_resolver(
                 layouts[layout_name].get("templatefile")
             )
+        return resolved_layouts
 
     def db_or_schema_exists(self):
         return self._db_connector.db_or_schema_exists()

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -625,6 +625,18 @@ class Generator(QObject):
 
         return legend
 
+    def resolve_layouts(
+        self,
+        layouts={},
+        path_resolver=lambda path: path,
+    ):
+        resolved_layouts = {}
+        for layout_name in layouts.keys():
+            resolved_layouts[layout_name] = {}
+            resolved_layouts[layout_name]["templatefile"] = path_resolver(
+                layouts[layout_name].get("templatefile")
+            )
+
     def db_or_schema_exists(self):
         return self._db_connector.db_or_schema_exists()
 

--- a/tests/test_projecttopping.py
+++ b/tests/test_projecttopping.py
@@ -1157,7 +1157,7 @@ class TestProjectTopping(unittest.TestCase):
                 else None,
             )
             assert "variables" in projecttopping_data
-            custom_project_variables = projecttopping_data["variables"]
+            custom_variables = projecttopping_data["variables"]
             assert "layouts" in projecttopping_data
             resolved_layouts = generator.resolved_layouts(
                 projecttopping_data["layouts"],
@@ -1177,7 +1177,7 @@ class TestProjectTopping(unittest.TestCase):
         project.layers = available_layers
         project.legend = legend
         project.relations = relations
-        project.custom_project_variables = custom_project_variables
+        project.custom_variables = custom_variables
         project.layouts = resolved_layouts
         project.post_generate()
 

--- a/tests/testdata/ilirepo/usabilityhub/layouttemplate/opengisch_KbS_LV95_V1_4_layout_one.qpt
+++ b/tests/testdata/ilirepo/usabilityhub/layouttemplate/opengisch_KbS_LV95_V1_4_layout_one.qpt
@@ -1,0 +1,156 @@
+<Layout worldFileMap="{fa260787-a843-4696-9cb7-0d61693605cf}" units="mm" name="Layout One" printResolution="300">
+ <Snapper snapToItems="1" tolerance="5" snapToGrid="0" snapToGuides="1"/>
+ <Grid offsetX="0" offsetUnits="mm" resolution="10" resUnits="mm" offsetY="0"/>
+ <PageCollection>
+  <symbol type="fill" name="" clip_to_extent="1" alpha="1" force_rhr="0">
+   <data_defined_properties>
+    <Option type="Map">
+     <Option value="" type="QString" name="name"/>
+     <Option name="properties"/>
+     <Option value="collection" type="QString" name="type"/>
+    </Option>
+   </data_defined_properties>
+   <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+    <Option type="Map">
+     <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+     <Option value="255,255,255,255" type="QString" name="color"/>
+     <Option value="miter" type="QString" name="joinstyle"/>
+     <Option value="0,0" type="QString" name="offset"/>
+     <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+     <Option value="MM" type="QString" name="offset_unit"/>
+     <Option value="35,35,35,255" type="QString" name="outline_color"/>
+     <Option value="no" type="QString" name="outline_style"/>
+     <Option value="0.26" type="QString" name="outline_width"/>
+     <Option value="MM" type="QString" name="outline_width_unit"/>
+     <Option value="solid" type="QString" name="style"/>
+    </Option>
+    <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+    <prop k="color" v="255,255,255,255"/>
+    <prop k="joinstyle" v="miter"/>
+    <prop k="offset" v="0,0"/>
+    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+    <prop k="offset_unit" v="MM"/>
+    <prop k="outline_color" v="35,35,35,255"/>
+    <prop k="outline_style" v="no"/>
+    <prop k="outline_width" v="0.26"/>
+    <prop k="outline_width_unit" v="MM"/>
+    <prop k="style" v="solid"/>
+    <data_defined_properties>
+     <Option type="Map">
+      <Option value="" type="QString" name="name"/>
+      <Option name="properties"/>
+      <Option value="collection" type="QString" name="type"/>
+     </Option>
+    </data_defined_properties>
+   </layer>
+  </symbol>
+  <LayoutItem frame="false" visibility="1" type="65638" outlineWidthM="0.3,mm" id="" background="true" uuid="{ec8edf97-671f-4cf5-8555-5d97b2bf672b}" itemRotation="0" referencePoint="0" size="297,210,mm" positionLock="false" groupUuid="" blendMode="0" zValue="0" position="0,0,mm" excludeFromExports="0" frameJoinStyle="miter" positionOnPage="0,0,mm" opacity="1" templateUuid="{ec8edf97-671f-4cf5-8555-5d97b2bf672b}">
+   <FrameColor red="0" green="0" blue="0" alpha="255"/>
+   <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+   <LayoutObject>
+    <dataDefinedProperties>
+     <Option type="Map">
+      <Option value="" type="QString" name="name"/>
+      <Option name="properties"/>
+      <Option value="collection" type="QString" name="type"/>
+     </Option>
+    </dataDefinedProperties>
+    <customproperties>
+     <Option/>
+    </customproperties>
+   </LayoutObject>
+   <symbol type="fill" name="" clip_to_extent="1" alpha="1" force_rhr="0">
+    <data_defined_properties>
+     <Option type="Map">
+      <Option value="" type="QString" name="name"/>
+      <Option name="properties"/>
+      <Option value="collection" type="QString" name="type"/>
+     </Option>
+    </data_defined_properties>
+    <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+     <Option type="Map">
+      <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+      <Option value="255,255,255,255" type="QString" name="color"/>
+      <Option value="miter" type="QString" name="joinstyle"/>
+      <Option value="0,0" type="QString" name="offset"/>
+      <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+      <Option value="MM" type="QString" name="offset_unit"/>
+      <Option value="35,35,35,255" type="QString" name="outline_color"/>
+      <Option value="no" type="QString" name="outline_style"/>
+      <Option value="0.26" type="QString" name="outline_width"/>
+      <Option value="MM" type="QString" name="outline_width_unit"/>
+      <Option value="solid" type="QString" name="style"/>
+     </Option>
+     <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+     <prop k="color" v="255,255,255,255"/>
+     <prop k="joinstyle" v="miter"/>
+     <prop k="offset" v="0,0"/>
+     <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+     <prop k="offset_unit" v="MM"/>
+     <prop k="outline_color" v="35,35,35,255"/>
+     <prop k="outline_style" v="no"/>
+     <prop k="outline_width" v="0.26"/>
+     <prop k="outline_width_unit" v="MM"/>
+     <prop k="style" v="solid"/>
+     <data_defined_properties>
+      <Option type="Map">
+       <Option value="" type="QString" name="name"/>
+       <Option name="properties"/>
+       <Option value="collection" type="QString" name="type"/>
+      </Option>
+     </data_defined_properties>
+    </layer>
+   </symbol>
+  </LayoutItem>
+  <GuideCollection visible="1"/>
+ </PageCollection>
+ <LayoutItem frame="false" mapFlags="0" visibility="1" type="65639" outlineWidthM="0.3,mm" id="Map 1" background="true" followPreset="false" keepLayerSet="false" uuid="{fa260787-a843-4696-9cb7-0d61693605cf}" itemRotation="0" referencePoint="0" size="259.194,135.734,mm" positionLock="false" groupUuid="" mapRotation="0" drawCanvasItems="true" blendMode="0" labelMargin="0,mm" zValue="2" position="17.5684,33.6928,mm" isTemporal="0" excludeFromExports="0" frameJoinStyle="miter" positionOnPage="17.5684,33.6928,mm" opacity="1" templateUuid="{fa260787-a843-4696-9cb7-0d61693605cf}" followPresetName="">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+  <LayoutObject>
+   <dataDefinedProperties>
+    <Option type="Map">
+     <Option value="" type="QString" name="name"/>
+     <Option name="properties"/>
+     <Option value="collection" type="QString" name="type"/>
+    </Option>
+   </dataDefinedProperties>
+   <customproperties>
+    <Option/>
+   </customproperties>
+  </LayoutObject>
+  <Extent xmin="2035625" ymax="1507089.13649025070481002" xmax="3294375" ymin="847910.86350974929518998"/>
+  <LayerSet/>
+  <AtlasMap atlasDriven="0" scalingMode="2" margin="0.10000000000000001"/>
+  <labelBlockingItems/>
+  <atlasClippingSettings forceLabelsInside="0" restrictLayers="0" clippingType="1" enabled="0">
+   <layersToClip/>
+  </atlasClippingSettings>
+  <itemClippingSettings forceLabelsInside="0" clipSource="" clippingType="1" enabled="0"/>
+ </LayoutItem>
+ <LayoutItem frame="false" marginX="0" visibility="1" type="65641" outlineWidthM="0.3,mm" id="" background="false" labelText="Layout One" uuid="{7741419a-336d-464e-9ffa-6f0085fdbf13}" itemRotation="0" referencePoint="0" size="259.194,24.7883,mm" positionLock="false" groupUuid="" marginY="0" blendMode="0" zValue="1" htmlState="0" position="17.5684,15.1617,mm" excludeFromExports="0" halign="8" frameJoinStyle="miter" positionOnPage="17.5684,15.1617,mm" opacity="1" valign="32" templateUuid="{7741419a-336d-464e-9ffa-6f0085fdbf13}">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+  <LayoutObject>
+   <dataDefinedProperties>
+    <Option type="Map">
+     <Option value="" type="QString" name="name"/>
+     <Option name="properties"/>
+     <Option value="collection" type="QString" name="type"/>
+    </Option>
+   </dataDefinedProperties>
+   <customproperties>
+    <Option/>
+   </customproperties>
+  </LayoutObject>
+  <LabelFont description="Ubuntu,27,-1,5,50,0,0,0,0,0" style=""/>
+  <FontColor red="0" green="0" blue="0" alpha="255"/>
+ </LayoutItem>
+ <customproperties>
+  <Option type="Map">
+   <Option value="png" type="QString" name="atlasRasterFormat"/>
+   <Option value="true" type="bool" name="singleFile"/>
+  </Option>
+ </customproperties>
+ <Atlas coverageLayerSource="dbname='test data' host=localhost user='postgres' key='t_id' srid=2056 type=MultiPolygon checkPrimaryKeyUnicity='1' table=&quot;lighningtes22&quot;.&quot;belasteter_standort&quot; (geo_lage_polygon)" pageNameExpression="&quot;t_ili_tid&quot;" filterFeatures="0" coverageLayer="Belasteter_Standort__Geo_Lage_Polygon__27bf8f98_4bb1_488d_b67f_58165fbd21eb" coverageLayerProvider="postgres" enabled="1" sortFeatures="0" coverageLayerName="Belasteter_Standort (Geo_Lage_Polygon)" hideCoverage="0" filenamePattern="'output_'||@atlas_featurenumber"/>
+</Layout>

--- a/tests/testdata/ilirepo/usabilityhub/layouttemplate/opengisch_KbS_LV95_V1_4_layout_two.qpt
+++ b/tests/testdata/ilirepo/usabilityhub/layouttemplate/opengisch_KbS_LV95_V1_4_layout_two.qpt
@@ -1,0 +1,180 @@
+<Layout worldFileMap="{610a47f2-4531-4a9e-a0b0-83bf5c42c513}" units="mm" name="Layout Two" printResolution="300">
+ <Snapper snapToItems="1" tolerance="5" snapToGrid="0" snapToGuides="1"/>
+ <Grid offsetX="0" offsetUnits="mm" resolution="10" resUnits="mm" offsetY="0"/>
+ <PageCollection>
+  <symbol type="fill" name="" clip_to_extent="1" alpha="1" force_rhr="0">
+   <data_defined_properties>
+    <Option type="Map">
+     <Option value="" type="QString" name="name"/>
+     <Option name="properties"/>
+     <Option value="collection" type="QString" name="type"/>
+    </Option>
+   </data_defined_properties>
+   <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+    <Option type="Map">
+     <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+     <Option value="255,255,255,255" type="QString" name="color"/>
+     <Option value="miter" type="QString" name="joinstyle"/>
+     <Option value="0,0" type="QString" name="offset"/>
+     <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+     <Option value="MM" type="QString" name="offset_unit"/>
+     <Option value="35,35,35,255" type="QString" name="outline_color"/>
+     <Option value="no" type="QString" name="outline_style"/>
+     <Option value="0.26" type="QString" name="outline_width"/>
+     <Option value="MM" type="QString" name="outline_width_unit"/>
+     <Option value="solid" type="QString" name="style"/>
+    </Option>
+    <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+    <prop k="color" v="255,255,255,255"/>
+    <prop k="joinstyle" v="miter"/>
+    <prop k="offset" v="0,0"/>
+    <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+    <prop k="offset_unit" v="MM"/>
+    <prop k="outline_color" v="35,35,35,255"/>
+    <prop k="outline_style" v="no"/>
+    <prop k="outline_width" v="0.26"/>
+    <prop k="outline_width_unit" v="MM"/>
+    <prop k="style" v="solid"/>
+    <data_defined_properties>
+     <Option type="Map">
+      <Option value="" type="QString" name="name"/>
+      <Option name="properties"/>
+      <Option value="collection" type="QString" name="type"/>
+     </Option>
+    </data_defined_properties>
+   </layer>
+  </symbol>
+  <LayoutItem frame="false" visibility="1" type="65638" outlineWidthM="0.3,mm" id="" background="true" uuid="{e28ac1ab-3ce1-404f-b25d-ce837f5bd9d8}" itemRotation="0" referencePoint="0" size="297,210,mm" positionLock="false" groupUuid="" blendMode="0" zValue="0" position="0,0,mm" excludeFromExports="0" frameJoinStyle="miter" positionOnPage="0,0,mm" opacity="1" templateUuid="{e28ac1ab-3ce1-404f-b25d-ce837f5bd9d8}">
+   <FrameColor red="0" green="0" blue="0" alpha="255"/>
+   <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+   <LayoutObject>
+    <dataDefinedProperties>
+     <Option type="Map">
+      <Option value="" type="QString" name="name"/>
+      <Option name="properties"/>
+      <Option value="collection" type="QString" name="type"/>
+     </Option>
+    </dataDefinedProperties>
+    <customproperties>
+     <Option/>
+    </customproperties>
+   </LayoutObject>
+   <symbol type="fill" name="" clip_to_extent="1" alpha="1" force_rhr="0">
+    <data_defined_properties>
+     <Option type="Map">
+      <Option value="" type="QString" name="name"/>
+      <Option name="properties"/>
+      <Option value="collection" type="QString" name="type"/>
+     </Option>
+    </data_defined_properties>
+    <layer pass="0" class="SimpleFill" locked="0" enabled="1">
+     <Option type="Map">
+      <Option value="3x:0,0,0,0,0,0" type="QString" name="border_width_map_unit_scale"/>
+      <Option value="255,255,255,255" type="QString" name="color"/>
+      <Option value="miter" type="QString" name="joinstyle"/>
+      <Option value="0,0" type="QString" name="offset"/>
+      <Option value="3x:0,0,0,0,0,0" type="QString" name="offset_map_unit_scale"/>
+      <Option value="MM" type="QString" name="offset_unit"/>
+      <Option value="35,35,35,255" type="QString" name="outline_color"/>
+      <Option value="no" type="QString" name="outline_style"/>
+      <Option value="0.26" type="QString" name="outline_width"/>
+      <Option value="MM" type="QString" name="outline_width_unit"/>
+      <Option value="solid" type="QString" name="style"/>
+     </Option>
+     <prop k="border_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+     <prop k="color" v="255,255,255,255"/>
+     <prop k="joinstyle" v="miter"/>
+     <prop k="offset" v="0,0"/>
+     <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+     <prop k="offset_unit" v="MM"/>
+     <prop k="outline_color" v="35,35,35,255"/>
+     <prop k="outline_style" v="no"/>
+     <prop k="outline_width" v="0.26"/>
+     <prop k="outline_width_unit" v="MM"/>
+     <prop k="style" v="solid"/>
+     <data_defined_properties>
+      <Option type="Map">
+       <Option value="" type="QString" name="name"/>
+       <Option name="properties"/>
+       <Option value="collection" type="QString" name="type"/>
+      </Option>
+     </data_defined_properties>
+    </layer>
+   </symbol>
+  </LayoutItem>
+  <GuideCollection visible="1"/>
+ </PageCollection>
+ <LayoutItem frame="false" mapFlags="0" visibility="1" type="65639" outlineWidthM="0.3,mm" id="Map 2" background="true" followPreset="false" keepLayerSet="false" uuid="{ba504bc2-d7cc-42fc-b331-68a77b1aa2f8}" itemRotation="0" referencePoint="0" size="136.467,160.281,mm" positionLock="false" groupUuid="" mapRotation="0" drawCanvasItems="true" blendMode="0" labelMargin="0,mm" zValue="3" position="12.0331,11.3111,mm" isTemporal="0" excludeFromExports="0" frameJoinStyle="miter" positionOnPage="12.0331,11.3111,mm" opacity="1" templateUuid="{ba504bc2-d7cc-42fc-b331-68a77b1aa2f8}" followPresetName="">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+  <LayoutObject>
+   <dataDefinedProperties>
+    <Option type="Map">
+     <Option value="" type="QString" name="name"/>
+     <Option name="properties"/>
+     <Option value="collection" type="QString" name="type"/>
+    </Option>
+   </dataDefinedProperties>
+   <customproperties>
+    <Option/>
+   </customproperties>
+  </LayoutObject>
+  <Extent xmin="2035625" ymax="1916705.50080561474896967" xmax="3294375" ymin="438294.49919438525103033"/>
+  <LayerSet/>
+  <AtlasMap atlasDriven="0" scalingMode="2" margin="0.10000000000000001"/>
+  <labelBlockingItems/>
+  <atlasClippingSettings forceLabelsInside="0" restrictLayers="0" clippingType="1" enabled="0">
+   <layersToClip/>
+  </atlasClippingSettings>
+  <itemClippingSettings forceLabelsInside="0" clipSource="" clippingType="1" enabled="0"/>
+ </LayoutItem>
+ <LayoutItem frame="false" mapFlags="0" visibility="1" type="65639" outlineWidthM="0.3,mm" id="Map 1" background="true" followPreset="false" keepLayerSet="false" uuid="{610a47f2-4531-4a9e-a0b0-83bf5c42c513}" itemRotation="0" referencePoint="0" size="141.498,160.281,mm" positionLock="false" groupUuid="" mapRotation="0" drawCanvasItems="true" blendMode="0" labelMargin="0,mm" zValue="2" position="148.5,11.3111,mm" isTemporal="0" excludeFromExports="0" frameJoinStyle="miter" positionOnPage="148.5,11.3111,mm" opacity="1" templateUuid="{610a47f2-4531-4a9e-a0b0-83bf5c42c513}" followPresetName="">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+  <LayoutObject>
+   <dataDefinedProperties>
+    <Option type="Map">
+     <Option value="" type="QString" name="name"/>
+     <Option name="properties"/>
+     <Option value="collection" type="QString" name="type"/>
+    </Option>
+   </dataDefinedProperties>
+   <customproperties>
+    <Option/>
+   </customproperties>
+  </LayoutObject>
+  <Extent xmin="2035625" ymax="1890419.66632962599396706" xmax="3294375" ymin="464580.33367037388961762"/>
+  <LayerSet/>
+  <AtlasMap atlasDriven="0" scalingMode="2" margin="0.10000000000000001"/>
+  <labelBlockingItems/>
+  <atlasClippingSettings forceLabelsInside="0" restrictLayers="0" clippingType="1" enabled="0">
+   <layersToClip/>
+  </atlasClippingSettings>
+  <itemClippingSettings forceLabelsInside="0" clipSource="" clippingType="1" enabled="0"/>
+ </LayoutItem>
+ <LayoutItem frame="false" marginX="0" visibility="1" type="65641" outlineWidthM="0.3,mm" id="" background="false" labelText="Layout Two" uuid="{40b5140a-4734-4963-a0db-23a73b5617d8}" itemRotation="0" referencePoint="0" size="274.115,24.5476,mm" positionLock="false" groupUuid="" marginY="0" blendMode="0" zValue="1" htmlState="0" position="15.8837,174.24,mm" excludeFromExports="0" halign="8" frameJoinStyle="miter" positionOnPage="15.8837,174.24,mm" opacity="1" valign="32" templateUuid="{40b5140a-4734-4963-a0db-23a73b5617d8}">
+  <FrameColor red="0" green="0" blue="0" alpha="255"/>
+  <BackgroundColor red="255" green="255" blue="255" alpha="255"/>
+  <LayoutObject>
+   <dataDefinedProperties>
+    <Option type="Map">
+     <Option value="" type="QString" name="name"/>
+     <Option name="properties"/>
+     <Option value="collection" type="QString" name="type"/>
+    </Option>
+   </dataDefinedProperties>
+   <customproperties>
+    <Option/>
+   </customproperties>
+  </LayoutObject>
+  <LabelFont description="Ubuntu,31,-1,5,50,0,0,0,0,0" style=""/>
+  <FontColor red="0" green="0" blue="0" alpha="255"/>
+ </LayoutItem>
+ <customproperties>
+  <Option type="Map">
+   <Option value="png" type="QString" name="atlasRasterFormat"/>
+   <Option value="true" type="bool" name="singleFile"/>
+  </Option>
+ </customproperties>
+ <Atlas coverageLayerSource="dbname='test data' host=localhost user='postgres' key='t_id' srid=2056 type=Point checkPrimaryKeyUnicity='1' table=&quot;lighningtes22&quot;.&quot;belasteter_standort&quot; (geo_lage_punkt)" pageNameExpression="'Default: '||standorttyp ||' - '||katasternummer" filterFeatures="0" coverageLayer="Belasteter_Standort__Geo_Lage_Punkt__924ac2c9_8248_4481_a168_3df9a5164120" coverageLayerProvider="postgres" enabled="1" sortFeatures="0" coverageLayerName="Belasteter_Standort (Geo_Lage_Punkt)" hideCoverage="0" filenamePattern="'output_'||@atlas_featurenumber"/>
+</Layout>

--- a/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_layouts_and_variables_KbS_LV95_V1_4.yaml
+++ b/tests/testdata/ilirepo/usabilityhub/projecttopping/opengis_projecttopping_layouts_and_variables_KbS_LV95_V1_4.yaml
@@ -1,0 +1,21 @@
+layertree:
+  - "Belasteter_Standort (Geo_Lage_Punkt)":
+  - "Belasteter_Standort (Geo_Lage_Polygon)":
+  - "Informationen":
+      group: true
+      checked: true
+      expanded: true
+      child-nodes:
+        - "EGRID_":
+        - "Deponietyp_":
+
+variables:
+  "First Variable": "This is a test value."
+  "Another Variable": "2"
+  "Variable with Structure": ["Not", "The", "Normal", 815, "Case"]
+
+layouts:
+  "Layout One":
+    templatefile: "../layouttemplate/opengisch_KbS_LV95_V1_4_layout_one.qpt"
+  "Layout Two":
+    templatefile: "../layouttemplate/opengisch_KbS_LV95_V1_4_layout_two.qpt"


### PR DESCRIPTION
See specifications in the issues https://github.com/opengisch/QgisModelBaker/issues/595 and https://github.com/opengisch/QgisModelBaker/issues/594

Basically this is parsed by the front end:
```yaml

variables:
  "First Variable": "This is a test value."
  "Another Variable": "2"
  "Variable with Structure": ["Not", "The", "Normal", 815, "Case"]

layouts:
  "Layout One":
    templatefile: "../layouttemplate/opengisch_KbS_LV95_V1_4_layout_one.qpt"
  "Layout Two":
    templatefile: "../layouttemplate/opengisch_KbS_LV95_V1_4_layout_two.qpt"

```

And in a dict structure - with resolved paths - passed to the modelbaker backend to create the project.