### PR TITLE
Get and reset T_Id Sequence

### DIFF
--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -338,6 +338,18 @@ class DBConnector(QObject):
         """
         return {}
 
+    def get_ili2db_sequence_value(self):
+        """
+        Returns the current value of the sequence used for the t_id
+        """
+        return None
+
+    def set_ili2db_sequence_value(self, value):
+        """
+        Resets the current value of the sequence used for the t_id
+        """
+        return False, None
+
 
 class DBConnectorError(Exception):
     """This error is raised when DbConnector could not connect to database.

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -981,7 +981,7 @@ WHERE TABLE_SCHEMA='{schema}'
                 cur.execute(
                     """
                     INSERT INTO {schema}.{basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES (NEXT VALUE FOR {schema}.{sequence}, {dataset_tid}, '{topic}', NEWID(), 'Qgis Model Baker')
+                    VALUES (NEXT VALUE FOR {schema}.{sequence}, {dataset_tid}, '{topic}', NEWID(), 'modelbaker')
                 """.format(
                         schema=self.schema,
                         sequence="t_ili2db_seq",
@@ -1033,3 +1033,41 @@ WHERE TABLE_SCHEMA='{schema}'
             )
             result = self._get_dict_result(cur)
         return result
+
+    def get_ili2db_sequence_value(self):
+        if self.schema:
+            cur = self.conn.cursor()
+            cur.execute(
+                """
+                    SELECT NEXT VALUE FOR {schema}.{sequence};
+                """.format(
+                    schema=self.schema, sequence="t_ili2db_seq"
+                )
+            )
+            content = cur.fetchone()
+            if content:
+                return content[0]
+        return None
+
+    def set_ili2db_sequence_value(self, value):
+        if self.schema:
+            cur = self.conn.cursor()
+            try:
+                cur.execute(
+                    """
+                    ALTER SEQUENCE {schema}.{sequence} RESTART WITH {value};
+                    """.format(
+                        schema=self.schema, sequence="t_ili2db_seq", value=value
+                    )
+                )
+                self.conn.commit()
+                return True, self.tr(
+                    'Successfully reset sequence value to "{}".'
+                ).format(value)
+            except pyodbc.errors.Error as e:
+                error_message = " ".join(e.args)
+                return False, self.tr("Could not reset sequence: {}").format(
+                    error_message
+                )
+
+        return False, self.tr("Could not reset sequence")

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -1019,7 +1019,7 @@ class PGConnector(DBConnector):
                 cur.execute(
                     """
                     INSERT INTO {schema}.{basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES (nextval('{schema}.{sequence}'), {dataset_tid}, '{topic}', uuid_generate_v4(), 'Qgis Model Baker')
+                    VALUES (nextval('{schema}.{sequence}'), {dataset_tid}, '{topic}', uuid_generate_v4(), 'modelbaker')
                 """.format(
                         schema=self.schema,
                         sequence="t_ili2db_seq",
@@ -1073,3 +1073,41 @@ class PGConnector(DBConnector):
             )
             result = cur.fetchall()
         return result
+
+    def get_ili2db_sequence_value(self):
+        if self.schema:
+            cur = self.conn.cursor()
+            cur.execute(
+                """
+                    SELECT last_value FROM {schema}.{sequence};
+                """.format(
+                    schema=self.schema, sequence="t_ili2db_seq"
+                )
+            )
+            content = cur.fetchone()
+            if content:
+                return content[0]
+        return None
+
+    def set_ili2db_sequence_value(self, value):
+        if self.schema:
+            cur = self.conn.cursor()
+            try:
+                cur.execute(
+                    """
+                    ALTER SEQUENCE {schema}.{sequence} RESTART WITH {value};
+                    """.format(
+                        schema=self.schema, sequence="t_ili2db_seq", value=value
+                    )
+                )
+                self.conn.commit()
+                return True, self.tr(
+                    'Successfully reset sequence value to "{}".'
+                ).format(value)
+            except psycopg2.errors.Error as e:
+                error_message = " ".join(e.args)
+                return False, self.tr("Could not reset sequence: {}").format(
+                    error_message
+                )
+
+        return False, self.tr("Could not reset sequence")

--- a/modelbaker/iliwrapper/ili2dbutils.py
+++ b/modelbaker/iliwrapper/ili2dbutils.py
@@ -347,7 +347,7 @@ class JavaNotFoundError(FileNotFoundError):
         if self.java_version:
             return QCoreApplication.translate(
                 "ili2dbutils",
-                'Wrong java version found. modelbaker requires at least java version 8. Please <a href="{0}">install Java</a> and or <a href="{1}">configure a custom java path</a>.<br/><br/>Java Version:<br/>{2}',
+                'Wrong java version found. Model Baker requires at least java version 8. Please <a href="{0}">install Java</a> and or <a href="{1}">configure a custom java path</a>.<br/><br/>Java Version:<br/>{2}',
             ).format(
                 JavaNotFoundError.JAVA_DOWNLOAD_URL,
                 JavaNotFoundError.PLUGIN_CONFIGURATION_URL,

--- a/modelbaker/iliwrapper/ili2dbutils.py
+++ b/modelbaker/iliwrapper/ili2dbutils.py
@@ -347,7 +347,7 @@ class JavaNotFoundError(FileNotFoundError):
         if self.java_version:
             return QCoreApplication.translate(
                 "ili2dbutils",
-                'Wrong java version found. Qgis Model Baker requires at least java version 8. Please <a href="{0}">install Java</a> and or <a href="{1}">configure a custom java path</a>.<br/><br/>Java Version:<br/>{2}',
+                'Wrong java version found. modelbaker requires at least java version 8. Please <a href="{0}">install Java</a> and or <a href="{1}">configure a custom java path</a>.<br/><br/>Java Version:<br/>{2}',
             ).format(
                 JavaNotFoundError.JAVA_DOWNLOAD_URL,
                 JavaNotFoundError.PLUGIN_CONFIGURATION_URL,

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -176,7 +176,7 @@ class IliCache(QObject):
                         file=file, exception=str(e)
                     )
                 ),
-                self.tr("QGIS Model Baker"),
+                self.tr("modelbaker"),
             )
             return
 
@@ -206,7 +206,7 @@ class IliCache(QObject):
                         file=file, exception=str(e)
                     )
                 ),
-                self.tr("QGIS Model Baker"),
+                self.tr("modelbaker"),
             )
             return
 
@@ -300,7 +300,7 @@ class IliCache(QObject):
                             ilifile=ilifile, exception=str(e)
                         )
                     ),
-                    self.tr("QGIS Model Baker"),
+                    self.tr("modelbaker"),
                 )
                 fileModels = list()
 
@@ -472,7 +472,7 @@ class IliDataCache(IliCache):
                         file=file, exception=str(e)
                     )
                 ),
-                self.tr("QGIS Model Baker"),
+                self.tr("modelbaker"),
             )
             return
 
@@ -903,7 +903,7 @@ class IliToppingFileCache(IliDataCache):
                         file=file, exception=str(e)
                     )
                 ),
-                self.tr("QGIS Model Baker"),
+                self.tr("modelbaker"),
             )
             return
 

--- a/modelbaker/utils/db_utils.py
+++ b/modelbaker/utils/db_utils.py
@@ -131,7 +131,7 @@ def get_db_connector(configuration):
             "There was an error connecting to the database. Check connection parameters. Error details: {}".format(
                 db_connector_error
             ),
-            "QGIS Model Baker",
+            "modelbaker",
         )
         return None
     except FileNotFoundError as file_not_found_error:
@@ -139,7 +139,7 @@ def get_db_connector(configuration):
             "There was an error connecting to the database. Check connection parameters. Error details: {}".format(
                 file_not_found_error
             ),
-            "QGIS Model Baker",
+            "modelbaker",
         )
         return None
 

--- a/tests/test_sequence_reset.py
+++ b/tests/test_sequence_reset.py
@@ -42,12 +42,10 @@ class TestSequenceReset(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path(
-            "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
-        )
-        importer.configuration.ilimodels = "Staedtische_Ortsplanung_V1_1"
-        importer.configuration.dbschema = (
-            "optimal_staedtische_{:%Y%m%d%H%M%S%f}".format(datetime.datetime.now())
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbschema = "road_simple{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
         )
 
         importer.configuration.srs_code = 2056

--- a/tests/test_sequence_reset.py
+++ b/tests/test_sequence_reset.py
@@ -1,0 +1,179 @@
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 10.11.2023
+        git sha              : :%H$
+        copyright            : (C) 2023 by Dave Signer
+        email                : david at opengis ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+import datetime
+import logging
+import os
+import tempfile
+
+from qgis.testing import start_app, unittest
+
+import modelbaker.utils.db_utils as db_utils
+from modelbaker.iliwrapper import iliimporter
+from modelbaker.iliwrapper.globals import DbIliMode
+from tests.utils import ilidataimporter_config, iliimporter_config, testdata_path
+
+start_app()
+
+
+class TestSequenceReset(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.basetestpath = tempfile.mkdtemp()
+
+    def test_reset_seq_postgis(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Staedtische_Ortsplanung_V1_1"
+        importer.configuration.dbschema = (
+            "optimal_staedtische_{:%Y%m%d%H%M%S%f}".format(datetime.datetime.now())
+        )
+
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        db_connector = db_utils.get_db_connector(importer.configuration)
+
+        assert db_connector.get_ili2db_sequence_value() == 1
+
+        success, _ = db_connector.set_ili2db_sequence_value(2000)
+        assert success
+
+        # Import 31 entries
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2pg
+        dataImporter.configuration = ilidataimporter_config(dataImporter.tool)
+        dataImporter.configuration.ilimodels = "RoadsSimple"
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.dataset = "Baseset"
+        dataImporter.configuration.xtffile = testdata_path("xtf/test_roads_simple.xtf")
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+        assert db_connector.get_ili2db_sequence_value() == 2042
+
+        success, _ = db_connector.set_ili2db_sequence_value(1000)
+        assert success
+
+        assert db_connector.get_ili2db_sequence_value() == 1000
+
+    def test_reset_seq_geopackage(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "tmp_roads_simple_resetseq_{:%Y%m%d%H%M%S%f}.gpkg".format(
+                datetime.datetime.now()
+            ),
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.create_basket_col = True
+        importer.configuration.inheritance = "smart2"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        db_connector = db_utils.get_db_connector(importer.configuration)
+
+        # not exiting yet, so it's none
+        assert db_connector.get_ili2db_sequence_value() == None
+        success, _ = db_connector.set_ili2db_sequence_value(2000)
+        assert success
+
+        # Import 31 entries
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2gpkg
+        dataImporter.configuration = ilidataimporter_config(dataImporter.tool)
+        dataImporter.configuration.ilimodels = "RoadsSimple"
+        dataImporter.configuration.dbfile = importer.configuration.dbfile
+        dataImporter.configuration.dataset = "Baseset"
+        dataImporter.configuration.xtffile = testdata_path("xtf/test_roads_simple.xtf")
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+        assert db_connector.get_ili2db_sequence_value() == 2042
+
+        success, _ = db_connector.set_ili2db_sequence_value(1000)
+        assert success
+
+        assert db_connector.get_ili2db_sequence_value() == 1000
+
+    def test_reset_seq_mssql(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2mssql
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        db_connector = db_utils.get_db_connector(importer.configuration)
+
+        # not sure what mssql produces but in the end it's 9
+        assert db_connector.get_ili2db_sequence_value() == 9
+        success, _ = db_connector.set_ili2db_sequence_value(2000)
+        assert success
+
+        # Import 31 entries
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2mssql
+        dataImporter.configuration = ilidataimporter_config(dataImporter.tool)
+        dataImporter.configuration.ilimodels = "RoadsSimple"
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.dataset = "Baseset"
+        dataImporter.configuration.xtffile = testdata_path("xtf/test_roads_simple.xtf")
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+        assert db_connector.get_ili2db_sequence_value() == 2033
+
+        success, _ = db_connector.set_ili2db_sequence_value(1000)
+        assert success
+
+        assert db_connector.get_ili2db_sequence_value() == 1000
+
+    def print_info(self, text):
+        logging.info(text)
+
+    def print_error(self, text):
+        logging.error(text)

--- a/tests/test_sequence_reset.py
+++ b/tests/test_sequence_reset.py
@@ -57,7 +57,7 @@ class TestSequenceReset(unittest.TestCase):
 
         db_connector = db_utils.get_db_connector(importer.configuration)
 
-        assert db_connector.get_ili2db_sequence_value() == 1
+        assert db_connector.get_ili2db_sequence_value() == 8
 
         success, _ = db_connector.set_ili2db_sequence_value(2000)
         assert success
@@ -74,7 +74,7 @@ class TestSequenceReset(unittest.TestCase):
         dataImporter.stderr.connect(self.print_error)
         assert dataImporter.run() == iliimporter.Importer.SUCCESS
 
-        assert db_connector.get_ili2db_sequence_value() == 2042
+        assert db_connector.get_ili2db_sequence_value() == 2032  # entries + basket
 
         success, _ = db_connector.set_ili2db_sequence_value(1000)
         assert success


### PR DESCRIPTION
This is a very powerful thingy that should be handled very carefully.

### Reset the Sequences
#### GPKG
```
UPDATE T_KEY_OBJECT SET T_LastUniqueID = 10 WHERE T_Key = 'T_Id'
```
#### PG
```
ALTER SEQUENCE oid_madness_01.t_ili2db_seq RESTART WITH 20;
```

### Limitations or "What is with conflicts?"
#### GPKG
When resetting the value and then run into conflicts.
![image](https://github.com/opengisch/QgisModelBakerLibrary/assets/28384354/c3c2dfa6-935a-4b00-af30-2db03f317aa0)

Because of the unique constraints it just counts it up - means it continues to work with the tablewide t_id (I guess it takes the Geopackage Function AUTOGENERATE)...

Our t_ili_tids are of course fucked up then...

On another table of course it works but on validation of course it has troubles then because of duplicates.

#### PG

Similar but not same on postgres. When resetting the sequence, it just counts up with it, but because of unique constraint it cannot store the feature.

![image](https://github.com/opengisch/QgisModelBakerLibrary/assets/28384354/23c4505a-c0d5-4a0a-85e8-9962682d9020)

On another table of course it works but on validation of course it has troubles then because of duplicates.
