### PR TITLE
Prefix for Model Baker Extra Metaattributes

### DIFF
--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -233,7 +233,10 @@ class Generator(QObject):
             elif "ili_name" in record and record["ili_name"]:
                 meta_attrs = self.get_meta_attrs(record["ili_name"])
                 for attr_record in meta_attrs:
-                    if attr_record["attr_name"] == "dispExpression":
+                    if attr_record["attr_name"] in [
+                        "dispExpression",
+                        "qgis.modelbaker.dispExpression",
+                    ]:
                         display_expression = attr_record["attr_value"]
 
             coord_decimals = (

--- a/modelbaker/utils/qgis_utils.py
+++ b/modelbaker/utils/qgis_utils.py
@@ -159,6 +159,8 @@ class QgisProjectUtils:
         tree_layers = root.findLayers()
         for tree_layer in tree_layers:
             # get t_ili_tid field OID field
+            if tree_layer.layer().type() != QgsMapLayer.VectorLayer:
+                continue
             fields = tree_layer.layer().fields()
             field_idx = fields.lookupField("t_ili_tid")
             if field_idx < 0:

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -1437,7 +1437,7 @@ class TestProjectGen(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool, "ilimodels")
-        importer.configuration.ilimodels = "ExceptionalLoadsRoute_LV95_V1"
+        importer.configuration.ilimodels = "ExceptionalLoadsRoute_LV03_V1"
         importer.configuration.dbschema = "ciaf_ladm_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
@@ -1482,7 +1482,7 @@ class TestProjectGen(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
         importer.configuration = iliimporter_config(importer.tool, "ilimodels")
-        importer.configuration.ilimodels = "ExceptionalLoadsRoute_LV95_V1"
+        importer.configuration.ilimodels = "ExceptionalLoadsRoute_LV03_V1"
 
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -1531,7 +1531,7 @@ class TestProjectGen(unittest.TestCase):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
         importer.configuration = iliimporter_config(importer.tool, "ilimodels")
-        importer.configuration.ilimodels = "ExceptionalLoadsRoute_LV95_V1"
+        importer.configuration.ilimodels = "ExceptionalLoadsRoute_LV03_V1"
         importer.configuration.dbschema = "ciaf_ladm_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
@@ -1620,9 +1620,6 @@ class TestProjectGen(unittest.TestCase):
                 assert layer.layer.displayExpression() == "type"
             if layer.name == "route":
                 count += 1
-                assert layer.layer.displayExpression() == (
-                    '"t_ili_tid"' if Qgis.QGIS_VERSION_INT >= 31800 else '"t_id"'
-                )
                 assert layer.layer.displayExpression() == "type"
             if layer.name == "obstacle":
                 count += 1
@@ -1677,9 +1674,6 @@ class TestProjectGen(unittest.TestCase):
                 assert layer.layer.displayExpression() == "type"
             if layer.name == "route":
                 count += 1
-                assert layer.layer.displayExpression() == (
-                    '"T_Ili_Tid"' if Qgis.QGIS_VERSION_INT >= 31800 else '"T_Id"'
-                )
                 assert layer.layer.displayExpression() == "type"
             if layer.name == "obstacle":
                 count += 1
@@ -1836,9 +1830,6 @@ class TestProjectGen(unittest.TestCase):
                 assert layer.layer.displayExpression() == "type"
             if layer.name == "route":
                 count += 1
-                assert layer.layer.displayExpression() == (
-                    '"T_Ili_Tid"' if Qgis.QGIS_VERSION_INT >= 31800 else '"T_Id"'
-                )
                 assert layer.layer.displayExpression() == "type"
             if layer.name == "obstacle":
                 count += 1

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -1623,6 +1623,7 @@ class TestProjectGen(unittest.TestCase):
                 assert layer.layer.displayExpression() == (
                     '"t_ili_tid"' if Qgis.QGIS_VERSION_INT >= 31800 else '"t_id"'
                 )
+                assert layer.layer.displayExpression() == "type"
             if layer.name == "obstacle":
                 count += 1
                 assert layer.layer.displayExpression() == "type"
@@ -1679,6 +1680,7 @@ class TestProjectGen(unittest.TestCase):
                 assert layer.layer.displayExpression() == (
                     '"T_Ili_Tid"' if Qgis.QGIS_VERSION_INT >= 31800 else '"T_Id"'
                 )
+                assert layer.layer.displayExpression() == "type"
             if layer.name == "obstacle":
                 count += 1
                 assert layer.layer.displayExpression() == "type"
@@ -1837,6 +1839,7 @@ class TestProjectGen(unittest.TestCase):
                 assert layer.layer.displayExpression() == (
                     '"T_Ili_Tid"' if Qgis.QGIS_VERSION_INT >= 31800 else '"T_Id"'
                 )
+                assert layer.layer.displayExpression() == "type"
             if layer.name == "obstacle":
                 count += 1
                 assert layer.layer.displayExpression() == "type"

--- a/tests/testdata/ilimodels/ExceptionalLoadsRoute_V1.ili
+++ b/tests/testdata/ilimodels/ExceptionalLoadsRoute_V1.ili
@@ -50,7 +50,6 @@ VERSION "2017-02-08"  =
       RestrictAxisLoad : 0 .. 1000 [Units.t];
     END Obstacle;
 
-    !!@ qgis.modelbaker.dispExpression="type"
     CLASS Route =
       Identifier : MANDATORY TEXT*50;
       Canton : MANDATORY CHAdminCodes_V1.CHCantonCode;
@@ -88,6 +87,7 @@ VERSION "2017-02-08"  =
       RestrictAxisLoad : 0 .. 1000 [Units.t];
     END Obstacle;
 
+    !!@ qgis.modelbaker.dispExpression="type"
     CLASS Route =
       Identifier : MANDATORY TEXT*50;
       Canton : MANDATORY CHAdminCodes_V1.CHCantonCode;

--- a/tests/testdata/ilimodels/ExceptionalLoadsRoute_V1.ili
+++ b/tests/testdata/ilimodels/ExceptionalLoadsRoute_V1.ili
@@ -50,6 +50,7 @@ VERSION "2017-02-08"  =
       RestrictAxisLoad : 0 .. 1000 [Units.t];
     END Obstacle;
 
+    !!@ qgis.modelbaker.dispExpression="type"
     CLASS Route =
       Identifier : MANDATORY TEXT*50;
       Canton : MANDATORY CHAdminCodes_V1.CHCantonCode;


### PR DESCRIPTION
Use `qgis.modelbaker` as prefix like suggested (by myself) here https://interlis.discourse.group/t/uebersicht-interlis-meta-attribute/70/2