### PR TITLE
use nice prefix for meta attribut form_order

### DIFF
--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -421,7 +421,11 @@ class GPKGConnector(DBConnector):
                     if record["fully_qualified_name"] != meta_attr["ilielement"]:
                         continue
 
-                    if meta_attr["attr_name"] == "form_order":
+                    if meta_attr["attr_name"] in [
+                        "form_order",  # obsolete
+                        "qgis.modelbaker.form_order",  # obsolete
+                        "qgis.modelbaker.formOrder",
+                    ]:
                         record["attr_order"] = meta_attr["attr_value"]
                         attr_order_found = True
 

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -537,7 +537,10 @@ class MssqlConnector(DBConnector):
                 if metaattrs_exists:
                     stmt += ln + "LEFT JOIN {schema}.t_ili2db_meta_attrs form_order"
                     stmt += ln + "    ON full_name.iliname=form_order.ilielement AND"
-                    stmt += ln + "    form_order.attr_name='form_order'"
+                    stmt += ln + "    form_order.attr_name IN ("
+                    stmt += ln + "        'form_order',"  # obsolete
+                    stmt += ln + "        'qgis.modelbaker.form_order',"  # obsolete
+                    stmt += ln + "        'qgis.modelbaker.formOrder')"
                     stmt += ln + "LEFT JOIN {schema}.t_ili2db_meta_attrs attr_mapping"
                     stmt += ln + "    ON full_name.iliname=attr_mapping.ilielement AND"
                     stmt += ln + "    attr_mapping.attr_name='ili2db.mapping'"

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -490,7 +490,10 @@ class PGConnector(DBConnector):
                     attr_order_field = "COALESCE(to_number(form_order.attr_value, '999'), 999) as attr_order,"
                     attr_order_join = """LEFT JOIN {schema}.{t_ili2db_meta_attrs} form_order
                                                             ON full_name.iliname=form_order.ilielement AND
-                                                            form_order.attr_name='form_order'
+                                                            form_order.attr_name IN (
+                                                                'form_order', --obsolete
+                                                                'qgis.modelbaker.form_order', --obsolete
+                                                                'qgis.modelbaker.formOrder')
                                                             """.format(
                         schema=self.schema, t_ili2db_meta_attrs=PG_METAATTRS_TABLE
                     )

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -234,7 +234,7 @@ class Generator(QObject):
                 meta_attrs = self.get_meta_attrs(record["ili_name"])
                 for attr_record in meta_attrs:
                     if attr_record["attr_name"] in [
-                        "dispExpression",
+                        "dispExpression",  # obsolete
                         "qgis.modelbaker.dispExpression",
                     ]:
                         display_expression = attr_record["attr_value"]


### PR DESCRIPTION
Meanwhile we prefer to have a prefix for modelbaker (like other tools do it as well) `qgis.modelbaker`