### PR TITLE
Basket OIDs

### DIFF
--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -319,7 +319,7 @@ class DBConnector(QObject):
         """
         return {}
 
-    def create_basket(self, dataset_tid, topic):
+    def create_basket(self, dataset_tid, topic, tilitid_value=None):
         """
         Returns the state and the errormessage
         """

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -19,6 +19,7 @@ import errno
 import os
 import re
 import sqlite3
+import uuid
 
 import qgis.utils
 from qgis.core import Qgis
@@ -881,11 +882,13 @@ class GPKGConnector(DBConnector):
                     ).format(topic, fetch_and_increment_feedback)
                 if not tilitid_value:
                     # default value
-                    tilitid_value = f"'uuid.uuid4()'"
+                    tilitid_value = f"'{uuid.uuid4()}'"
+                elif not tilitid_value.isnumeric():
+                    tilitid_value = f"'{tilitid_value}'"
                 cursor.execute(
                     """
                     INSERT INTO {basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES ({next_id}, {dataset_tid}, '{topic}', '{uuid}', 'modelbaker')
+                    VALUES ({next_id}, {dataset_tid}, '{topic}', {tilitid}, 'modelbaker')
                 """.format(
                         tid_name=self.tid,
                         tilitid_name=self.tilitid,

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -19,7 +19,6 @@ import errno
 import os
 import re
 import sqlite3
-import uuid
 
 import qgis.utils
 from qgis.core import Qgis
@@ -851,7 +850,7 @@ class GPKGConnector(DBConnector):
             return contents
         return {}
 
-    def create_basket(self, dataset_tid, topic):
+    def create_basket(self, dataset_tid, topic, tilitid_value=None):
         if self._table_exists(GPKG_BASKET_TABLE):
             cursor = self.conn.cursor()
             cursor.execute(
@@ -877,10 +876,13 @@ class GPKGConnector(DBConnector):
                     return False, self.tr(
                         'Could not create basket for topic "{}": {}'
                     ).format(topic, fetch_and_increment_feedback)
+                if not tilitid_value:
+                    # default value
+                    tilitid_value = f"'uuid.uuid4()'"
                 cursor.execute(
                     """
                     INSERT INTO {basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES ({next_id}, {dataset_tid}, '{topic}', '{uuid}', 'Qgis Model Baker')
+                    VALUES ({next_id}, {dataset_tid}, '{topic}', {tilitid}, 'Qgis Model Baker')
                 """.format(
                         tid_name=self.tid,
                         tilitid_name=self.tilitid,
@@ -888,7 +890,7 @@ class GPKGConnector(DBConnector):
                         next_id=next_id,
                         dataset_tid=dataset_tid,
                         topic=topic,
-                        uuid=uuid.uuid4(),
+                        tilitid=tilitid_value,
                     )
                 )
                 self.conn.commit()

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -825,10 +825,13 @@ class GPKGConnector(DBConnector):
                 """
                     SELECT DISTINCT substr(CN.IliName, 0, instr(CN.IliName, '.')) as model,
                     substr(substr(CN.IliName, instr(CN.IliName, '.')+1),0, instr(substr(CN.IliName, instr(CN.IliName, '.')+1),'.')) as topic,
+                    MA.attr_value as bid_domain,
                     {relevance}
                     FROM T_ILI2DB_CLASSNAME as CN
                     JOIN T_ILI2DB_TABLE_PROP as TP
                     ON CN.sqlname = TP.tablename
+                    LEFT JOIN T_ILI2DB_META_ATTRS as MA
+                    ON substr( CN.IliName, 0, instr(substr( CN.IliName, instr(CN.IliName, '.')+1), '.')+instr(CN.IliName, '.')) = MA.ilielement and MA.attr_name = 'ili2db.ili.bidDomain'
 					WHERE topic != '' and TP.setting != 'ENUM'
                 """.format(
                     # it's relevant, when it's not extended

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -946,14 +946,14 @@ WHERE TABLE_SCHEMA='{schema}'
             cur = self.conn.cursor()
             cur.execute(
                 """
-                    SELECT DISTINCT PARSENAME(cn.iliname,1) as model,
+                    SELECT DISTINCT PARSENAME(cn.iliname,3) as model,
                     PARSENAME(cn.iliname,2) as topic,
                     ma.attr_value as bid_domain
                     FROM {schema}.t_ili2db_classname as cn
                     JOIN {schema}.t_ili2db_table_prop as tp
                     ON cn.sqlname = tp.tablename
                     LEFT JOIN {schema}.t_ili2db_meta_attrs as ma
-                    ON CONCAT(PARSENAME(cn.iliname,1),'.',PARSENAME(cn.iliname,2)) = ma.ilielement AND ma.attr_name = 'ili2db.ili.bidDomain'
+                    ON CONCAT(PARSENAME(cn.iliname,3),'.',PARSENAME(cn.iliname,2)) = ma.ilielement AND ma.attr_name = 'ili2db.ili.bidDomain'
 					WHERE PARSENAME(cn.iliname,3) != '' and tp.setting != 'ENUM'
                 """.format(
                     schema=self.schema
@@ -984,10 +984,12 @@ WHERE TABLE_SCHEMA='{schema}'
                 if not tilitid_value:
                     # default value
                     tilitid_value = "NEWID()"
+                elif not tilitid_value.isnumeric():
+                    tilitid_value = f"'{tilitid_value}'"
                 cur.execute(
                     """
                     INSERT INTO {schema}.{basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES (NEXT VALUE FOR {schema}.{sequence}, {dataset_tid}, '{topic}', NEWID(), 'modelbaker')
+                    VALUES (NEXT VALUE FOR {schema}.{sequence}, {dataset_tid}, '{topic}', {tilitid}, 'modelbaker')
                 """.format(
                         schema=self.schema,
                         sequence="t_ili2db_seq",

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -947,10 +947,13 @@ WHERE TABLE_SCHEMA='{schema}'
             cur.execute(
                 """
                     SELECT DISTINCT PARSENAME(cn.iliname,1) as model,
-                    PARSENAME(cn.iliname,2) as topic
+                    PARSENAME(cn.iliname,2) as topic,
+                    ma.attr_value as bid_domain,
                     FROM {schema}.t_ili2db_classname as cn
                     JOIN {schema}.t_ili2db_table_prop as tp
                     ON cn.sqlname = tp.tablename
+                    LEFT JOIN {schema}.t_ili2db_meta_attrs as ma
+                    ON CONCAT(PARSENAME(cn.iliname,1),'.',PARSENAME(cn.iliname,2)) = ma.ilielement and ma.attr_name = 'ili2db.ili.bidDomain'
 					WHERE PARSENAME(cn.iliname,3) != '' and tp.setting != 'ENUM'
                 """.format(
                     schema=self.schema

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -948,12 +948,12 @@ WHERE TABLE_SCHEMA='{schema}'
                 """
                     SELECT DISTINCT PARSENAME(cn.iliname,1) as model,
                     PARSENAME(cn.iliname,2) as topic,
-                    ma.attr_value as bid_domain,
+                    ma.attr_value as bid_domain
                     FROM {schema}.t_ili2db_classname as cn
                     JOIN {schema}.t_ili2db_table_prop as tp
                     ON cn.sqlname = tp.tablename
                     LEFT JOIN {schema}.t_ili2db_meta_attrs as ma
-                    ON CONCAT(PARSENAME(cn.iliname,1),'.',PARSENAME(cn.iliname,2)) = ma.ilielement and ma.attr_name = 'ili2db.ili.bidDomain'
+                    ON CONCAT(PARSENAME(cn.iliname,1),'.',PARSENAME(cn.iliname,2)) = ma.ilielement AND ma.attr_name = 'ili2db.ili.bidDomain'
 					WHERE PARSENAME(cn.iliname,3) != '' and tp.setting != 'ENUM'
                 """.format(
                     schema=self.schema

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -959,7 +959,7 @@ WHERE TABLE_SCHEMA='{schema}'
             result = self._get_dict_result(cur)
         return result
 
-    def create_basket(self, dataset_tid, topic):
+    def create_basket(self, dataset_tid, topic, tilitid_value=None):
         if self.schema and self._table_exists(BASKET_TABLE):
             cur = self.conn.cursor()
             cur.execute(
@@ -978,10 +978,13 @@ WHERE TABLE_SCHEMA='{schema}'
                     topic
                 )
             try:
+                if not tilitid_value:
+                    # default value
+                    tilitid_value = "NEWID()"
                 cur.execute(
                     """
                     INSERT INTO {schema}.{basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES (NEXT VALUE FOR {schema}.{sequence}, {dataset_tid}, '{topic}', NEWID(), 'Qgis Model Baker')
+                    VALUES (NEXT VALUE FOR {schema}.{sequence}, {dataset_tid}, '{topic}', {tilitid}, 'Qgis Model Baker')
                 """.format(
                         schema=self.schema,
                         sequence="t_ili2db_seq",
@@ -990,6 +993,7 @@ WHERE TABLE_SCHEMA='{schema}'
                         basket_table=BASKET_TABLE,
                         dataset_tid=dataset_tid,
                         topic=topic,
+                        tilitid=tilitid_value,
                     )
                 )
                 self.conn.commit()

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -997,7 +997,7 @@ class PGConnector(DBConnector):
             return cur.fetchall()
         return {}
 
-    def create_basket(self, dataset_tid, topic):
+    def create_basket(self, dataset_tid, topic, tilitid_value=None):
         if self.schema and self._table_exists(PG_BASKET_TABLE):
             cur = self.conn.cursor()
             cur.execute(
@@ -1016,10 +1016,13 @@ class PGConnector(DBConnector):
                     topic
                 )
             try:
+                if tilitid_value == None:
+                    # default value
+                    tilitid_value = "uuid_generate_v4()"
                 cur.execute(
                     """
                     INSERT INTO {schema}.{basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES (nextval('{schema}.{sequence}'), {dataset_tid}, '{topic}', uuid_generate_v4(), 'Qgis Model Baker')
+                    VALUES (nextval('{schema}.{sequence}'), {dataset_tid}, '{topic}', {tilitid} , 'Qgis Model Baker')
                 """.format(
                         schema=self.schema,
                         sequence="t_ili2db_seq",
@@ -1028,6 +1031,7 @@ class PGConnector(DBConnector):
                         basket_table=PG_BASKET_TABLE,
                         dataset_tid=dataset_tid,
                         topic=topic,
+                        tilitid=tilitid_value,
                     )
                 )
                 self.conn.commit()

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -973,10 +973,13 @@ class PGConnector(DBConnector):
                 """
                     SELECT DISTINCT (string_to_array(cn.iliname, '.'))[1] as model,
                     (string_to_array(cn.iliname, '.'))[2] as topic,
+                    ma.attr_value as bid_domain,
                     {relevance}
                     FROM {schema}.t_ili2db_classname as cn
                     JOIN {schema}.t_ili2db_table_prop as tp
                     ON cn.sqlname = tp.tablename
+                    LEFT JOIN {schema}.t_ili2db_meta_attrs as ma
+                    ON CONCAT((string_to_array(cn.iliname, '.'))[1],'.',(string_to_array(cn.iliname, '.'))[2]) = ma.ilielement and ma.attr_name = 'ili2db.ili.bidDomain'
 					WHERE array_length(string_to_array(cn.iliname, '.'),1) > 2 and tp.setting != 'ENUM'
                 """.format(
                     schema=self.schema,

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -1020,13 +1020,15 @@ class PGConnector(DBConnector):
                     topic
                 )
             try:
-                if tilitid_value == None:
+                if not tilitid_value:
                     # default value
                     tilitid_value = "uuid_generate_v4()"
+                elif not tilitid_value.isnumeric():
+                    tilitid_value = f"'{tilitid_value}'"
                 cur.execute(
                     """
                     INSERT INTO {schema}.{basket_table} ({tid_name}, dataset, topic, {tilitid_name}, attachmentkey )
-                    VALUES (nextval('{schema}.{sequence}'), {dataset_tid}, '{topic}', uuid_generate_v4(), 'modelbaker')
+                    VALUES (nextval('{schema}.{sequence}'), {dataset_tid}, '{topic}', {tilitid}, 'modelbaker')
                 """.format(
                         schema=self.schema,
                         sequence="t_ili2db_seq",

--- a/tests/test_dataset_handling.py
+++ b/tests/test_dataset_handling.py
@@ -266,6 +266,17 @@ class TestDatasetHandling(unittest.TestCase):
         topics = db_connector.get_topics_info()
         assert len(topics) == 2
 
+        # check the bid_domain
+        count = 0
+        for topic in topics:
+            if topic["topic"] == "Infrastructure":
+                assert topic["bid_domain"] == "INTERLIS.UUIDOID"
+                count += 1
+            if topic["topic"] == "Lines":
+                assert topic["bid_domain"] == "INTERLIS.UUIDOID"
+                count += 1
+        assert count == 2
+
         # Generate the basket for 'Glarus Nord' and the first topic
         result = db_connector.create_basket(
             glarus_nord_tid, f"{topics[0]['model']}.{topics[0]['topic']}"


### PR DESCRIPTION
This PR provides:
- BID Domains of the topics on `get_topics_info` \*
- Possibility to pass a `t_ili_tid` (OID) on `create_basket`

\* It passes back the defined BASKET OID, but if a topic is extended and inherits the BASKET OID of it's parent, this is not provided.