### PR TITLE
Validation of schemas based on ili2db 3.x.x

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -421,6 +421,7 @@ class ValidateConfiguration(Ili2DbCommandConfiguration):
         self.xtflog = ""
         self.skip_geometry_errors = False
         self.valid_config = ""
+        self.xtffile = ""
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
         args = list()
@@ -448,6 +449,9 @@ class ValidateConfiguration(Ili2DbCommandConfiguration):
         if self.with_exporttid:
             self.append_args(args, ["--exportTid"])
 
+        if self.db_ili_version == 3:
+            self.append_args(args, ["--export3"])
+            
         if self.xtflog:
             self.append_args(args, ["--xtflog", self.xtflog])
 
@@ -457,6 +461,9 @@ class ValidateConfiguration(Ili2DbCommandConfiguration):
 
         if self.valid_config:
             self.append_args(args, ["--validConfig", self.valid_config])
+        
+        if self.db_ili_version == 3:
+            self.append_args(args, [self.xtffile])
 
         self.append_args(args, Ili2DbCommandConfiguration.to_ili2db_args(self))
 

--- a/modelbaker/iliwrapper/ilivalidator.py
+++ b/modelbaker/iliwrapper/ilivalidator.py
@@ -30,10 +30,21 @@ from .iliexecutable import IliExecutable
 class Validator(IliExecutable):
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.version = 4
 
     def _create_config(self):
         return ValidateConfiguration()
+        
+    def _get_ili2db_version(self):
+        return self.version
+        
+    def _args(self, hide_password):
+        args = super()._args(hide_password)
 
+        if self.version == 3 and "--export3" in args:
+            args.remove("--export3")
+
+        return args
 
 class ValidationResultModel(QStandardItemModel):
     """


### PR DESCRIPTION
On schemas based on ili2db 3 we need to pass export3 and with it a xtffile.