### PR TITLE
Change signalname because it's triggered when downloaded and model ready

### DIFF
--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -835,7 +835,7 @@ class IliDataFileCompleterDelegate(QItemDelegate):
 
 class IliToppingFileCache(IliDataCache):
 
-    download_finished = pyqtSignal()
+    download_finished_and_model_fresh = pyqtSignal()
     """
     meta_netloc is the repository (netloc) of the metaconfiguration file used for file paths in the file_ids
     file_ids can contain ilidata: or file: information
@@ -904,8 +904,9 @@ class IliToppingFileCache(IliDataCache):
         # here we could add some more logic
         if dataset_id is not None:
             self.downloaded_files.append(dataset_id)
+        # ensure all the files are downloaded and contained in the model
         if len(self.downloaded_files) == len(self.file_ids) == self.model.rowCount():
-            self.download_finished.emit()
+            self.download_finished_and_model_fresh.emit()
 
     def _process_informationfile(self, file, netloc, url):
         """

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -4259,7 +4259,9 @@ class TestProjectGen(unittest.TestCase):
 
         # we wait for the download or we timeout after 30 seconds and we apply what we have
         loop = QEventLoop()
-        topping_file_cache.download_finished.connect(lambda: loop.quit())
+        topping_file_cache.download_finished_and_model_fresh.connect(
+            lambda: loop.quit()
+        )
         timer = QTimer()
         timer.setSingleShot(True)
         timer.timeout.connect(lambda: loop.quit())

--- a/tests/test_projecttopping.py
+++ b/tests/test_projecttopping.py
@@ -1238,7 +1238,9 @@ class TestProjectTopping(unittest.TestCase):
 
         # we wait for the download or we timeout after 30 seconds and we apply what we have
         loop = QEventLoop()
-        topping_file_cache.download_finished.connect(lambda: loop.quit())
+        topping_file_cache.download_finished_and_model_fresh.connect(
+            lambda: loop.quit()
+        )
         timer = QTimer()
         timer.setSingleShot(True)
         timer.timeout.connect(lambda: loop.quit())


### PR DESCRIPTION
To avoid confusion.

And I think because this concerns UsabILIty Hub it's not really used by 3rd party software, so we can handle the backwards compatibility break.