### PR TITLE
Improved Basket Handling in optimized Projects

### DIFF
--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -151,7 +151,7 @@ class Layer:
         self.styles = definition["styles"]
         self.__form.load(definition["form"])
 
-    def create(self, optimize_strategy=OptimizeStrategy.NONE):
+    def create(self):
         if self.definitionfile:
             if self.__layer is None:
                 layers = QgsLayerDefinition.loadLayerDefinitionLayers(
@@ -191,16 +191,6 @@ class Layer:
                 )
                 self.__layer.geometryOptions().setRemoveDuplicateNodes(True)
 
-        # set the layer variable according to the strategy
-        interlis_topics = ",".join(
-            self.all_topics
-            if optimize_strategy == OptimizeStrategy.NONE
-            else self.relevant_topics
-        )
-        QgsExpressionContextUtils.setLayerVariable(
-            self.__layer, "interlis_topic", interlis_topics
-        )
-
         for field in self.fields:
             field.create(self)
 
@@ -236,6 +226,8 @@ class Layer:
         Will be called when the whole project has been generated and
         therefore all relations are available and the form
         can also be generated.
+
+        As well we set the variable.
         """
         has_tabs = False
         for relation in project.relations:
@@ -320,6 +312,16 @@ class Layer:
                 if not field.hidden:
                     widget = FormFieldWidget(field.alias, field.name)
                     self.__form.add_element(widget)
+
+        # set the layer variable according to the strategy
+        interlis_topics = ",".join(
+            self.all_topics
+            if project.optimize_strategy == OptimizeStrategy.NONE
+            else self.relevant_topics
+        )
+        QgsExpressionContextUtils.setLayerVariable(
+            self.__layer, "interlis_topic", interlis_topics
+        )
 
     def source(self):
         return QgsDataSourceUri(self.uri)

--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -215,6 +215,19 @@ class Layer:
             # set the default style
             self.__layer.styleManager().setCurrentStyle("default")
 
+    def store_variables(self, project):
+        """
+        Set the layer variables according to the strategy
+        """
+        interlis_topics = ",".join(
+            self.all_topics
+            if project.optimize_strategy == OptimizeStrategy.NONE
+            else self.relevant_topics
+        )
+        QgsExpressionContextUtils.setLayerVariable(
+            self.__layer, "interlis_topic", interlis_topics
+        )
+
     def _create_layer(self, uri, layer_name, provider):
         if provider and provider.lower() == "wms":
             return QgsRasterLayer(uri, layer_name, provider)
@@ -226,8 +239,6 @@ class Layer:
         Will be called when the whole project has been generated and
         therefore all relations are available and the form
         can also be generated.
-
-        As well we set the variable.
         """
         has_tabs = False
         for relation in project.relations:
@@ -312,16 +323,6 @@ class Layer:
                 if not field.hidden:
                     widget = FormFieldWidget(field.alias, field.name)
                     self.__form.add_element(widget)
-
-        # set the layer variable according to the strategy
-        interlis_topics = ",".join(
-            self.all_topics
-            if project.optimize_strategy == OptimizeStrategy.NONE
-            else self.relevant_topics
-        )
-        QgsExpressionContextUtils.setLayerVariable(
-            self.__layer, "interlis_topic", interlis_topics
-        )
 
     def source(self):
         return QgsDataSourceUri(self.uri)

--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -220,9 +220,9 @@ class Layer:
         Set the layer variables according to the strategy
         """
         interlis_topics = ",".join(
-            self.all_topics
+            sorted(self.all_topics)
             if project.optimize_strategy == OptimizeStrategy.NONE
-            else self.relevant_topics
+            else sorted(self.relevant_topics)
         )
         QgsExpressionContextUtils.setLayerVariable(
             self.__layer, "interlis_topic", interlis_topics

--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -22,6 +22,7 @@ from qgis.core import (
     Qgis,
     QgsCoordinateReferenceSystem,
     QgsDataSourceUri,
+    QgsExpressionContextUtils,
     QgsLayerDefinition,
     QgsRasterLayer,
     QgsRectangle,

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -182,10 +182,11 @@ class Project(QObject):
                         "AllowAddFeatures": False,
                         "FilterExpression": "\"topic\" IN ({}) and attribute(get_feature('{}', 't_id', \"dataset\"), 'datasetname') != '{}'".format(
                             ",".join(
-                                [f"'{topic}'" for topic in filter_topics]
+                                [f"'{topic}'" for topic in sorted(filter_topics)]
                             ),  # create comma separated string
                             "T_ILI2DB_DATASET"
                             if referenced_layer.provider == "ogr"
+                            or referenced_layer.provider == "mssql"
                             else "t_ili2db_dataset",
                             self.context.get("catalogue_datasetname", ""),
                         )

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -225,7 +225,7 @@ class Project(QObject):
 
                 minimal_selection = cardinality.startswith("1")
 
-                current_layer = layer_obj.create(self.optimize_strategy)
+                current_layer = layer_obj.create()
 
                 field_widget = "ValueRelation"
                 field_widget_config = {

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -225,7 +225,7 @@ class Project(QObject):
 
                 minimal_selection = cardinality.startswith("1")
 
-                current_layer = layer_obj.create()
+                current_layer = layer_obj.create(self.optimize_strategy)
 
                 field_widget = "ValueRelation"
                 field_widget_config = {
@@ -234,7 +234,7 @@ class Project(QObject):
                     "Value": value_field,
                     "OrderByValue": False,
                     "AllowNull": True,
-                    "Layer": domain_table.create().id(),
+                    "Layer": domain_table.real_id,
                     "FilterExpression": "",
                     "Key": key_field,
                     "NofColumns": 1,

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -119,7 +119,7 @@ class Project(QObject):
         qgis_project.setEvaluateDefaultValues(self.evaluate_default_values)
         qgis_layers = list()
         for layer in self.layers:
-            qgis_layer = layer.create()
+            qgis_layer = layer.create(self.optimize_strategy)
             self.layer_added.emit(qgis_layer.id())
             if not self.crs and qgis_layer.isSpatial():
                 self.crs = qgis_layer.crs()

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -165,6 +165,12 @@ class Project(QObject):
                     },
                 )
             elif referenced_layer and referenced_layer.is_basket_table:
+                # list the topics we filter the basket with. On NONE strategy those should be all topics the class could be in. On optimized strategies GROUP/HIDE only the relevant topics should be listed.
+                filter_topics = (
+                    referencing_layer.all_topics
+                    if self.optimize_strategy == OptimizeStrategy.NONE
+                    else referencing_layer.relevant_topics
+                )
                 editor_widget_setup = QgsEditorWidgetSetup(
                     "RelationReference",
                     {
@@ -174,15 +180,17 @@ class Project(QObject):
                         "ShowOpenFormButton": False,
                         "AllowNULL": True,
                         "AllowAddFeatures": False,
-                        "FilterExpression": "\"topic\" = '{}' and attribute(get_feature('{}', 't_id', \"dataset\"), 'datasetname') != '{}'".format(
-                            referencing_layer.model_topic_name,
+                        "FilterExpression": "\"topic\" IN ({}) and attribute(get_feature('{}', 't_id', \"dataset\"), 'datasetname') != '{}'".format(
+                            ",".join(
+                                [f"'{topic}'" for topic in filter_topics]
+                            ),  # create comma separated string
                             "T_ILI2DB_DATASET"
                             if referenced_layer.provider == "ogr"
                             else "t_ili2db_dataset",
                             self.context.get("catalogue_datasetname", ""),
                         )
-                        if referencing_layer.model_topic_name
-                        else "",
+                        if filter_topics
+                        else "",  # no filter if no topics (means could be everywhere)
                         "FilterFields": list(),
                     },
                 )

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -255,6 +255,7 @@ class Project(QObject):
                 # even when a style will be loaded we create the form because not sure if the style contains form settngs
                 layer.create_form(self)
                 layer.load_styles()
+                layer.store_variables(self)
 
         if self.legend:
             self.legend.create(qgis_project, group)

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -119,7 +119,7 @@ class Project(QObject):
         qgis_project.setEvaluateDefaultValues(self.evaluate_default_values)
         qgis_layers = list()
         for layer in self.layers:
-            qgis_layer = layer.create(self.optimize_strategy)
+            qgis_layer = layer.create()
             self.layer_added.emit(qgis_layer.id())
             if not self.crs and qgis_layer.isSpatial():
                 self.crs = qgis_layer.crs()
@@ -234,7 +234,7 @@ class Project(QObject):
                     "Value": value_field,
                     "OrderByValue": False,
                     "AllowNull": True,
-                    "Layer": domain_table.real_id,
+                    "Layer": domain_table.create().id(),
                     "FilterExpression": "",
                     "Key": key_field,
                     "NofColumns": 1,

--- a/modelbaker/dataobjects/relations.py
+++ b/modelbaker/dataobjects/relations.py
@@ -53,8 +53,8 @@ class Relation:
 
         relation.setId(self._id)
         relation.setName(self.name)
-        relation.setReferencingLayer(self.referencing_layer.create().id())
-        relation.setReferencedLayer(self.referenced_layer.create().id())
+        relation.setReferencingLayer(self.referencing_layer.real_id)
+        relation.setReferencedLayer(self.referenced_layer.real_id)
         relation.addFieldPair(self.referencing_field, self.referenced_field)
         relation.setStrength(self.strength)
         self.qgis_relation = relation

--- a/modelbaker/dataobjects/relations.py
+++ b/modelbaker/dataobjects/relations.py
@@ -53,8 +53,8 @@ class Relation:
 
         relation.setId(self._id)
         relation.setName(self.name)
-        relation.setReferencingLayer(self.referencing_layer.real_id)
-        relation.setReferencedLayer(self.referenced_layer.real_id)
+        relation.setReferencingLayer(self.referencing_layer.create().id())
+        relation.setReferencedLayer(self.referenced_layer.create().id())
         relation.addFieldPair(self.referencing_field, self.referenced_field)
         relation.setStrength(self.strength)
         self.qgis_relation = relation

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -182,7 +182,8 @@ class GPKGConnector(DBConnector):
                 # topics - where this class or an instance of it is located - are emitted by going recursively through the inheritance table.
                 # if something of this topic where the current class is located has been extended, it gets the next child topic.
                 # the relevant topics for optimization are the ones that are not more extended (or in the very last class).
-                topics="""(SELECT group_concat(childTopic) FROM {topic_pedigree}) as all_topics,
+                topics="""substr( c.iliname, 0, instr(substr( c.iliname, instr(c.iliname, '.')+1), '.')+instr(c.iliname, '.')) as base_topic,
+                        (SELECT group_concat(childTopic) FROM {topic_pedigree}) as all_topics,
                         (SELECT group_concat(childTopic) FROM {topic_pedigree} WHERE NOT is_a_base) as relevant_topics""".format(
                     topic_pedigree="""(WITH RECURSIVE children(is_a_base, childTopic, baseTopic) AS (
                         SELECT

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -26,8 +26,8 @@ from .db_connector import DBConnector, DBConnectorError
 METADATA_TABLE = "t_ili2db_table_prop"
 METAATTRS_TABLE = "t_ili2db_meta_attrs"
 SETTINGS_TABLE = "t_ili2db_settings"
-DATASET_TABLE = "t_ili2db_dataset"
-BASKET_TABLE = "t_ili2db_basket"
+DATASET_TABLE = "T_ILI2DB_DATASET"
+BASKET_TABLE = "T_ILI2DB_BASKET"
 
 
 class MssqlConnector(DBConnector):

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -289,71 +289,73 @@ class MssqlConnector(DBConnector):
             # the relevant topics for optimization are the ones that are not more extended (or in the very last class).
             # get the topics
             for res_entry in res:
-                stmt = """
-                WITH children(is_a_base, childTopic, baseTopic) AS (
-                    SELECT
-                    (CASE
-                        WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass) ) != substring( i.baseClass, 1,  CHARINDEX('.', i.baseClass)))
-                        THEN 1
-                        ELSE 0
-                    END) AS is_a_base,
-                    substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) as childTopic,
-                    substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', baseClass)-1) as baseTopic
-                    FROM {schema}.T_ILI2DB_INHERITANCE
-                    WHERE substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(thisClass)))+CHARINDEX('.', baseClass)-1) = '{base_topic}'
-                    UNION ALL
-                    SELECT
-                    (CASE
-                        WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass)) != substring( i.baseClass, 1, CHARINDEX('.', i.baseClass)))
-                        THEN 1
-                        ELSE 0
-                    END) AS is_a_base,
-                    substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) as childTopic ,
-                    substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) as baseTopic
-                    FROM children
-                    JOIN {schema}.T_ILI2DB_INHERITANCE as inheritance
-                    ON substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', inheritance.baseClass)+1, len(inheritance.baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) = children.childTopic -- when the childTopic is as well the baseTopic of another childTopic
-                    WHERE substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) != children.childTopic -- break the recursion when the coming childTopic will be the same
-                ) SELECT STRING_AGG(childTopic,',') as all_topics FROM children
-                """.format(
-                    schema=self.schema, base_topic=res_entry["base_topic"]
-                )
-                cur.execute(stmt)
-                res_entry["all_topics"] = cur.fetchone()[0]
+                if "base_topic" in res_entry:
+                    stmt = """
+                    WITH children(is_a_base, childTopic, baseTopic) AS (
+                        SELECT
+                        (CASE
+                            WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass) ) != substring( i.baseClass, 1,  CHARINDEX('.', i.baseClass)))
+                            THEN 1
+                            ELSE 0
+                        END) AS is_a_base,
+                        substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) as childTopic,
+                        substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', baseClass)-1) as baseTopic
+                        FROM {schema}.T_ILI2DB_INHERITANCE
+                        WHERE substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(thisClass)))+CHARINDEX('.', baseClass)-1) = '{base_topic}'
+                        UNION ALL
+                        SELECT
+                        (CASE
+                            WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass)) != substring( i.baseClass, 1, CHARINDEX('.', i.baseClass)))
+                            THEN 1
+                            ELSE 0
+                        END) AS is_a_base,
+                        substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) as childTopic ,
+                        substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) as baseTopic
+                        FROM children
+                        JOIN {schema}.T_ILI2DB_INHERITANCE as inheritance
+                        ON substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', inheritance.baseClass)+1, len(inheritance.baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) = children.childTopic -- when the childTopic is as well the baseTopic of another childTopic
+                        WHERE substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) != children.childTopic -- break the recursion when the coming childTopic will be the same
+                    ) SELECT STRING_AGG(childTopic,',') as all_topics FROM children
+                    """.format(
+                        schema=self.schema, base_topic=res_entry["base_topic"]
+                    )
+                    cur.execute(stmt)
+                    res_entry["all_topics"] = cur.fetchone()[0]
 
             # get the relevant topics
             for res_entry in res:
-                stmt = """
-                WITH children(is_a_base, childTopic, baseTopic) AS (
-                    SELECT
-                    (CASE
-                        WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass) ) != substring( i.baseClass, 1,  CHARINDEX('.', i.baseClass)))
-                        THEN 1
-                        ELSE 0
-                    END) AS is_a_base,
-                    substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) as childTopic,
-                    substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', baseClass)-1) as baseTopic
-                    FROM {schema}.T_ILI2DB_INHERITANCE
-                    WHERE substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(thisClass)))+CHARINDEX('.', baseClass)-1) = '{base_topic}'
-                    UNION ALL
-                    SELECT
-                    (CASE
-                        WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass)) != substring( i.baseClass, 1, CHARINDEX('.', i.baseClass)))
-                        THEN 1
-                        ELSE 0
-                    END) AS is_a_base,
-                    substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) as childTopic ,
-                    substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) as baseTopic
-                    FROM children
-                    JOIN {schema}.T_ILI2DB_INHERITANCE as inheritance
-                    ON substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', inheritance.baseClass)+1, len(inheritance.baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) = children.childTopic -- when the childTopic is as well the baseTopic of another childTopic
-                    WHERE substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) != children.childTopic -- break the recursion when the coming childTopic will be the same
-                ) SELECT STRING_AGG(childTopic,',') as relevant_topics FROM children WHERE is_a_base = 0
-                """.format(
-                    schema=self.schema, base_topic=res_entry["base_topic"]
-                )
-                cur.execute(stmt)
-                res_entry["relevant_topics"] = cur.fetchone()[0]
+                if "base_topic" in res_entry:
+                    stmt = """
+                    WITH children(is_a_base, childTopic, baseTopic) AS (
+                        SELECT
+                        (CASE
+                            WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass) ) != substring( i.baseClass, 1,  CHARINDEX('.', i.baseClass)))
+                            THEN 1
+                            ELSE 0
+                        END) AS is_a_base,
+                        substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) as childTopic,
+                        substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', baseClass)-1) as baseTopic
+                        FROM {schema}.T_ILI2DB_INHERITANCE
+                        WHERE substring( baseClass, 1, CHARINDEX('.', substring( baseClass, CHARINDEX('.', baseClass)+1, len(thisClass)))+CHARINDEX('.', baseClass)-1) = '{base_topic}'
+                        UNION ALL
+                        SELECT
+                        (CASE
+                            WHEN substring( thisClass, 1, CHARINDEX('.', substring( thisClass, CHARINDEX('.', thisClass)+1, len(thisClass)))+CHARINDEX('.', thisClass)-1) IN (SELECT substring( i.baseClass, 1, CHARINDEX('.', substring( i.baseClass, CHARINDEX('.', i.baseClass)+1, len(i.baseClass)))+CHARINDEX('.', i.baseClass)-1) FROM {schema}.T_ILI2DB_INHERITANCE i WHERE substring( i.thisClass, 1,  CHARINDEX('.', i.thisClass)) != substring( i.baseClass, 1, CHARINDEX('.', i.baseClass)))
+                            THEN 1
+                            ELSE 0
+                        END) AS is_a_base,
+                        substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) as childTopic ,
+                        substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', baseClass)+1, len(baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) as baseTopic
+                        FROM children
+                        JOIN {schema}.T_ILI2DB_INHERITANCE as inheritance
+                        ON substring( inheritance.baseClass, 1, CHARINDEX('.', substring( inheritance.baseClass, CHARINDEX('.', inheritance.baseClass)+1, len(inheritance.baseClass)))+CHARINDEX('.', inheritance.baseClass)-1) = children.childTopic -- when the childTopic is as well the baseTopic of another childTopic
+                        WHERE substring( inheritance.thisClass, 1, CHARINDEX('.', substring( inheritance.thisClass, CHARINDEX('.', inheritance.thisClass)+1, len(inheritance.thisClass)))+CHARINDEX('.', inheritance.thisClass)-1) != children.childTopic -- break the recursion when the coming childTopic will be the same
+                    ) SELECT STRING_AGG(childTopic,',') as relevant_topics FROM children WHERE is_a_base = 0
+                    """.format(
+                        schema=self.schema, base_topic=res_entry["base_topic"]
+                    )
+                    cur.execute(stmt)
+                    res_entry["relevant_topics"] = cur.fetchone()[0]
         return res
 
     def _def_cursor(self, query):

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -230,7 +230,8 @@ class MssqlConnector(DBConnector):
                 ''' This part is not yet working
                 stmt += (
                     ln
-                    + """  ,(SELECT STRING_AGG(childTopic,',') FROM {topic_pedigree}) as all_topics
+                    + """   ,substring( c.iliname, 1, CHARINDEX('.', substring( c.iliname, CHARINDEX('.', c.iliname)+1, len(c.iliname)))+CHARINDEX('.', c.iliname)-1) as base_topic
+                            ,(SELECT STRING_AGG(childTopic,',') FROM {topic_pedigree}) as all_topics
                             ,(SELECT STRING_AGG(childTopic,',') FROM {topic_pedigree} WHERE NOT is_a_base) as relevant_topics""".format(
                         topic_pedigree="""(WITH children(is_a_base, childTopic, baseTopic) AS (
                                     SELECT

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -233,7 +233,8 @@ class PGConnector(DBConnector):
                 # topics - where this class or an instance of it is located - are emitted by going recursively through the inheritance table.
                 # if something of this topic where the current class is located has been extended, it gets the next child topic.
                 # the relevant topics for optimization are the ones that are not more extended (or in the very last class).
-                topics = """(SELECT STRING_AGG(childTopic,',') FROM {topic_pedigree}) as all_topics,
+                topics = """substring( c.iliname from 1 for position('.' in substring( c.iliname from position('.' in c.iliname)+1))+position('.' in c.iliname)-1) as base_topic,
+                        (SELECT STRING_AGG(childTopic,',') FROM {topic_pedigree}) as all_topics,
                         (SELECT STRING_AGG(childTopic,',') FROM {topic_pedigree} WHERE NOT is_a_base) as relevant_topics,""".format(
                     topic_pedigree="""(WITH RECURSIVE children(is_a_base, childTopic, baseTopic) AS (
                         SELECT

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -146,20 +146,31 @@ class Generator(QObject):
 
             base_topic = record["base_topic"] if "base_topic" in record else None
 
+            # get all the topics
             all_topics = (
                 record.get("all_topics").split(",") if record.get("all_topics") else []
             )
-            # include the topic where the class is designed in
-            if base_topic:
+            # don't concern no-topics (e.g. when a domain is designed directly in the model)
+            all_topics = [topic for topic in all_topics if topic.count(".") > 0]
+
+            # and include the topic where the class is designed in
+            if base_topic and base_topic.count(".") > 0:
                 all_topics.append(base_topic)
 
+            # get all the relevant topics
             relevant_topics = (
                 record.get("relevant_topics").split(",")
                 if record.get("relevant_topics")
                 else []
             )
+
+            # don't concern no-topics (e.g. when a domain is designed directly in the model)
+            relevant_topics = [
+                topic for topic in relevant_topics if topic.count(".") > 0
+            ]
+
             # if no relevant_topic found the relevant is the one where the class is designed in
-            if not relevant_topics and base_topic:
+            if not relevant_topics and base_topic and base_topic.count(".") > 0:
                 relevant_topics.append(base_topic)
 
             alias = record["table_alias"] if "table_alias" in record else None

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -375,8 +375,16 @@ class Generator(QObject):
                     ]
 
                 if self.basket_handling and column_name in BASKET_FIELDNAMES:
+                    # on NONE strategy those should be all topics the class could be in. On optimized strategies GROUP/HIDE only the relevant topics should be listed.
+                    interlis_topics = ",".join(
+                        layer.all_topics
+                        if self.optimize_strategy == OptimizeStrategy.NONE
+                        else layer.relevant_topics
+                    )
+
+                    # and set the default value (to be used from the projet variables)
                     default_basket_topic = slugify(
-                        f"default_basket{'_' if layer.model_topic_name else ''}{layer.model_topic_name}"
+                        f"default_basket{'_' if interlis_topics else ''}{interlis_topics}"
                     )
                     field.default_value_expression = f"@{default_basket_topic}"
 

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -377,9 +377,9 @@ class Generator(QObject):
                 if self.basket_handling and column_name in BASKET_FIELDNAMES:
                     # on NONE strategy those should be all topics the class could be in. On optimized strategies GROUP/HIDE only the relevant topics should be listed.
                     interlis_topics = ",".join(
-                        layer.all_topics
+                        sorted(layer.all_topics)
                         if self.optimize_strategy == OptimizeStrategy.NONE
-                        else layer.relevant_topics
+                        else sorted(layer.relevant_topics)
                     )
 
                     # and set the default value (to be used from the projet variables)

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -144,14 +144,23 @@ class Generator(QObject):
                 record.get("relevance", True)
             )  # it can be not relevant and still be displayed (in case of NONE)
 
+            base_topic = record["base_topic"] if "base_topic" in record else None
+
             all_topics = (
                 record.get("all_topics").split(",") if record.get("all_topics") else []
             )
+            # include the topic where the class is designed in
+            if base_topic:
+                all_topics.append(base_topic)
+
             relevant_topics = (
                 record.get("relevant_topics").split(",")
                 if record.get("relevant_topics")
                 else []
             )
+            # if no relevant_topic found the relevant is the one where the class is designed in
+            if not relevant_topics and base_topic:
+                relevant_topics.append(base_topic)
 
             alias = record["table_alias"] if "table_alias" in record else None
             if not alias:
@@ -439,7 +448,8 @@ class Generator(QObject):
                         relation.strength = (
                             QgsRelation.Composition
                             if "strength" in record
-                            and record["strength"] == "COMPOSITE" or referencing_layer.is_structure
+                            and record["strength"] == "COMPOSITE"
+                            or referencing_layer.is_structure
                             else QgsRelation.Association
                         )
                         relation.cardinality_max = record.get("cardinality_max", None)

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -3006,7 +3006,7 @@ class TestProjectGen(unittest.TestCase):
                 assert map["Relation"] == "belasteter_standort_t_basket_fkey"
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" = 'KbS_LV95_V1_3.Belastete_Standorte' and attribute(get_feature('t_ili2db_dataset', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('KbS_LV95_V1_3.Belastete_Standorte') and attribute(get_feature('t_ili2db_dataset', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
             # check the display expression of the basket table
@@ -3099,7 +3099,7 @@ class TestProjectGen(unittest.TestCase):
                 )
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" = 'KbS_LV95_V1_3.Belastete_Standorte' and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('KbS_LV95_V1_3.Belastete_Standorte') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
             # check the display expression of the basket table

--- a/tests/test_projectgen_extension_optimization.py
+++ b/tests/test_projectgen_extension_optimization.py
@@ -224,7 +224,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_staedtische_none(generator, strategy, True)
+        self._extopt_staedtische_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -238,7 +238,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_staedtische_group(generator, strategy, True)
+        self._extopt_staedtische_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -252,7 +252,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_staedtische_hide(generator, strategy, True)
+        self._extopt_staedtische_hide(generator, strategy)
 
     def _extopt_staedtische_none(self, generator, strategy, skip_topic_check=False):
 
@@ -408,7 +408,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -442,7 +442,7 @@ class TestProjectExtOptimization(unittest.TestCase):
 
                 assert (
                     layer_model_topic_names
-                    == "kantonale_ortsplanung_v1_1_konstruktionen_staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe_ortsplanung_v1_1_konstruktionen"
+                    == "Kantonale_Ortsplanung_V1_1.Konstruktionen,Staedtische_Ortsplanung_V1_1.Freizeit,Staedtische_Ortsplanung_V1_1.Gewerbe,Ortsplanung_V1_1.Konstruktionen"
                 )
 
                 # check filter in widget
@@ -629,7 +629,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -663,7 +663,7 @@ class TestProjectExtOptimization(unittest.TestCase):
 
                 assert (
                     layer_model_topic_names
-                    == "staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe"
+                    == "Staedtische_Ortsplanung_V1_1.Freizeit,Staedtische_Ortsplanung_V1_1.Gewerbe"
                 )
 
                 # check filter in widget
@@ -819,7 +819,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -853,7 +853,7 @@ class TestProjectExtOptimization(unittest.TestCase):
 
                 assert (
                     layer_model_topic_names
-                    == "staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe"
+                    == "Staedtische_Ortsplanung_V1_1.Freizeit,Staedtische_Ortsplanung_V1_1.Gewerbe"
                 )
 
                 # check filter in widget
@@ -1038,7 +1038,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_polymorphic_none(generator, strategy, True)
+        self._extopt_polymorphic_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -1052,7 +1052,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_polymorphic_group(generator, strategy, True)
+        self._extopt_polymorphic_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -1066,7 +1066,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_polymorphic_hide(generator, strategy, True)
+        self._extopt_polymorphic_hide(generator, strategy)
 
     def _extopt_polymorphic_none(self, generator, strategy, skip_topic_check=False):
         available_layers = generator.layers()
@@ -1260,7 +1260,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -1294,7 +1294,7 @@ class TestProjectExtOptimization(unittest.TestCase):
 
                 assert (
                     layer_model_topic_names
-                    == "polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe_ortsplanung_v1_1_konstruktionen"
+                    == "Polymorphic_Ortsplanung_V1_1.Gewerbe,Polymorphic_Ortsplanung_V1_1.Freizeit,Polymorphic_Ortsplanung_V1_1.Hallen,Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe,Ortsplanung_V1_1.Konstruktionen"
                 )
 
                 # check filter in widget
@@ -1522,7 +1522,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -1556,7 +1556,7 @@ class TestProjectExtOptimization(unittest.TestCase):
 
                 assert (
                     layer_model_topic_names
-                    == "polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe"
+                    == "Polymorphic_Ortsplanung_V1_1.Gewerbe,Polymorphic_Ortsplanung_V1_1.Freizeit,Polymorphic_Ortsplanung_V1_1.Hallen,Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
                 )
 
                 # check filter in widget
@@ -1764,7 +1764,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -1798,7 +1798,7 @@ class TestProjectExtOptimization(unittest.TestCase):
 
                 assert (
                     layer_model_topic_names
-                    == "polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe"
+                    == "Polymorphic_Ortsplanung_V1_1.Gewerbe,Polymorphic_Ortsplanung_V1_1.Freizeit,Polymorphic_Ortsplanung_V1_1.Hallen,Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
                 )
 
                 # check filter in widget
@@ -1981,7 +1981,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_baustruct_none(generator, strategy, True)
+        self._extopt_baustruct_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -1995,7 +1995,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_baustruct_group(generator, strategy, True)
+        self._extopt_baustruct_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -2009,7 +2009,7 @@ class TestProjectExtOptimization(unittest.TestCase):
         )
 
         # we skip the topic check since it's not supported in mssql
-        self._extopt_baustruct_hide(generator, strategy, True)
+        self._extopt_baustruct_hide(generator, strategy)
 
     def _extopt_baustruct_none(self, generator, strategy, skip_topic_check=False):
         available_layers = generator.layers()
@@ -2182,7 +2182,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -2403,7 +2403,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()
@@ -2587,7 +2587,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                     or ""
                 )
 
-                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
 
                 # check filter in widget
                 efc = layer.layer.editFormConfig()

--- a/tests/test_projectgen_extension_optimization.py
+++ b/tests/test_projectgen_extension_optimization.py
@@ -23,7 +23,7 @@ import os
 import pathlib
 import tempfile
 
-from qgis.core import QgsLayerTreeLayer, QgsProject
+from qgis.core import QgsExpressionContextUtils, QgsLayerTreeLayer, QgsProject
 from qgis.testing import start_app, unittest
 
 from modelbaker.dataobjects.project import Project

--- a/tests/test_projectgen_extension_optimization.py
+++ b/tests/test_projectgen_extension_optimization.py
@@ -328,7 +328,10 @@ class TestProjectExtOptimization(unittest.TestCase):
                     }
             assert count == 4
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -389,6 +392,80 @@ class TestProjectExtOptimization(unittest.TestCase):
                         assert len(tab.children()) == 1
         # should find 4
         assert count == 4
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of topics Ortsplanung_V1_1.Konstruktionen, Kantonale_Ortsplanung_V1_1.Konstruktionen, Staedtische_Ortsplanung_V1_1.Freizeit, Staedtische_Ortsplanung_V1_1.Gewerbe)
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "kantonale_ortsplanung_v1_1_konstruktionen_staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe_ortsplanung_v1_1_konstruktionen"
+                )
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Kantonale_Ortsplanung_V1_1.Konstruktionen','Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe','Ortsplanung_V1_1.Konstruktionen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_kantonale_ortsplanung_v1_1_konstruktionen_staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe_ortsplanung_v1_1_konstruktionen"
+                )
+
+        # should find 2
+        assert count == 2
 
         QgsProject.instance().clear()
 
@@ -466,7 +543,10 @@ class TestProjectExtOptimization(unittest.TestCase):
                     }
             assert count == 4
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -534,6 +614,77 @@ class TestProjectExtOptimization(unittest.TestCase):
 
         assert count == 2
 
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of relevant topics Staedtische_Ortsplanung_V1_1.Freizeit, Staedtische_Ortsplanung_V1_1.Gewerbe)
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe"
+                )
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe"
+                )
+
         QgsProject.instance().clear()
 
     def _extopt_staedtische_hide(self, generator, strategy, skip_topic_check=False):
@@ -599,7 +750,10 @@ class TestProjectExtOptimization(unittest.TestCase):
                     assert layer.relevant_topics == ["Staedtisches_Gewerbe_V1.Firmen"]
             assert count == 3
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -648,6 +802,80 @@ class TestProjectExtOptimization(unittest.TestCase):
                     if tab.name() == "gebaeude":  # should not happen
                         count += 1
         # should find only 2
+        assert count == 2
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of relevant topics Staedtische_Ortsplanung_V1_1.Freizeit, Staedtische_Ortsplanung_V1_1.Gewerbe)
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe"
+                )
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe"
+                )
+
+        # should find 2
         assert count == 2
 
         QgsProject.instance().clear()
@@ -938,7 +1166,10 @@ class TestProjectExtOptimization(unittest.TestCase):
 
             assert count == 5
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -1013,6 +1244,80 @@ class TestProjectExtOptimization(unittest.TestCase):
                         assert len(tab.children()) == 1
         # should find 8
         assert count == 8
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of topics 'Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe','Ortsplanung_V1_1.Konstruktionen')
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe_ortsplanung_v1_1_konstruktionen"
+                )
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe','Ortsplanung_V1_1.Konstruktionen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe_ortsplanung_v1_1_konstruktionen"
+                )
+
+        # should find 2
+        assert count == 2
 
         QgsProject.instance().clear()
 
@@ -1115,7 +1420,10 @@ class TestProjectExtOptimization(unittest.TestCase):
 
             assert count == 5
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -1198,6 +1506,80 @@ class TestProjectExtOptimization(unittest.TestCase):
                         assert len(tab.children()) == 1
         # should find 7
         assert count == 7
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of topics 'Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe')
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe"
+                )
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe"
+                )
+
+        # should find 2
+        assert count == 2
 
         QgsProject.instance().clear()
 
@@ -1292,7 +1674,10 @@ class TestProjectExtOptimization(unittest.TestCase):
 
             assert count == 5
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -1363,6 +1748,80 @@ class TestProjectExtOptimization(unittest.TestCase):
                         assert len(tab.children()) == 1
         # should find 7
         assert count == 7
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of topics 'Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe')
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe"
+                )
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe"
+                )
+
+        # should find 2
+        assert count == 2
 
         QgsProject.instance().clear()
 
@@ -1640,7 +2099,10 @@ class TestProjectExtOptimization(unittest.TestCase):
 
             assert count == 5
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -1704,6 +2166,45 @@ class TestProjectExtOptimization(unittest.TestCase):
                         assert len(tab.children()) == 1
         # should find 3 (one times gebaeude and two times kantnl_ng_v1_1konstruktionen_gebaeude because it's extended)
         assert count == 3
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # no special cases with multi basket layers...
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+        # should find 1
+        assert count == 1
 
         QgsProject.instance().clear()
 
@@ -1797,7 +2298,10 @@ class TestProjectExtOptimization(unittest.TestCase):
 
             assert count == 5
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -1882,6 +2386,45 @@ class TestProjectExtOptimization(unittest.TestCase):
                         count += 1
                         assert len(tab.children()) == 1
         # should find 1 (one times kantnl_ng_v1_1konstruktionen_gebaeude)
+        assert count == 1
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # no special cases with multi basket layers...
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+        # should find 1
         assert count == 1
 
         QgsProject.instance().clear()
@@ -1971,7 +2514,10 @@ class TestProjectExtOptimization(unittest.TestCase):
 
             assert count == 5
 
-        project = Project(optimize_strategy=strategy)
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
         project.layers = available_layers
         project.relations = relations
         project.legend = legend
@@ -2024,6 +2570,45 @@ class TestProjectExtOptimization(unittest.TestCase):
                         count += 1
                         assert len(tab.children()) == 1
         # should find 1 (one times kantnl_ng_v1_1konstruktionen_gebaeude)
+        assert count == 1
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # no special cases with multi basket layers...
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "infrastruktur_v1_strassen"
+
+                # check filter in widget
+                efc = layer.layer.editFormConfig()
+                map = efc.widgetConfig("T_basket")
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('T_ILI2DB_DATASET', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                fields = layer.layer.fields()
+                field_idx = fields.lookupField("t_basket")
+                t_basket_field = fields.field(field_idx)
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+        # should find 1
         assert count == 1
 
         QgsProject.instance().clear()

--- a/tests/test_projectgen_extension_optimization.py
+++ b/tests/test_projectgen_extension_optimization.py
@@ -223,7 +223,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_staedtische_none(generator, strategy, True)
 
         ### 2. OptimizeStrategy.GROUP ###
@@ -237,7 +237,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_staedtische_group(generator, strategy, True)
 
         ### 3. OptimizeStrategy.HIDE ###
@@ -251,7 +251,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_staedtische_hide(generator, strategy, True)
 
     def _extopt_staedtische_none(self, generator, strategy, skip_topic_check=False):
@@ -293,11 +293,11 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # BesitzerIn from Ortsplanung_V1_1
                 if layer.alias == "BesitzerIn":
                     count += 1
@@ -305,6 +305,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Kantonale_Ortsplanung_V1_1.Konstruktionen",
                         "Staedtische_Ortsplanung_V1_1.Freizeit",
                         "Staedtische_Ortsplanung_V1_1.Gewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Staedtische_Ortsplanung_V1_1.Freizeit",
@@ -313,13 +314,15 @@ class TestProjectExtOptimization(unittest.TestCase):
                 # Firma from Staedtisches_Gewerbe_V1
                 if layer.alias == "Staedtisches_Gewerbe_V1.Firmen.Firma":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Staedtisches_Gewerbe_V1.Firmen"]
+                    assert layer.relevant_topics == ["Staedtisches_Gewerbe_V1.Firmen"]
                 # Firma from Gewerbe_V1
                 if layer.alias == "Gewerbe_V1.Firmen.Firma":
                     count += 1
-                    print(layer.all_topics)
-                    assert set(layer.all_topics) == {"Staedtisches_Gewerbe_V1.Firmen"}
+                    assert set(layer.all_topics) == {
+                        "Gewerbe_V1.Firmen",
+                        "Staedtisches_Gewerbe_V1.Firmen",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Staedtisches_Gewerbe_V1.Firmen"
                     }
@@ -428,11 +431,11 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # BesitzerIn from Ortsplanung_V1_1
                 if layer.alias == "BesitzerIn":
                     count += 1
@@ -440,6 +443,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Kantonale_Ortsplanung_V1_1.Konstruktionen",
                         "Staedtische_Ortsplanung_V1_1.Freizeit",
                         "Staedtische_Ortsplanung_V1_1.Gewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Staedtische_Ortsplanung_V1_1.Freizeit",
@@ -448,12 +452,15 @@ class TestProjectExtOptimization(unittest.TestCase):
                 # Firma from Staedtisches_Gewerbe_V1
                 if layer.alias == "Staedtisches_Gewerbe_V1.Firmen.Firma":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Staedtisches_Gewerbe_V1.Firmen"]
+                    assert layer.relevant_topics == ["Staedtisches_Gewerbe_V1.Firmen"]
                 # Firma from Gewerbe_V1
                 if layer.alias == "Gewerbe_V1.Firmen.Firma":
                     count += 1
-                    assert set(layer.all_topics) == {"Staedtisches_Gewerbe_V1.Firmen"}
+                    assert set(layer.all_topics) == {
+                        "Gewerbe_V1.Firmen",
+                        "Staedtisches_Gewerbe_V1.Firmen",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Staedtisches_Gewerbe_V1.Firmen"
                     }
@@ -567,11 +574,11 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # BesitzerIn from Ortsplanung_V1_1
                 if layer.alias == "BesitzerIn":
                     count += 1
@@ -579,6 +586,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Kantonale_Ortsplanung_V1_1.Konstruktionen",
                         "Staedtische_Ortsplanung_V1_1.Freizeit",
                         "Staedtische_Ortsplanung_V1_1.Gewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Staedtische_Ortsplanung_V1_1.Freizeit",
@@ -587,8 +595,8 @@ class TestProjectExtOptimization(unittest.TestCase):
                 # Firma from Staedtisches_Gewerbe_V1
                 if layer.alias == "Firma" and layer.is_relevant:
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Staedtisches_Gewerbe_V1.Firmen"]
+                    assert layer.relevant_topics == ["Staedtisches_Gewerbe_V1.Firmen"]
             assert count == 3
 
         project = Project(optimize_strategy=strategy)
@@ -801,7 +809,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_polymorphic_none(generator, strategy, True)
 
         ### 2. OptimizeStrategy.GROUP ###
@@ -815,7 +823,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_polymorphic_group(generator, strategy, True)
 
         ### 3. OptimizeStrategy.HIDE ###
@@ -829,7 +837,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_polymorphic_hide(generator, strategy, True)
 
     def _extopt_polymorphic_none(self, generator, strategy, skip_topic_check=False):
@@ -871,11 +879,11 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # BesitzerIn from Ortsplanung_V1_1
                 if layer.alias == "BesitzerIn":
                     count += 1
@@ -884,6 +892,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Polymorphic_Ortsplanung_V1_1.Freizeit",
                         "Polymorphic_Ortsplanung_V1_1.Hallen",
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.Gewerbe",
@@ -899,6 +908,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Polymorphic_Ortsplanung_V1_1.Freizeit",
                         "Polymorphic_Ortsplanung_V1_1.Hallen",
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.Gewerbe",
@@ -910,7 +920,8 @@ class TestProjectExtOptimization(unittest.TestCase):
                 if layer.alias == "Gewerbe.Gebaeude":
                     count += 1
                     assert set(layer.all_topics) == {
-                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                        "Polymorphic_Ortsplanung_V1_1.Gewerbe",
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
@@ -918,8 +929,12 @@ class TestProjectExtOptimization(unittest.TestCase):
                 # Gebaeude from Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe
                 if layer.alias == "IndustrieGewerbe.Gebaeude":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                    ]
+                    assert layer.relevant_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                    ]
 
             assert count == 5
 
@@ -1041,11 +1056,11 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Ortsplanung_V1_1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # BesitzerIn from Ortsplanung_V1_1
                 if layer.alias == "BesitzerIn":
                     count += 1
@@ -1054,6 +1069,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Polymorphic_Ortsplanung_V1_1.Freizeit",
                         "Polymorphic_Ortsplanung_V1_1.Hallen",
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.Gewerbe",
@@ -1069,6 +1085,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Polymorphic_Ortsplanung_V1_1.Freizeit",
                         "Polymorphic_Ortsplanung_V1_1.Hallen",
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.Gewerbe",
@@ -1080,7 +1097,8 @@ class TestProjectExtOptimization(unittest.TestCase):
                 if layer.alias == "Gewerbe.Gebaeude":
                     count += 1
                     assert set(layer.all_topics) == {
-                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                        "Polymorphic_Ortsplanung_V1_1.Gewerbe",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
@@ -1088,8 +1106,12 @@ class TestProjectExtOptimization(unittest.TestCase):
                 # Gebaeude from Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe
                 if layer.alias == "IndustrieGewerbe.Gebaeude":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                    ]
+                    assert layer.relevant_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                    ]
 
             assert count == 5
 
@@ -1218,11 +1240,11 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # BesitzerIn from Ortsplanung_V1_1
                 if layer.alias == "BesitzerIn":
                     count += 1
@@ -1231,21 +1253,7 @@ class TestProjectExtOptimization(unittest.TestCase):
                         "Polymorphic_Ortsplanung_V1_1.Freizeit",
                         "Polymorphic_Ortsplanung_V1_1.Hallen",
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
-                    }
-                    assert set(layer.relevant_topics) == {
-                        "Polymorphic_Ortsplanung_V1_1.Gewerbe",
-                        "Polymorphic_Ortsplanung_V1_1.Freizeit",
-                        "Polymorphic_Ortsplanung_V1_1.Hallen",
-                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
-                    }
-                # Gebaeude from Ortsplanung_V1_1
-                if layer.alias == "Konstruktionen.Gebaeude" and not layer.is_relevant:
-                    count += 1
-                    assert set(layer.all_topics) == {
-                        "Polymorphic_Ortsplanung_V1_1.Gewerbe",
-                        "Polymorphic_Ortsplanung_V1_1.Freizeit",
-                        "Polymorphic_Ortsplanung_V1_1.Hallen",
-                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                        "Ortsplanung_V1_1.Konstruktionen",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.Gewerbe",
@@ -1256,13 +1264,18 @@ class TestProjectExtOptimization(unittest.TestCase):
                 # Gebaeude from Polymorphic_Ortsplanung_V1_1
                 if layer.alias == "Konstruktionen.Gebaeude" and layer.is_relevant:
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.Konstruktionen"
+                    ]
+                    assert layer.relevant_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.Konstruktionen"
+                    ]
                 # Gebaeude from Polymorphic_Ortsplanung_V1_1.Gewerbe
                 if layer.alias == "Gewerbe.Gebaeude":
                     count += 1
                     assert set(layer.all_topics) == {
-                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                        "Polymorphic_Ortsplanung_V1_1.Gewerbe",
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
                     }
                     assert set(layer.relevant_topics) == {
                         "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
@@ -1270,10 +1283,14 @@ class TestProjectExtOptimization(unittest.TestCase):
                 # Gebaeude from Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe
                 if layer.alias == "IndustrieGewerbe.Gebaeude":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                    ]
+                    assert layer.relevant_topics == [
+                        "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                    ]
 
-            assert count == 6
+            assert count == 5
 
         project = Project(optimize_strategy=strategy)
         project.layers = available_layers
@@ -1504,7 +1521,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_baustruct_none(generator, strategy, True)
 
         ### 2. OptimizeStrategy.GROUP ###
@@ -1518,7 +1535,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_baustruct_group(generator, strategy, True)
 
         ### 3. OptimizeStrategy.HIDE ###
@@ -1532,7 +1549,7 @@ class TestProjectExtOptimization(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        # we skip the relation check since it's not supported in mssql
+        # we skip the topic check since it's not supported in mssql
         self._extopt_baustruct_hide(generator, strategy, True)
 
     def _extopt_baustruct_none(self, generator, strategy, skip_topic_check=False):
@@ -1585,35 +1602,41 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # Park from Bauplanung_V1_1
                 if layer.alias == "Bauplanung_V1_1.Natur.Park":
                     count += 1
-                    assert set(layer.all_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+                    assert set(layer.all_topics) == {
+                        "Bauplanung_V1_1.Natur",
+                        "Kantonale_Bauplanung_V1_1.Natur",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Kantonale_Bauplanung_V1_1.Natur"
                     }
                 # Park from Kantonale_Bauplanung_V1_1
                 if layer.alias == "Kantonale_Bauplanung_V1_1.Natur.Park":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
+                    assert layer.relevant_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
                 # Feld from Bauplanung_V1_1
                 if layer.alias == "Feld":
                     count += 1
-                    assert set(layer.all_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+                    assert set(layer.all_topics) == {
+                        "Bauplanung_V1_1.Natur",
+                        "Kantonale_Bauplanung_V1_1.Natur",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Kantonale_Bauplanung_V1_1.Natur"
                     }
                 # Kartoffelfeld from Kantonale_Bauplanung_V1_1.Natur
                 if layer.alias == "Kartoffelfeld":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
+                    assert layer.relevant_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
 
             assert count == 5
 
@@ -1736,35 +1759,41 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # Park from Bauplanung_V1_1
                 if layer.alias == "Bauplanung_V1_1.Natur.Park":
                     count += 1
-                    assert set(layer.all_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+                    assert set(layer.all_topics) == {
+                        "Bauplanung_V1_1.Natur",
+                        "Kantonale_Bauplanung_V1_1.Natur",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Kantonale_Bauplanung_V1_1.Natur"
                     }
                 # Park from Kantonale_Bauplanung_V1_1
                 if layer.alias == "Kantonale_Bauplanung_V1_1.Natur.Park":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
+                    assert layer.relevant_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
                 # Feld from Bauplanung_V1_1
                 if layer.alias == "Feld":
                     count += 1
-                    assert set(layer.all_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+                    assert set(layer.all_topics) == {
+                        "Bauplanung_V1_1.Natur",
+                        "Kantonale_Bauplanung_V1_1.Natur",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Kantonale_Bauplanung_V1_1.Natur"
                     }
                 # Kartoffelfeld from Kantonale_Bauplanung_V1_1.Natur
                 if layer.alias == "Kartoffelfeld":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
+                    assert layer.relevant_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
 
             assert count == 5
 
@@ -1904,35 +1933,41 @@ class TestProjectExtOptimization(unittest.TestCase):
             # check relevant topics
             count = 0
             for layer in available_layers:
-                # Strasse from Infrastruktur_V1_1
+                # Strasse from Infrastruktur_V1
                 if layer.alias == "Strasse":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                    assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
                 # Park from Bauplanung_V1_1
                 if layer.alias == "Park" and not layer.is_relevant:
                     count += 1
-                    assert set(layer.all_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+                    assert set(layer.all_topics) == {
+                        "Bauplanung_V1_1.Natur",
+                        "Kantonale_Bauplanung_V1_1.Natur",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Kantonale_Bauplanung_V1_1.Natur"
                     }
                 # Park from Kantonale_Bauplanung_V1_1
                 if layer.alias == "Park" and layer.is_relevant:
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
+                    assert layer.relevant_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
                 # Feld from Bauplanung_V1_1
                 if layer.alias == "Feld":
                     count += 1
-                    assert set(layer.all_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+                    assert set(layer.all_topics) == {
+                        "Bauplanung_V1_1.Natur",
+                        "Kantonale_Bauplanung_V1_1.Natur",
+                    }
                     assert set(layer.relevant_topics) == {
                         "Kantonale_Bauplanung_V1_1.Natur"
                     }
                 # Kartoffelfeld from Kantonale_Bauplanung_V1_1.Natur
                 if layer.alias == "Kartoffelfeld":
                     count += 1
-                    assert layer.all_topics == []
-                    assert layer.relevant_topics == []
+                    assert layer.all_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
+                    assert layer.relevant_topics == ["Kantonale_Bauplanung_V1_1.Natur"]
 
             assert count == 5
 


### PR DESCRIPTION
See https://github.com/opengisch/QgisModelBaker/issues/827

## Backend
In the backend it should be determinded what topics are *possible* or *relevant* for a layer. So this information can be used together with the OptimizeStrategy (HIDE, GROUP or NONE).

This part is already implemented here https://github.com/opengisch/QgisModelBakerLibrary/pull/61 for PostgreSQL and GeoPackage (MSSQL has some draft code but does not work yet).

- [x] MSSQL

(Another part in the backend that *might* be used is the information `relevance` of `get_topic_info` where a topic is relevant if it's not extended.)

## Filter in Relation Reference for Baskets

Here should be listed all possible baskets (if NONE-Strategy) or only the relevant ones (if GROUP- or HIDE-Strategy).

This filter is currently made according to the `Layer.model_topic_name` (what is the topic the class is designed in) and should be more tolerant:

- NONE-Stragegy: Use the `all_topics` list to set the filter accordingly.
- GROUP- and HIDE-Strategy: Use the `relevant_topics` list to set the filter accordingly.

- [x] Receive Base Topic as well
- [x] Updated Tests
- [x] Implementation Filter

## Dataset Selector and Default Values

Before in the data selector we currently list all the possible baskets with the current layers topic (stored as Layer Variable `interlis_topic`) what is the topic where the class is designed in, what leaded to problems.

### Example
```
 INTERLIS 2.3;

MODEL MultiTopicBaskets_V1 (en) AT "https://modelbaker.ch" VERSION "2023-09-29" =

  TOPIC Konstruktionen (ABSTRACT)=
    BASKET OID AS INTERLIS.UUIDOID;
    OID AS INTERLIS.UUIDOID;

    CLASS Gebaeude (ABSTRACT)=
      Name : MANDATORY TEXT*99;
    END Gebaeude;

    CLASS BesitzerIn =
      Vorname : MANDATORY TEXT*99;
      Nachname : MANDATORY TEXT*99;
    END BesitzerIn;

    ASSOCIATION Gebaeude_BesitzerIn =
      BesitzerIn -- {0..1} BesitzerIn;
      Gebaeude -- 
      TOPIC Wohnraum EXTENDS MultiTopicBaskets_V1.Konstruktionen =
        BASKET OID AS INTERLIS.UUIDOID;
        OID AS INTERLIS.UUIDOID;
    
        CLASS Gebaeude (EXTENDED)  =
          AnzWohnungen : 1 .. 99;
        END Gebaeude;
    
      END Wohnraum;
    
      TOPIC Business EXTENDS MultiTopicBaskets_V1.Konstruktionen =
        BASKET OID AS INTERLIS.UUIDOID;
        OID AS INTERLIS.UUIDOID;
    
        CLASS Gebaeude (EXTENDED)  =
          Firma : MANDATORY TEXT*99;
        END Gebaeude;
    
      END Business;
    
    END MultiTopicBaskets_V1.
```

#### All topics of each layer (NONE-Strategy)
- BesitzerIn has ['MultiTopicBaskets_V1.Wohnraum', 'MultiTopicBaskets_V1.Business', 'MultiTopicBaskets_V1.Konstruktionen']
- Wohnraum.Gebaeude has ['MultiTopicBaskets_V1.Wohnraum']
- Business.Gebaeude has ['MultiTopicBaskets_V1.Business']

#### Baskets with one dataset (0)
```
1	0	MultiTopicBaskets_V1.Wohnraum	      
2	0	MultiTopicBaskets_V1.Konstruktionen	
3	0	MultiTopicBaskets_V1.Business	      
```

#### Workflow (before):
1. Layer Param: interlis_topic=<topic where class is designed in>
2. Gets all baskets of the interlis_topic (means for each dataset) and stores it in cache according "{schema_identificator}_{layer_model_topic_name}"
3. Stores selection and provides it as project variable for default values: default_basket_multitopicbaskets_v1_business: 3

**Default Value in Layer:**
@default_basket_multitopicbaskets_v1_business

#### Workflow (now):
1. Layer Param: interlis_topic=<comma-separated:all_topics/relevant_topics(depending on strategy)>
2. Gets all baskets of the interlis_topic (means for each topic and dataset) and stores it in cache according "{schema_identificator}_{layer_model_topic_name}" (the slugified list)0
3. Stores selection and provides it as project variable for default values: default_basket_multitopicbaskets_v1_konstruktionen_multitopicbaskets_v1_business_multitopicbaskets_v1_wohnraum: 3

**Default Value in Layer:**
@default_basket_multitopicbaskets_v1_konstruktionen_multitopicbaskets_v1_business_multitopicbaskets_v1_wohnraum

#### Strategies

- NONE-Stragegy: The baskets of `all_topics`.
- GROUP- and HIDE-Strategy: The baskets of `relevant_topics`.

### Deliverables

- [x] Backend: Write comma sparated list into Layer Variable `interlis_topic`:
  ```
  interlis_topic = ",".join( 
      self.all_topics
      if self.optimize_strategy == OptimizeStrategy.NONE
      else self.relevant_topics 
  )
   ```
- [x] Backend: Write slug to default value in basket-field 
- [x] Frontend: Dataset Selector - see https://github.com/opengisch/QgisModelBaker/pull/836
- [x] Tests

### Possible improvements (dreams)
It would be supernice when I work on the layer Wohnraum.Gebaeude and switch to BesitzerIn, it takes over the Wohnraum-Basket and when I work on Business-Gebaeude and switch to BesitzerIn, it takes over the Business-Basket... But this is hard to achieve...