### PR TITLE
COMPOSITION strength relation on STRUCTURE childs

### DIFF
--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -386,7 +386,7 @@ class Generator(QObject):
                         relation.strength = (
                             QgsRelation.Composition
                             if "strength" in record
-                            and record["strength"] == "COMPOSITE"
+                            and record["strength"] == "COMPOSITE" or referencing_layer.is_structure
                             else QgsRelation.Association
                         )
                         relation.cardinality_max = record.get("cardinality_max", None)

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -4204,6 +4204,15 @@ class TestProjectGen(unittest.TestCase):
 
         assert count == 1
 
+        count = 0
+        # when the referencing layer is a structure, it should be a composition
+        for relation in relations:
+            if relation.referencing_layer.name == "maphierref":
+                assert relation.strength == QgsRelation.Composition
+                count += 1
+
+        assert count == 2
+
     def print_info(self, text):
         logging.info(text)
 


### PR DESCRIPTION
A `STRUCTURE` object cannot exist without a parent.

This means when the parent is deleted the entry in the linking table (the structure) needs to be deleted. 

Means, every relation with a child that is a structure, shall have composition as strength.

Fixes https://github.com/opengisch/QgisModelBaker/issues/822