### PR TITLE
Passing `--sqlColAsText` when importing schema without constraints

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -347,12 +347,17 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         if self.baskets:
             self.append_args(args, ["--baskets", ";".join(self.baskets)])
 
-        self.append_args(
-            args,
-            SchemaImportConfiguration.to_ili2db_args(
-                self, extra_args=extra_args, with_action=False
-            ),
-        )
+        if self.with_schemaimport:
+            self.append_args(
+                args,
+                SchemaImportConfiguration.to_ili2db_args(
+                    self, extra_args=extra_args, with_action=False
+                ),
+            )
+        else:
+            self.append_args(
+                args, Ili2DbCommandConfiguration.to_ili2db_args(self), force_append=True
+            )
 
         self.append_args(args, [self.xtffile])
 

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -355,6 +355,8 @@ class ImportDataConfiguration(SchemaImportConfiguration):
                 ),
             )
         else:
+            self.append_args(args, extra_args)
+
             self.append_args(
                 args, Ili2DbCommandConfiguration.to_ili2db_args(self), force_append=True
             )

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -247,6 +247,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
 
         if self.disable_validation:
             self.append_args(args, ["--sqlEnableNull"], force_append=True)
+            self.append_args(args, ["--sqlColsAsText"], force_append=True)
         else:
             self.append_args(args, ["--createNumChecks"], True)
             self.append_args(args, ["--createUnique"], True)


### PR DESCRIPTION
On disable validation on the schema import config (means not create physical constraints like not null) it makes sense to create all the columns as text. Since then it allows to import wrong data to fix it later via QGIS or whatever. This resolves https://github.com/opengisch/QgisModelBaker/issues/777