### PR TITLE
Support of --replace on basket-handled data imports. 

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -380,6 +380,7 @@ class UpdateDataConfiguration(Ili2DbCommandConfiguration):
         super().__init__()
         self.xtffile = ""
         self.dataset = ""
+        self.delete_data = False
         self.with_importtid = False
         self.with_importbid = False
 
@@ -387,7 +388,10 @@ class UpdateDataConfiguration(Ili2DbCommandConfiguration):
         args = list()
 
         if with_action:
-            self.append_args(args, ["--update"])
+            if self.delete_data:
+                self.append_args(args, ["--replace"])
+            else:
+                self.append_args(args, ["--update"])
 
         self.append_args(args, extra_args)
 


### PR DESCRIPTION
Integrated in `UpdateDataConfiguration`, since --replace handles the same parameters like `--update`. 

The parameter that decides is delete_data. This because like this it's equivalent to the delete_data parameter on import. It makes sense to use the same class. I thought about renaming to `UpdateOrReplaceDataConfiguration` but I decided against not to risk backwards incompatibility.