### PR TITLE
IliDataCache: Check category `codes.modelbaker.ch/preferredDataSource`

### DIFF
--- a/modelbaker/ilitoppingmaker/ilidata.py
+++ b/modelbaker/ilitoppingmaker/ilidata.py
@@ -41,11 +41,13 @@ class DatasetMetadata:
         file_type: str = None,
         file_path: str = None,
         linking_models: list = [],
+        preferred_datasource: str = None,
     ):
         self.id = id
         self.file_type = file_type
         self.file_path = file_path
         self.linking_models = linking_models
+        self.preferred_datasource = preferred_datasource
 
         self.version = dataset_version
         self.publishing_date = publishing_date
@@ -99,7 +101,7 @@ class DatasetMetadata:
             type_datasetidx16_code, "value"
         ).text = f"http://codes.interlis.ch/type/{self.file_type}"
 
-        if self.file_type in ["metaconfig", "referencedata"]:
+        if self.file_type in ["metaconfig", "referencedata", "projecttopping"]:
             for linking_model in self.linking_models:
                 linking_model_datasetidx16_code = ET.SubElement(
                     categories, "DatasetIdx16.Code_"
@@ -107,6 +109,14 @@ class DatasetMetadata:
                 ET.SubElement(
                     linking_model_datasetidx16_code, "value"
                 ).text = f"http://codes.interlis.ch/model/{linking_model}"
+
+            if self.preferred_datasource:
+                datasource_datasetidx16_code = ET.SubElement(
+                    categories, "DatasetIdx16.Code_"
+                )
+                ET.SubElement(
+                    datasource_datasetidx16_code, "value"
+                ).text = f"http://codes.modelbaker.ch/preferredDataSource/{self.preferred_datasource}"
 
         files = ET.SubElement(element, "files")
         datsaetidx16_datafile = ET.SubElement(files, "DatasetIdx16.DataFile")
@@ -127,7 +137,12 @@ class IliData:
     def __init__(self):
         pass
 
-    def generate_file(self, target: IliTarget, linking_models: list = []):
+    def generate_file(
+        self,
+        target: IliTarget,
+        linking_models: list = [],
+        preferred_datasource: str = None,
+    ):
         """
         Generates the ilidata.xml file containing all the toppingfile listed in the targets toppingfileinfo_list and writes it to the targets folders.
         """
@@ -168,6 +183,7 @@ class IliData:
                 toppingfileinfo["type"],
                 toppingfileinfo["path"],
                 linking_models,
+                preferred_datasource,
             )
             dataset.make_xml_element(dataset_metadata_element)
 

--- a/modelbaker/ilitoppingmaker/iliprojecttopping.py
+++ b/modelbaker/ilitoppingmaker/iliprojecttopping.py
@@ -50,6 +50,7 @@ class IliProjectTopping(ProjectTopping):
         self.target = target
         self.export_settings = export_settings
         self.metaconfig = metaconfig
+        self.preferred_datasource = None
 
     @property
     def models(self):
@@ -94,7 +95,9 @@ class IliProjectTopping(ProjectTopping):
 
         # generate ilidata
         ilidata = IliData()
-        ilidata_path = ilidata.generate_file(self.target, self.models)
+        ilidata_path = ilidata.generate_file(
+            self.target, self.models, self.preferred_datasource
+        )
         if ilidata_path:
             self.stdout.emit(
                 self.tr("IliData written to XML file: {}").format(ilidata_path),

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -101,7 +101,7 @@ class BaseConfiguration:
         return dirs
 
     @property
-    def metaconfig_directories(self):
+    def ilidata_directories(self):
         dirs = list()
         if self.custom_model_directories_enabled and self.custom_model_directories:
             dirs = self.custom_model_directories.split(";")
@@ -451,7 +451,7 @@ class ValidateConfiguration(Ili2DbCommandConfiguration):
 
         if self.db_ili_version == 3:
             self.append_args(args, ["--export3"])
-            
+
         if self.xtflog:
             self.append_args(args, ["--xtflog", self.xtflog])
 
@@ -461,7 +461,7 @@ class ValidateConfiguration(Ili2DbCommandConfiguration):
 
         if self.valid_config:
             self.append_args(args, ["--validConfig", self.valid_config])
-        
+
         if self.db_ili_version == 3:
             self.append_args(args, [self.xtffile])
 

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -437,7 +437,7 @@ class IliDataCache(IliCache):
 
     CACHE_PATH = os.path.expanduser("~/.ilidatacache")
 
-    def __init__(self, configuration, type="metaconfig", models=None):
+    def __init__(self, configuration, type="metaconfig", models=None, datasources=[]):
         IliCache.__init__(self, configuration)
         self.information_file = "ilidata.xml"
 
@@ -454,6 +454,7 @@ class IliDataCache(IliCache):
             if self.base_configuration
             else []
         )
+        self.datasources = datasources
 
     def process_model_directory(self, path):
         # download remote and local repositories
@@ -512,9 +513,16 @@ class IliDataCache(IliCache):
                                 datasource = datasource_code_regex.search(
                                     category_value
                                 ).group(1)
+
+                    # filter for models and types and if datasources are passed and found in the category, they need to be considered
                     if (
                         not any(model in models for model in self.filter_models)
                         or type != self.type
+                        or (
+                            self.datasources
+                            and datasource
+                            and datasource not in self.datasources
+                        )
                     ):
                         continue
                     title = list()

--- a/tests/test_ilicache.py
+++ b/tests/test_ilicache.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 
-from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtCore import QEventLoop, Qt, QTimer
 from qgis.testing import unittest
 
 from modelbaker.iliwrapper.ili2dbconfig import BaseConfiguration
@@ -361,6 +361,8 @@ class IliCacheTest(unittest.TestCase):
         }
         assert metaconfigs == expected_metaconfigs
 
+        self._sleep()
+
         ilimetaconfigcache_model = ilimetaconfigcache.model
 
         matches_on_id = ilimetaconfigcache_model.match(
@@ -439,6 +441,8 @@ class IliCacheTest(unittest.TestCase):
         }
         assert metaconfigs == expected_metaconfigs
 
+        self._sleep()
+
         ilimetaconfigcache_model = ilimetaconfigcache.model
 
         matches_on_id = ilimetaconfigcache_model.match(
@@ -510,6 +514,8 @@ class IliCacheTest(unittest.TestCase):
         }
         assert referencedata == expected_referencedata
 
+        self._sleep()
+
         linked_model_list = []
         for r in range(ilireferencedatacache.model.rowCount()):
             if ilireferencedatacache.model.item(r).data(
@@ -562,6 +568,8 @@ class IliCacheTest(unittest.TestCase):
             "ch.gl.ili.catalogue.GL_Forstreviere_V1_Kataloge",
         }
         assert referencedata == expected_referencedata
+
+        self._sleep()
 
         linked_model_list = []
         for r in range(ilireferencedatacache.model.rowCount()):
@@ -616,6 +624,8 @@ class IliCacheTest(unittest.TestCase):
         }
 
         assert files == expected_files
+
+        self._sleep()
 
         ilitoppingfilecache_model = ilitoppingfilecache.model
 
@@ -765,3 +775,11 @@ class IliCacheTest(unittest.TestCase):
         # not finding invalid metaconfig but the one with none as id
         expected_metaconfigs = {None, "ch.opengis.ili.config.valid"}
         assert metaconfigs == expected_metaconfigs
+
+    def _sleep(self, mili=2000):
+        loop = QEventLoop()
+        timer = QTimer()
+        timer.setSingleShot(True)
+        timer.timeout.connect(lambda: loop.quit())
+        timer.start(mili)
+        loop.exec()

--- a/tests/test_ilicache.py
+++ b/tests/test_ilicache.py
@@ -285,6 +285,58 @@ class IliCacheTest(unittest.TestCase):
 
     def test_ilidata_xml_parser_metaconfig_kbs(self):
         # find kbs metaconfig file according to the model(s) with direct ilidata.xml scan
+        # pass gpkg as datasource find the ones with gpkg-datasource-category and the ones without datasource-category
+        ilimetaconfigcache = IliDataCache(
+            configuration=None, models="KbS_LV95_V1_4", datasources=["gpkg"]
+        )
+        ilimetaconfigcache._process_informationfile(
+            os.path.join(
+                test_path, "testdata", "ilirepo", "usabilityhub", "ilidata.xml"
+            ),
+            "test_repo",
+            os.path.join(test_path, "testdata", "ilirepo", "usabilityhub"),
+        )
+        assert "test_repo" in ilimetaconfigcache.repositories.keys()
+        metaconfigs = {
+            e["id"]
+            for e in next(elem for elem in ilimetaconfigcache.repositories.values())
+        }
+        expected_metaconfigs = {
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-technical",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg_localfiletest",  # gpkg as preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-wrong",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg",  # no preferred datasource
+        }
+        assert metaconfigs == expected_metaconfigs
+
+        # pass pg as datasource find the ones with pg-datasource-category and the ones without datasource-category
+        ilimetaconfigcache = IliDataCache(
+            configuration=None, models="KbS_LV95_V1_4", datasources=["pg"]
+        )
+        ilimetaconfigcache._process_informationfile(
+            os.path.join(
+                test_path, "testdata", "ilirepo", "usabilityhub", "ilidata.xml"
+            ),
+            "test_repo",
+            os.path.join(test_path, "testdata", "ilirepo", "usabilityhub"),
+        )
+        assert "test_repo" in ilimetaconfigcache.repositories.keys()
+        metaconfigs = {
+            e["id"]
+            for e in next(elem for elem in ilimetaconfigcache.repositories.values())
+        }
+        expected_metaconfigs = {
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-technical",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_localfiletest",  # pg as preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_ili2db",  # pg as preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-wrong",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg",  # no preferred datasource
+        }
+        assert metaconfigs == expected_metaconfigs
+
+        # don't pass any datasource, means find all
         ilimetaconfigcache = IliDataCache(configuration=None, models="KbS_LV95_V1_4")
         ilimetaconfigcache._process_informationfile(
             os.path.join(
@@ -299,13 +351,13 @@ class IliCacheTest(unittest.TestCase):
             for e in next(elem for elem in ilimetaconfigcache.repositories.values())
         }
         expected_metaconfigs = {
-            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-technical",
-            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0",
-            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_localfiletest",
-            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg_localfiletest",
-            "ch.opengis.ili.config.KbS_LV95_V1_4_ili2db",
-            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-wrong",
-            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg",
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-technical",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_localfiletest",  # pg as preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg_localfiletest",  # gpkg as preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_ili2db",  # pg as preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0-wrong",  # no preferred datasource
+            "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg",  # no preferred datasource
         }
         assert metaconfigs == expected_metaconfigs
 

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -3158,6 +3158,9 @@ class TestProjectGen(unittest.TestCase):
             models="KbS_LV95_V1_4",
         )
         ilimetaconfigcache.refresh()
+
+        self._sleep()
+
         matches_on_id = ilimetaconfigcache.model.match(
             ilimetaconfigcache.model.index(0, 0),
             int(IliDataItemModel.Roles.ID),
@@ -3548,6 +3551,9 @@ class TestProjectGen(unittest.TestCase):
             models="KbS_LV95_V1_4",
         )
         ilimetaconfigcache.refresh()
+
+        self._sleep()
+
         matches_on_id = ilimetaconfigcache.model.match(
             ilimetaconfigcache.model.index(0, 0),
             int(IliDataItemModel.Roles.ID),
@@ -4264,7 +4270,18 @@ class TestProjectGen(unittest.TestCase):
         if len(topping_file_cache.downloaded_files) != len(id_list):
             loop.exec()
 
+        # since the local download is quicker than the delay in the model refresh, we make one here as well
+        self._sleep(3000)
+
         return topping_file_cache.model
+
+    def _sleep(self, mili=2000):
+        loop = QEventLoop()
+        timer = QTimer()
+        timer.setSingleShot(True)
+        timer.timeout.connect(lambda: loop.quit())
+        timer.start(mili)
+        loop.exec()
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_projecttopping.py
+++ b/tests/test_projecttopping.py
@@ -1249,6 +1249,10 @@ class TestProjectTopping(unittest.TestCase):
         if len(topping_file_cache.downloaded_files) != len(id_list):
             loop.exec()
 
+        # since the local download is quicker than the delay in the model refresh, we make one here as well
+        timer.start(3000)
+        loop.exec()
+
         return topping_file_cache.model
 
     # that's the same (more or less) like in project_creation_page.py

--- a/tests/testdata/ilirepo/invalid/ilidata.xml
+++ b/tests/testdata/ilirepo/invalid/ilidata.xml
@@ -34,9 +34,6 @@
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -68,9 +65,6 @@
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
         </categories>
       </DatasetIdx16.DataIndex.DatasetMetadata>
 
@@ -94,9 +88,6 @@
           </DatasetIdx16.Code_>
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
-          </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
           </DatasetIdx16.Code_>
         </categories>
         <files>
@@ -132,9 +123,6 @@
           </DatasetIdx16.Code_>
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
-          </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
           </DatasetIdx16.Code_>
         </categories>
         <files>

--- a/tests/testdata/ilirepo/usabilityhub/ilidata.xml
+++ b/tests/testdata/ilirepo/usabilityhub/ilidata.xml
@@ -36,9 +36,6 @@
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -72,9 +69,6 @@
           </DatasetIdx16.Code_>
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
-          </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
           </DatasetIdx16.Code_>
         </categories>
         <files>
@@ -111,7 +105,7 @@
           	<value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
           <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
+          	<value>http://codes.modelbaker.ch/preferredDataSource/pg</value>
           </DatasetIdx16.Code_>
         </categories>
         <files>
@@ -148,7 +142,7 @@
           	<value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
           <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
+          	<value>http://codes.modelbaker.ch/preferredDataSource/gpkg</value>
           </DatasetIdx16.Code_>
         </categories>
         <files>
@@ -184,9 +178,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -211,9 +203,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -249,7 +239,7 @@
             <value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
           <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
+          	<value>http://codes.modelbaker.ch/preferredDataSource/pg</value>
           </DatasetIdx16.Code_>
         </categories>
         <files>
@@ -414,9 +404,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/projecttopping</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -452,9 +440,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/projecttopping</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -554,9 +540,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/referenceData</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
          <files>
           <DatasetIdx16.DataFile>
@@ -591,9 +575,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/referenceData</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
          <files>
           <DatasetIdx16.DataFile>
@@ -641,9 +623,6 @@
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -677,9 +656,6 @@
           </DatasetIdx16.Code_>
           <DatasetIdx16.Code_>
           	<value>http://codes.interlis.ch/type/metaconfig</value>
-          </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-          	<value>http://codes.opengis.ch/modelbaker</value>
           </DatasetIdx16.Code_>
         </categories>
         <files>
@@ -716,9 +692,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/referenceData</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -764,9 +738,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/referenceData</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
         <files>
           <DatasetIdx16.DataFile>
@@ -812,9 +784,7 @@
           <DatasetIdx16.Code_>
             <value>http://codes.interlis.ch/type/referenceData</value>
           </DatasetIdx16.Code_>
-          <DatasetIdx16.Code_>
-            <value>http://codes.opengis.ch/modelbaker</value>
-          </DatasetIdx16.Code_>
+
         </categories>
         <files>
           <DatasetIdx16.DataFile>


### PR DESCRIPTION
- introducing new category to check on IliDataCache `codes.modelbaker.ch/preferredDataSource`
- rename of remaining metaconfig-variables to ilidata or ilidatafile
- Some optimization of the model update (with QTimer) to avoid multiple updates of the combos on every model reset.