### PR TITLE
Smart 1 Improvements (t_type consistency and optimization strategy)

### DIFF
--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -147,6 +147,16 @@ class DBConnector(QObject):
         """
         return {}
 
+    def get_t_type_map_info(self, table_name):
+        """
+        Info about available types of a given smart1-inherited table.
+
+        Return:
+            Dictionary with keys corresponding to column names and values
+            with lists of allowed values
+        """
+        return {}
+
     def get_relations_info(self, filter_layer_list=[]):
         """
         Info about relations found in a database (or database schema).

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -326,8 +326,21 @@ class DBConnector(QObject):
             Expected columns are:
                 model
                 topic
+                bid_domain
+                relevance
         """
         return {}
+
+    def get_classes_relevance(self):
+        """
+        Returns the ili classes and it's sqlname and relevance. Compared to tables_info it returns the classes (and the sqlnames of tables that might not be existing)
+        and not the existing tables. This is mainly used, when smart1 has been selected.
+            Expected colums are:
+                iliname
+                sqlname
+                relevance
+        """
+        return []
 
     def create_basket(self, dataset_tid, topic, tilitid_value=None):
         """

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -874,6 +874,58 @@ class GPKGConnector(DBConnector):
             return contents
         return {}
 
+    def get_classes_relevance(self):
+        if self._table_exists("T_ILI2DB_CLASSNAME"):
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """
+                SELECT
+                    c.iliname as iliname,
+                    c.SqlName as sqlname,
+                    CASE WHEN c.iliname IN (
+                            WITH names AS (
+                                WITH class_level_name AS(
+                                    WITH topic_level_name AS (
+                                        SELECT
+                                        thisClass as fullname,
+                                        substr(thisClass, 0, instr(thisClass, '.')) as model,
+                                        substr(ltrim(thisClass,substr(thisClass, 0, instr(thisClass, '.'))),2) as topicclass
+                                        FROM T_ILI2DB_INHERITANCE
+                                    )
+                                    SELECT *, ltrim(topicclass,substr(topicclass, 0, instr(topicclass, '.'))) as class_with_dot
+                                    FROM topic_level_name
+                                )
+                                SELECT fullname, model, topicclass, substr(class_with_dot, instr(class_with_dot,'.')+1) as class
+                                FROM class_level_name
+                                )
+                                SELECT i.baseClass as iliname
+                                FROM T_ILI2DB_INHERITANCE i
+                                LEFT JOIN names extend_names
+                                ON thisClass = extend_names.fullname
+                                LEFT JOIN names base_names
+                                ON baseClass = base_names.fullname
+                                -- it's extended
+                                LEFT JOIN T_ILI2DB_CLASSNAME c
+                                ON IliName = i.baseClass
+                                WHERE baseClass IS NOT NULL
+                                -- in a different model
+                                AND base_names.model != extend_names.model
+                                AND (
+                                    -- with the same name
+                                    base_names.class = extend_names.class
+                                    OR
+                                    -- multiple times in the same extended model
+                                    (SELECT MAX(count) FROM (SELECT COUNT(baseClass) AS count FROM T_ILI2DB_INHERITANCE JOIN names extend_names ON thisClass = extend_names.fullname WHERE baseClass = i.baseClass GROUP BY baseClass, extend_names.model) AS counts )>1
+                                )
+                    ) THEN FALSE ELSE TRUE END AS relevance
+                FROM T_ILI2DB_CLASSNAME c
+                """
+            )
+            contents = cursor.fetchall()
+            cursor.close()
+            return contents
+        return []
+
     def create_basket(self, dataset_tid, topic, tilitid_value=None):
         if self._table_exists(GPKG_BASKET_TABLE):
             cursor = self.conn.cursor()

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -470,7 +470,7 @@ class GPKGConnector(DBConnector):
         cursor.close()
         return constraint_mapping
 
-    def get_value_map_info(self, table_name):
+    def get_t_type_map_info(self, table_name):
         if self.metadata_exists():
             cursor = self.conn.cursor()
             cursor.execute(

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -470,6 +470,28 @@ class GPKGConnector(DBConnector):
         cursor.close()
         return constraint_mapping
 
+    def get_value_map_info(self, table_name):
+        if self.metadata_exists():
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """
+                SELECT *
+                FROM t_ili2db_column_prop
+                WHERE tablename = '{}'
+                AND tag = 'ch.ehi.ili2db.types'
+                """.format(
+                    table_name
+                )
+            )
+            types_entries = cursor.fetchall()
+
+            types_mapping = dict()
+            for types_entry in types_entries:
+                values = eval(types_entry["setting"])
+                types_mapping[types_entry["columnname"]] = values
+            return types_mapping
+        return {}
+
     def get_relations_info(self, filter_layer_list=[]):
         # We need to get the PK for each table, so first get tables_info
         # and then build something more searchable

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -597,6 +597,28 @@ class MssqlConnector(DBConnector):
 
         return result
 
+    def get_t_type_map_info(self, table_name):
+        if self.schema and self.metadata_exists():
+            cur = self.conn.cursor()
+            cur.execute(
+                """
+                SELECT *
+                FROM {}.t_ili2db_column_prop
+                WHERE tablename = '{}'
+                AND tag = 'ch.ehi.ili2db.types'
+                """.format(
+                    self.schema, table_name
+                )
+            )
+            types_entries = cur.fetchall()
+
+            types_mapping = dict()
+            for types_entry in types_entries:
+                values = eval(types_entry["setting"])
+                types_mapping[types_entry["columnname"]] = values
+            return types_mapping
+        return {}
+
     def get_relations_info(self, filter_layer_list=[]):
         result = []
 

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -610,7 +610,7 @@ class MssqlConnector(DBConnector):
                     self.schema, table_name
                 )
             )
-            types_entries = cur.fetchall()
+            types_entries = self._get_dict_result(cur)
 
             types_mapping = dict()
             for types_entry in types_entries:

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -631,6 +631,28 @@ class PGConnector(DBConnector):
 
         return {}
 
+    def get_t_type_map_info(self, table_name):
+        if self.schema and self.metadata_exists():
+            cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+            cur.execute(
+                """
+                SELECT *
+                FROM {}.t_ili2db_column_prop
+                WHERE tablename = '{}'
+                AND tag = 'ch.ehi.ili2db.types'
+                """.format(
+                    self.schema, table_name
+                )
+            )
+            types_entries = cur.fetchall()
+
+            types_mapping = dict()
+            for types_entry in types_entries:
+                values = eval(types_entry["setting"])
+                types_mapping[types_entry["columnname"].lower()] = values
+            return types_mapping
+        return {}
+
     def get_relations_info(self, filter_layer_list=[]):
         if self.schema:
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -271,9 +271,12 @@ class Generator(QObject):
             # Configure fields for current table
             fields_info = self.get_fields_info(record["tablename"])
             min_max_info = self.get_min_max_info(record["tablename"])
+            # We get the value map values from the check-constraints (only pg support) and additionally we check the t_type values in the ili2db-meta-tables
             value_map_info = self.get_value_map_info(record["tablename"])
-            re_iliname = re.compile(r".*\.(.*)$")
+            t_type_map_info = self.get_t_type_map_info(record["tablename"])
+            value_map_info.update(t_type_map_info)
 
+            re_iliname = re.compile(r".*\.(.*)$")
             for fielddef in fields_info:
                 column_name = fielddef["column_name"]
                 fully_qualified_name = (
@@ -878,6 +881,9 @@ class Generator(QObject):
 
     def get_value_map_info(self, table_name):
         return self._db_connector.get_value_map_info(table_name)
+
+    def get_t_type_map_info(self, table_name):
+        return self._db_connector.get_t_type_map_info(table_name)
 
     def get_relations_info(self, filter_layer_list=[]):
         return self._db_connector.get_relations_info(filter_layer_list)

--- a/tests/test_projectgen_extension_optimization_smart1.py
+++ b/tests/test_projectgen_extension_optimization_smart1.py
@@ -234,7 +234,8 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             "Strasse",
             "Gebaeude",
             "Gebaeude_StadtFirma",
-            "BesitzerIn" "Firma",
+            "BesitzerIn",
+            "Firma",
         ]
         assert set(aliases) == set(expected_aliases)
 
@@ -266,10 +267,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
                     "Staedtisches_Gewerbe_V1.Firmen",
                     "Gewerbe_V1.Firmen",
                 }
-                assert set(layer.relevant_topics) == {
-                    "Staedtisches_Gewerbe_V1.Firmen",
-                    "Gewerbe_V1.Firmen",
-                }
+                assert set(layer.relevant_topics) == {"Staedtisches_Gewerbe_V1.Firmen"}
         assert count == 3
 
         project = Project(
@@ -423,7 +421,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
             if layer.layer.name() == "Gebaeude":
                 count += 1
-
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
                 assert value_map
 
                 expected_entries = {
@@ -610,7 +610,6 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         expected_aliases = [
             "BesitzerIn",
-            "Markthalle",
             "Ortsplanung_V1_1.Konstruktionen.Gebaeude",
             "Polymorphic_Ortsplanung_V1_1.Konstruktionen.Gebaeude",
             "Strasse",
@@ -679,7 +678,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
         assert root is not None
 
         all_layers = root.findLayers()
-        assert len(all_layers) == 13
+        assert len(all_layers) == 8
 
         geometry_layers = {
             l.name() for l in root.children() if isinstance(l, QgsLayerTreeLayer)
@@ -817,7 +816,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
             if layer.layer.name() == "Ortsplanung_V1_1.Konstruktionen.Gebaeude":
                 count += 1
-
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
                 assert value_map
 
                 expected_entries = {
@@ -1096,7 +1097,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
                 # one general and four relation editors
                 assert len(efc.tabs()) == 2
                 for tab in efc.tabs():
-                    if tab.name() == "gebaeude":
+                    if tab.name() == "strassen_gebaeude":
                         count += 1
                         assert len(tab.children()) == 1
         # should find 1 (one times gebaeude)
@@ -1164,7 +1165,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
             if layer.layer.name() == "Gebaeude":
                 count += 1
-
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
                 assert value_map
 
                 expected_entries = {"gebaeude", "kantnl_ng_v1_1konstruktionen_gebaeude"}
@@ -1174,7 +1177,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
             if layer.layer.name() == "Buntbrache":
                 count += 1
-
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
                 assert value_map
 
                 expected_entries = {"buntbrache", "kantonalebuntbrache"}
@@ -1184,7 +1189,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
             if layer.layer.name() == "Feld":
                 count += 1
-
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
                 assert value_map
 
                 expected_entries = {"feld", "sonnenblumenfeld", "kartoffelfeld"}

--- a/tests/test_projectgen_extension_optimization_smart1.py
+++ b/tests/test_projectgen_extension_optimization_smart1.py
@@ -1,0 +1,1211 @@
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 14.08.2023
+        git sha              : :%H$
+        copyright            : (C) 2023 by Dave Signer
+        email                : david@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+import datetime
+import logging
+import os
+import pathlib
+import tempfile
+
+from qgis.core import QgsExpressionContextUtils, QgsLayerTreeLayer, QgsProject
+from qgis.testing import start_app, unittest
+
+from modelbaker.dataobjects.project import Project
+from modelbaker.db_factory.gpkg_command_config_manager import GpkgCommandConfigManager
+from modelbaker.generator.generator import Generator
+from modelbaker.iliwrapper import iliimporter
+from modelbaker.iliwrapper.globals import DbIliMode
+from modelbaker.utils.globals import OptimizeStrategy
+from tests.utils import get_pg_connection_string, iliimporter_config, testdata_path
+
+CATALOGUE_DATASETNAME = "Catset"
+
+start_app()
+
+test_path = pathlib.Path(__file__).parent.absolute()
+
+
+class TestProjectExtOptimizationSmart2(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.basetestpath = tempfile.mkdtemp()
+
+    """
+    Those tests check if:
+    - possible t_types are detected
+    # to do in next step: - irrelevant basetables are detected (according to the assumptions below)
+    # to do in next step: - t_types of irrelevant basetables will not be provided on hide-strategy but they are on none-strategy (there is no group strategy on smart1)
+
+    Assumption:
+    Since it appears almost impossible to care for all the cases, I need to make some assumptions what mostly would be the case.
+    - When you extend a base class with the same name, you intend to "replace" it, otherwise you would rename it.
+    - When you extend a base class multiple times (what you do with different names) then you intend to "replace" it.
+    - Exception for the two cases above: When you extended the class it in the same model but another topic (because if you intent to "replace" it, you would have made it ABSTRACT)
+
+    This is tested with three use cases:
+    - Polymorphic_Ortsplanung_V1_1 containing several topics extending the same class
+    - Staedtische_Ortsplanung_V1_1 containing several extention levels on the same class
+    - Bauplanung_V1_1 containing structures and extending assocciations
+    """
+
+    def test_extopt_staedtische_postgis(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Staedtische_Ortsplanung_V1_1"
+        importer.configuration.dbschema = (
+            "optimal_staedtische_{:%Y%m%d%H%M%S%f}".format(datetime.datetime.now())
+        )
+
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2pg,
+            uri=get_pg_connection_string(),
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_staedtische_none(generator, strategy)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2pg,
+            uri=get_pg_connection_string(),
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_staedtische_hide(generator, strategy)
+
+    def test_extopt_staedtische_geopackage(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Staedtische_Ortsplanung_V1_1"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "tmp_optimal_staedtische_{:%Y%m%d%H%M%S%f}.gpkg".format(
+                datetime.datetime.now()
+            ),
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2gpkg,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+            consider_basket_handling=True,
+        )
+
+        self._extopt_staedtische_none(generator, strategy, True)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2gpkg,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+            consider_basket_handling=True,
+        )
+
+        self._extopt_staedtische_hide(generator, strategy, True)
+
+    def test_extopt_staedtische_mssql(self):
+
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2mssql
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Staedtische_Ortsplanung_V1_1"
+        importer.configuration.dbschema = (
+            "optimal_staedtische_{:%Y%m%d%H%M%S%f}".format(datetime.datetime.now())
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+
+        uri = "DRIVER={drv};SERVER={server};DATABASE={db};UID={uid};PWD={pwd}".format(
+            drv="{ODBC Driver 17 for SQL Server}",
+            server=importer.configuration.dbhost,
+            db=importer.configuration.database,
+            uid=importer.configuration.dbusr,
+            pwd=importer.configuration.dbpwd,
+        )
+
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2mssql,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_staedtische_none(generator, strategy, True)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2mssql,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_staedtische_hide(generator, strategy, True)
+
+    def _extopt_staedtische_none(self, generator, strategy, not_pg=False):
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        aliases = [l.alias for l in available_layers if l.alias is not None]
+        ambiguous_aliases = [alias for alias in aliases if aliases.count(alias) > 1]
+        # check no ambiguous layers exists
+        assert len(ambiguous_aliases) == 0
+
+        # check the layers - strategy should not have influence here
+        expected_aliases = [
+            "Strasse",
+            "Gebaeude",
+            "Gebaeude_StadtFirma",
+            "BesitzerIn" "Firma",
+        ]
+        assert set(aliases) == set(expected_aliases)
+
+        # check relevant topics
+        count = 0
+        for layer in available_layers:
+            # Strasse from Infrastruktur_V1
+            if layer.alias == "Strasse":
+                count += 1
+                assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
+            # BesitzerIn from Ortsplanung_V1_1
+            if layer.alias == "BesitzerIn":
+                count += 1
+                assert set(layer.all_topics) == {
+                    "Kantonale_Ortsplanung_V1_1.Konstruktionen",
+                    "Staedtische_Ortsplanung_V1_1.Freizeit",
+                    "Staedtische_Ortsplanung_V1_1.Gewerbe",
+                    "Ortsplanung_V1_1.Konstruktionen",
+                }
+                assert set(layer.relevant_topics) == {
+                    "Staedtische_Ortsplanung_V1_1.Freizeit",
+                    "Staedtische_Ortsplanung_V1_1.Gewerbe",
+                }
+            # Firma from Staedtisches_Gewerbe_V1 and Gewerbe_V1
+            if layer.alias == "Firma":
+                count += 1
+                assert set(layer.all_topics) == {
+                    "Staedtisches_Gewerbe_V1.Firmen",
+                    "Gewerbe_V1.Firmen",
+                }
+                assert set(layer.relevant_topics) == {
+                    "Staedtisches_Gewerbe_V1.Firmen",
+                    "Gewerbe_V1.Firmen",
+                }
+        assert count == 3
+
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # check layertree
+        root = qgis_project.layerTreeRoot()
+        assert root is not None
+
+        all_layers = root.findLayers()
+        assert len(all_layers) == 7
+
+        geometry_layers = {
+            l.name() for l in root.children() if isinstance(l, QgsLayerTreeLayer)
+        }
+        assert geometry_layers == {"Strasse", "Gebaeude"}
+
+        tables_layers = {l.name() for l in root.findGroup("tables").children()}
+        assert tables_layers == {
+            "Firma",
+            "Gebaeude_StadtFirma",
+            "BesitzerIn",
+        }
+
+        # check relations - all are there
+        relations = list(qgis_project.relationManager().relations().values())
+        assert len(relations) == 10
+
+        # strasse should have relation editors to only one layer (that sums up all the possibilities)
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                efc = layer.layer.editFormConfig()
+                # one general and four relation editors
+                assert len(efc.tabs()) == 2
+                for tab in efc.tabs():
+                    if tab.name() == "gebaeude":
+                        count += 1
+                        assert len(tab.children()) == 1
+        # should find 1
+        assert count == 1
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of topics Ortsplanung_V1_1.Konstruktionen, Kantonale_Ortsplanung_V1_1.Konstruktionen, Staedtische_Ortsplanung_V1_1.Freizeit, Staedtische_Ortsplanung_V1_1.Gewerbe)
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
+
+                # have look at the basket field
+                fields = layer.layer.fields()
+                field_idx = (
+                    fields.lookupField("T_basket")
+                    if not_pg
+                    else fields.lookupField("t_basket")
+                )
+                t_basket_field = fields.field(field_idx)
+
+                # check filter in widget
+                ews = t_basket_field.editorWidgetSetup()
+                map = ews.config()
+                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "Kantonale_Ortsplanung_V1_1.Konstruktionen,Ortsplanung_V1_1.Konstruktionen,Staedtische_Ortsplanung_V1_1.Freizeit,Staedtische_Ortsplanung_V1_1.Gewerbe"
+                )
+
+                # have look at the basket field
+                fields = layer.layer.fields()
+                field_idx = (
+                    fields.lookupField("T_basket")
+                    if not_pg
+                    else fields.lookupField("t_basket")
+                )
+                t_basket_field = fields.field(field_idx)
+
+                # check filter in widget
+                ews = t_basket_field.editorWidgetSetup()
+                map = ews.config()
+                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Kantonale_Ortsplanung_V1_1.Konstruktionen','Ortsplanung_V1_1.Konstruktionen','Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_kantonale_ortsplanung_v1_1_konstruktionen_ortsplanung_v1_1_konstruktionen_staedtische_ortsplanung_v1_1_freizeit_staedtische_ortsplanung_v1_1_gewerbe"
+                )
+
+        # should find 2
+        assert count == 2
+
+        # Strasse should not have a t_type column
+        # Gebaeude should have a t_type with all possible entries
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
+
+                assert not value_map
+
+            if layer.layer.name() == "Gebaeude":
+                count += 1
+
+                assert value_map
+
+                expected_entries = {
+                    "gebaeude",
+                    "stadtscng_v1_1freizeit_gebaeude",
+                    "kantnl_ng_v1_1konstruktionen_gebaeude",
+                    "stadtscng_v1_1gewerbe_gebaeude",
+                }
+                entries = {next(iter(entry)) for entry in value_map["map"]}
+
+                assert entries == expected_entries
+
+        # should find 2
+        assert count == 2
+
+        QgsProject.instance().clear()
+
+    def _extopt_staedtische_hide(self, generator, strategy, not_pg=False):
+        # to do in next step
+        return
+
+    def test_extopt_polymorphic_postgis(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Polymorphic_Ortsplanung_V1_1"
+        importer.configuration.dbschema = "optimal_polymorph_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2pg,
+            uri=get_pg_connection_string(),
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_polymorphic_none(generator, strategy)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2pg,
+            uri=get_pg_connection_string(),
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_polymorphic_hide(generator, strategy)
+
+    def test_extopt_polymorphic_geopackage(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Polymorphic_Ortsplanung_V1_1"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "tmp_optimal_polymorph_{:%Y%m%d%H%M%S%f}.gpkg".format(
+                datetime.datetime.now()
+            ),
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2gpkg,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+            consider_basket_handling=True,
+        )
+
+        self._extopt_polymorphic_none(generator, strategy, True)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2gpkg,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+            consider_basket_handling=True,
+        )
+
+        self._extopt_polymorphic_hide(generator, strategy, True)
+
+    def test_extopt_polymorphic_mssql(self):
+
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2mssql
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Polymorphic_Ortsplanung_V1_1"
+        importer.configuration.dbschema = "optimal_polymorph_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+
+        uri = "DRIVER={drv};SERVER={server};DATABASE={db};UID={uid};PWD={pwd}".format(
+            drv="{ODBC Driver 17 for SQL Server}",
+            server=importer.configuration.dbhost,
+            db=importer.configuration.database,
+            uid=importer.configuration.dbusr,
+            pwd=importer.configuration.dbpwd,
+        )
+
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2mssql,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_polymorphic_none(generator, strategy, True)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2mssql,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_polymorphic_hide(generator, strategy, True)
+
+    def _extopt_polymorphic_none(self, generator, strategy, not_pg=False):
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        aliases = [l.alias for l in available_layers if l.alias is not None]
+        ambiguous_aliases = [alias for alias in aliases if aliases.count(alias) > 1]
+        # check no ambiguous layers exists
+        assert len(ambiguous_aliases) == 0
+
+        expected_aliases = [
+            "BesitzerIn",
+            "Markthalle",
+            "Ortsplanung_V1_1.Konstruktionen.Gebaeude",
+            "Polymorphic_Ortsplanung_V1_1.Konstruktionen.Gebaeude",
+            "Strasse",
+            "TurnhalleTyp1",
+            "TurnhalleTyp2",
+        ]
+        assert set(aliases) == set(expected_aliases)
+
+        # check relevant topics
+        count = 0
+        for layer in available_layers:
+            # Strasse from Infrastruktur_V1
+            if layer.alias == "Strasse":
+                count += 1
+                assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
+            # BesitzerIn from Ortsplanung_V1_1
+            if layer.alias == "BesitzerIn":
+                count += 1
+                assert set(layer.all_topics) == {
+                    "Polymorphic_Ortsplanung_V1_1.Gewerbe",
+                    "Polymorphic_Ortsplanung_V1_1.Freizeit",
+                    "Polymorphic_Ortsplanung_V1_1.Hallen",
+                    "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                    "Ortsplanung_V1_1.Konstruktionen",
+                }
+                assert set(layer.relevant_topics) == {
+                    "Polymorphic_Ortsplanung_V1_1.Gewerbe",
+                    "Polymorphic_Ortsplanung_V1_1.Freizeit",
+                    "Polymorphic_Ortsplanung_V1_1.Hallen",
+                    "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                }
+            # Gebaeude from Ortsplanung_V1_1
+            if layer.alias == "Ortsplanung_V1_1.Konstruktionen.Gebaeude":
+                count += 1
+                assert set(layer.all_topics) == {
+                    "Polymorphic_Ortsplanung_V1_1.Gewerbe",
+                    "Polymorphic_Ortsplanung_V1_1.Freizeit",
+                    "Polymorphic_Ortsplanung_V1_1.Hallen",
+                    "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                    "Ortsplanung_V1_1.Konstruktionen",
+                }
+                assert set(layer.relevant_topics) == {
+                    "Polymorphic_Ortsplanung_V1_1.Gewerbe",
+                    "Polymorphic_Ortsplanung_V1_1.Freizeit",
+                    "Polymorphic_Ortsplanung_V1_1.Hallen",
+                    "Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe",
+                }
+
+        assert count == 3
+
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # check layertree
+        root = qgis_project.layerTreeRoot()
+        assert root is not None
+
+        all_layers = root.findLayers()
+        assert len(all_layers) == 13
+
+        geometry_layers = {
+            l.name() for l in root.children() if isinstance(l, QgsLayerTreeLayer)
+        }
+        assert geometry_layers == {
+            "Strasse",
+            "Ortsplanung_V1_1.Konstruktionen.Gebaeude",
+        }
+
+        tables_layers = {l.name() for l in root.findGroup("tables").children()}
+        assert tables_layers == {
+            "Polymorphic_Ortsplanung_V1_1.Konstruktionen.Gebaeude",
+            "BesitzerIn",
+            "TurnhalleTyp1",
+            "TurnhalleTyp2",
+        }
+
+        # check relations - all are there
+        relations = list(qgis_project.relationManager().relations().values())
+        assert len(relations) == 11
+
+        # strasse should have relation editors only to gebaeude (1)
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                efc = layer.layer.editFormConfig()
+                # one general and four relation editors
+                assert len(efc.tabs()) == 2
+                for tab in efc.tabs():
+                    if tab.name() == "gebaeude":
+                        count += 1
+                        assert len(tab.children()) == 1
+        # should find 1
+        assert count == 1
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # besitzerin can be in multiple baskets (instances of topics 'Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe','Ortsplanung_V1_1.Konstruktionen')
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
+
+                # have look at the basket field
+                fields = layer.layer.fields()
+                field_idx = (
+                    fields.lookupField("T_basket")
+                    if not_pg
+                    else fields.lookupField("t_basket")
+                )
+                t_basket_field = fields.field(field_idx)
+
+                # check filter in widget
+                ews = t_basket_field.editorWidgetSetup()
+                map = ews.config()
+                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+            if layer.layer.name() == "BesitzerIn":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert (
+                    layer_model_topic_names
+                    == "Ortsplanung_V1_1.Konstruktionen,Polymorphic_Ortsplanung_V1_1.Freizeit,Polymorphic_Ortsplanung_V1_1.Gewerbe,Polymorphic_Ortsplanung_V1_1.Hallen,Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe"
+                )
+
+                # have look at the basket field
+                fields = layer.layer.fields()
+                field_idx = (
+                    fields.lookupField("T_basket")
+                    if not_pg
+                    else fields.lookupField("t_basket")
+                )
+                t_basket_field = fields.field(field_idx)
+
+                # check filter in widget
+                ews = t_basket_field.editorWidgetSetup()
+                map = ews.config()
+                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Ortsplanung_V1_1.Konstruktionen','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_ortsplanung_v1_1_konstruktionen_polymorphic_ortsplanung_v1_1_freizeit_polymorphic_ortsplanung_v1_1_gewerbe_polymorphic_ortsplanung_v1_1_hallen_polymorphic_ortsplanung_v1_1_industriegewerbe"
+                )
+
+        # should find 2
+        assert count == 2
+
+        # Strasse should not have a t_type column
+        # Ortsplanung_V1_1.Konstruktionen.Gebaeude should have a t_type with all possible entries
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
+
+                assert not value_map
+
+            if layer.layer.name() == "Ortsplanung_V1_1.Konstruktionen.Gebaeude":
+                count += 1
+
+                assert value_map
+
+                expected_entries = {
+                    "polymrpng_v1_1hallen_gebaeude",
+                    "turnhalletyp2",
+                    "polymrpng_v1_1gewerbe_gebaeude",
+                    "polymrpng_v1_1industriegewerbe_gebaeude",
+                    "turnhalletyp1",
+                    "gebaeude",
+                    "markthalle",
+                    "polymrpng_v1_1freizeit_gebaeude",
+                }
+                entries = {next(iter(entry)) for entry in value_map["map"]}
+
+                assert entries == expected_entries
+
+        # should find 2
+        assert count == 2
+
+        QgsProject.instance().clear()
+
+    def _extopt_polymorphic_hide(self, generator, strategy, not_pg=False):
+        # to do in next step
+        return
+
+    def test_extopt_baustruct_postgis(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Kantonale_Bauplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Kantonale_Bauplanung_V1_1"
+        importer.configuration.dbschema = "optimal_baustruct_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2pg,
+            uri=get_pg_connection_string(),
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_baustruct_none(generator, strategy)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2pg,
+            uri=get_pg_connection_string(),
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_baustruct_hide(generator, strategy)
+
+    def test_extopt_baustruct_geopackage(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Kantonale_Bauplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Kantonale_Bauplanung_V1_1"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "tmp_optimal_baustruct_{:%Y%m%d%H%M%S%f}.gpkg".format(
+                datetime.datetime.now()
+            ),
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2gpkg,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+            consider_basket_handling=True,
+        )
+
+        self._extopt_baustruct_none(generator, strategy, True)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2gpkg,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            optimize_strategy=strategy,
+            consider_basket_handling=True,
+        )
+
+        self._extopt_baustruct_hide(generator, strategy, True)
+
+    def test_extopt_baustruct_mssql(self):
+
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2mssql
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path(
+            "ilimodels/Kantonale_Bauplanung_V1_1.ili"
+        )
+        importer.configuration.ilimodels = "Kantonale_Bauplanung_V1_1"
+        importer.configuration.dbschema = "optimal_polymorph_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.srs_code = 2056
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+
+        uri = "DRIVER={drv};SERVER={server};DATABASE={db};UID={uid};PWD={pwd}".format(
+            drv="{ODBC Driver 17 for SQL Server}",
+            server=importer.configuration.dbhost,
+            db=importer.configuration.database,
+            uid=importer.configuration.dbusr,
+            pwd=importer.configuration.dbpwd,
+        )
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        ### 1. OptimizeStrategy.NONE ###
+        strategy = OptimizeStrategy.NONE
+
+        generator = Generator(
+            tool=DbIliMode.ili2mssql,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_baustruct_none(generator, strategy, True)
+
+        ### 2. OptimizeStrategy.HIDE ###
+        strategy = OptimizeStrategy.HIDE
+
+        generator = Generator(
+            tool=DbIliMode.ili2mssql,
+            uri=uri,
+            inheritance=importer.configuration.inheritance,
+            schema=importer.configuration.dbschema,
+            consider_basket_handling=True,
+            optimize_strategy=strategy,
+        )
+
+        self._extopt_baustruct_hide(generator, strategy, True)
+
+    def _extopt_baustruct_none(self, generator, strategy, not_pg=False):
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+        legend = generator.legend(available_layers)
+
+        aliases = [l.alias for l in available_layers if l.alias is not None]
+        ambiguous_aliases = [alias for alias in aliases if aliases.count(alias) > 1]
+        # check no ambiguous layers exists
+        assert len(ambiguous_aliases) == 0
+
+        expected_aliases = [
+            "Strasse",
+            "Feld",
+            "Buntbrache",
+            "Park",
+            "Gebaeude",
+            "Buntbrache",
+            "Brutstelle",
+            "Tierart",
+            "Strassen_Gebaeude",
+            "Material",
+            "Bauart",
+        ]
+        assert set(aliases) == set(expected_aliases)
+
+        # check relevant topics
+        count = 0
+        for layer in available_layers:
+            # Strasse from Infrastruktur_V1
+            if layer.alias == "Strasse":
+                count += 1
+                assert layer.all_topics == ["Infrastruktur_V1.Strassen"]
+                assert layer.relevant_topics == ["Infrastruktur_V1.Strassen"]
+            # Park from Bauplanung_V1_1 and Kantonale_Bauplanung_V1_1
+            if layer.alias == "Park":
+                count += 1
+                assert set(layer.all_topics) == {
+                    "Bauplanung_V1_1.Natur",
+                    "Kantonale_Bauplanung_V1_1.Natur",
+                }
+                assert set(layer.relevant_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+            # Feld from Bauplanung_V1_1
+            if layer.alias == "Feld":
+                count += 1
+                assert set(layer.all_topics) == {
+                    "Bauplanung_V1_1.Natur",
+                    "Kantonale_Bauplanung_V1_1.Natur",
+                }
+                assert set(layer.relevant_topics) == {"Kantonale_Bauplanung_V1_1.Natur"}
+        assert count == 3
+
+        project = Project(
+            optimize_strategy=strategy,
+            context={"catalogue_datasetname": CATALOGUE_DATASETNAME},
+        )
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # check layertree
+        root = qgis_project.layerTreeRoot()
+        assert root is not None
+
+        all_layers = root.findLayers()
+        assert len(all_layers) == 12
+
+        geometry_layers = {
+            l.name() for l in root.children() if isinstance(l, QgsLayerTreeLayer)
+        }
+        assert geometry_layers == {
+            "Strasse",
+            "Feld",
+            "Buntbrache",
+            "Brutstelle",
+            "Park",
+            "Gebaeude",
+        }
+
+        tables_layers = {l.name() for l in root.findGroup("tables").children()}
+        assert tables_layers == {
+            "Bauart",
+            "Strassen_Gebaeude",
+            "Tierart",
+            "Material",
+        }
+
+        # check relations - all are there
+        relations = list(qgis_project.relationManager().relations().values())
+        assert len(relations) == 18
+
+        # strasse should have relation editors to one layer (gebaeude) (1)
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                efc = layer.layer.editFormConfig()
+                # one general and four relation editors
+                assert len(efc.tabs()) == 2
+                for tab in efc.tabs():
+                    if tab.name() == "gebaeude":
+                        count += 1
+                        assert len(tab.children()) == 1
+        # should find 1 (one times gebaeude)
+        assert count == 1
+
+        # strasse can only be in it's dedicated basket (only instance of topic Infrastruktur_V1.Strassen)
+        # no special cases with multi basket layers...
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+
+                # check layer variable
+                layer_model_topic_names = (
+                    QgsExpressionContextUtils.layerScope(layer.layer).variable(
+                        "interlis_topic"
+                    )
+                    or ""
+                )
+
+                assert layer_model_topic_names == "Infrastruktur_V1.Strassen"
+
+                # have look at the basket field
+                fields = layer.layer.fields()
+                field_idx = (
+                    fields.lookupField("T_basket")
+                    if not_pg
+                    else fields.lookupField("t_basket")
+                )
+                t_basket_field = fields.field(field_idx)
+
+                # check filter in widget
+                ews = t_basket_field.editorWidgetSetup()
+                map = ews.config()
+                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+                assert (
+                    map["FilterExpression"]
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                )
+
+                # check default value expression
+                default_value_definition = t_basket_field.defaultValueDefinition()
+                assert default_value_definition is not None
+                assert (
+                    default_value_definition.expression()
+                    == "@default_basket_infrastruktur_v1_strassen"
+                )
+
+        # should find 1
+        assert count == 1
+
+        # Strasse should not have a t_type column
+        # Gebaeude should have a t_type with all possible entries
+        # Buntbrache should have a t_type with all possible entries
+        # Feld should have a t_type with all possible entries
+        count = 0
+        for layer in project.layers:
+            if layer.layer.name() == "Strasse":
+                count += 1
+                value_map = layer.layer.editFormConfig().widgetConfig(
+                    "T_Type" if not_pg else "t_type"
+                )
+
+                assert not value_map
+
+            if layer.layer.name() == "Gebaeude":
+                count += 1
+
+                assert value_map
+
+                expected_entries = {"gebaeude", "kantnl_ng_v1_1konstruktionen_gebaeude"}
+                entries = {next(iter(entry)) for entry in value_map["map"]}
+
+                assert entries == expected_entries
+
+            if layer.layer.name() == "Buntbrache":
+                count += 1
+
+                assert value_map
+
+                expected_entries = {"buntbrache", "kantonalebuntbrache"}
+                entries = {next(iter(entry)) for entry in value_map["map"]}
+
+                assert entries == expected_entries
+
+            if layer.layer.name() == "Feld":
+                count += 1
+
+                assert value_map
+
+                expected_entries = {"feld", "sonnenblumenfeld", "kartoffelfeld"}
+                entries = {next(iter(entry)) for entry in value_map["map"]}
+
+                assert entries == expected_entries
+
+        # should find 4
+        assert count == 4
+
+        QgsProject.instance().clear()
+
+    def _extopt_baustruct_hide(self, generator, strategy, not_pg=False):
+        # to do in next step
+        return
+
+    def print_info(self, text):
+        logging.info(text)
+
+    def print_error(self, text):
+        logging.error(text)
+
+    def tearDown(self):
+        QgsProject.instance().removeAllMapLayers()

--- a/tests/test_projectgen_extension_optimization_smart2.py
+++ b/tests/test_projectgen_extension_optimization_smart2.py
@@ -41,7 +41,7 @@ start_app()
 test_path = pathlib.Path(__file__).parent.absolute()
 
 
-class TestProjectExtOptimization(unittest.TestCase):
+class TestProjectExtOptimizationSmart2(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Run before all tests."""

--- a/tests/test_projectgen_extension_optimization_smart2.py
+++ b/tests/test_projectgen_extension_optimization_smart2.py
@@ -67,6 +67,8 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
     """
 
     def test_extopt_staedtische_postgis(self):
+        self._set_pg_naming()
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool)
@@ -128,6 +130,8 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
         self._extopt_staedtische_hide(generator, strategy)
 
     def test_extopt_staedtische_geopackage(self):
+        self._set_pg_naming(False)
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
         importer.configuration = iliimporter_config(importer.tool)
@@ -162,7 +166,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_staedtische_none(generator, strategy, True)
+        self._extopt_staedtische_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -175,7 +179,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_staedtische_group(generator, strategy, True)
+        self._extopt_staedtische_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -188,9 +192,10 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_staedtische_hide(generator, strategy, True)
+        self._extopt_staedtische_hide(generator, strategy)
 
     def test_extopt_staedtische_mssql(self):
+        self._set_pg_naming(False)
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
@@ -230,7 +235,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_staedtische_none(generator, strategy, True)
+        self._extopt_staedtische_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -244,7 +249,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_staedtische_group(generator, strategy, True)
+        self._extopt_staedtische_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -258,9 +263,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_staedtische_hide(generator, strategy, True)
+        self._extopt_staedtische_hide(generator, strategy)
 
-    def _extopt_staedtische_none(self, generator, strategy, not_pg=False):
+    def _extopt_staedtische_none(self, generator, strategy):
 
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
@@ -415,20 +420,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -457,20 +458,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Kantonale_Ortsplanung_V1_1.Konstruktionen','Ortsplanung_V1_1.Konstruktionen','Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Kantonale_Ortsplanung_V1_1.Konstruktionen','Ortsplanung_V1_1.Konstruktionen','Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -486,7 +483,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         QgsProject.instance().clear()
 
-    def _extopt_staedtische_group(self, generator, strategy, not_pg=False):
+    def _extopt_staedtische_group(self, generator, strategy):
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
         legend = generator.legend(available_layers)
@@ -647,20 +644,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -689,20 +682,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -715,7 +704,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         QgsProject.instance().clear()
 
-    def _extopt_staedtische_hide(self, generator, strategy, not_pg=False):
+    def _extopt_staedtische_hide(self, generator, strategy):
 
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
@@ -850,20 +839,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -892,20 +877,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Staedtische_Ortsplanung_V1_1.Freizeit','Staedtische_Ortsplanung_V1_1.Gewerbe') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -922,6 +903,8 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
         QgsProject.instance().clear()
 
     def test_extopt_polymorphic_postgis(self):
+        self._set_pg_naming()
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool)
@@ -983,6 +966,8 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
         self._extopt_polymorphic_hide(generator, strategy)
 
     def test_extopt_polymorphic_geopackage(self):
+        self._set_pg_naming(False)
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
         importer.configuration = iliimporter_config(importer.tool)
@@ -1017,7 +1002,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_polymorphic_none(generator, strategy, True)
+        self._extopt_polymorphic_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -1030,7 +1015,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_polymorphic_group(generator, strategy, True)
+        self._extopt_polymorphic_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -1043,9 +1028,10 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_polymorphic_hide(generator, strategy, True)
+        self._extopt_polymorphic_hide(generator, strategy)
 
     def test_extopt_polymorphic_mssql(self):
+        self._set_pg_naming(False)
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
@@ -1085,7 +1071,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_polymorphic_none(generator, strategy, True)
+        self._extopt_polymorphic_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -1099,7 +1085,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_polymorphic_group(generator, strategy, True)
+        self._extopt_polymorphic_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -1113,9 +1099,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_polymorphic_hide(generator, strategy, True)
+        self._extopt_polymorphic_hide(generator, strategy)
 
-    def _extopt_polymorphic_none(self, generator, strategy, not_pg=False):
+    def _extopt_polymorphic_none(self, generator, strategy):
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
         legend = generator.legend(available_layers)
@@ -1310,20 +1296,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -1352,20 +1334,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Ortsplanung_V1_1.Konstruktionen','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Ortsplanung_V1_1.Konstruktionen','Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -1381,7 +1359,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         QgsProject.instance().clear()
 
-    def _extopt_polymorphic_group(self, generator, strategy, not_pg=False):
+    def _extopt_polymorphic_group(self, generator, strategy):
 
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
@@ -1585,20 +1563,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -1627,20 +1601,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -1656,7 +1626,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         QgsProject.instance().clear()
 
-    def _extopt_polymorphic_hide(self, generator, strategy, not_pg=False):
+    def _extopt_polymorphic_hide(self, generator, strategy):
 
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
@@ -1840,20 +1810,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -1882,20 +1848,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Polymorphic_Ortsplanung_V1_1.Freizeit','Polymorphic_Ortsplanung_V1_1.Gewerbe','Polymorphic_Ortsplanung_V1_1.Hallen','Polymorphic_Ortsplanung_V1_1.IndustrieGewerbe') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -1912,6 +1874,8 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
         QgsProject.instance().clear()
 
     def test_extopt_baustruct_postgis(self):
+        self._set_pg_naming()
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool)
@@ -1972,6 +1936,8 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
         self._extopt_baustruct_hide(generator, strategy)
 
     def test_extopt_baustruct_geopackage(self):
+        self._set_pg_naming(False)
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
         importer.configuration = iliimporter_config(importer.tool)
@@ -2006,7 +1972,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_baustruct_none(generator, strategy, True)
+        self._extopt_baustruct_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -2019,7 +1985,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_baustruct_group(generator, strategy, True)
+        self._extopt_baustruct_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -2032,9 +1998,10 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._extopt_baustruct_hide(generator, strategy, True)
+        self._extopt_baustruct_hide(generator, strategy)
 
     def test_extopt_baustruct_mssql(self):
+        self._set_pg_naming(False)
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
@@ -2073,7 +2040,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_baustruct_none(generator, strategy, True)
+        self._extopt_baustruct_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -2087,7 +2054,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_baustruct_group(generator, strategy, True)
+        self._extopt_baustruct_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -2101,9 +2068,9 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._extopt_baustruct_hide(generator, strategy, True)
+        self._extopt_baustruct_hide(generator, strategy)
 
-    def _extopt_baustruct_none(self, generator, strategy, not_pg=False):
+    def _extopt_baustruct_none(self, generator, strategy):
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
         legend = generator.legend(available_layers)
@@ -2273,20 +2240,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -2302,7 +2265,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         QgsProject.instance().clear()
 
-    def _extopt_baustruct_group(self, generator, strategy, not_pg=False):
+    def _extopt_baustruct_group(self, generator, strategy):
 
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
@@ -2496,20 +2459,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -2525,7 +2484,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         QgsProject.instance().clear()
 
-    def _extopt_baustruct_hide(self, generator, strategy, not_pg=False):
+    def _extopt_baustruct_hide(self, generator, strategy):
 
         available_layers = generator.layers()
         relations, _ = generator.relations(available_layers)
@@ -2682,20 +2641,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
                 # have look at the basket field
                 fields = layer.layer.fields()
-                field_idx = (
-                    fields.lookupField("T_basket")
-                    if not_pg
-                    else fields.lookupField("t_basket")
-                )
+                field_idx = fields.lookupField(self.basket_fieldname)
                 t_basket_field = fields.field(field_idx)
 
                 # check filter in widget
                 ews = t_basket_field.editorWidgetSetup()
                 map = ews.config()
-                dataset_table = "T_ILI2DB_DATASET" if not_pg else "t_ili2db_dataset"
+
                 assert (
                     map["FilterExpression"]
-                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{dataset_table}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
+                    == f"\"topic\" IN ('Infrastruktur_V1.Strassen') and attribute(get_feature('{self.dataset_tablename}', 't_id', \"dataset\"), 'datasetname') != '{CATALOGUE_DATASETNAME}'"
                 )
 
                 # check default value expression
@@ -2710,6 +2665,16 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
         assert count == 1
 
         QgsProject.instance().clear()
+
+    def _set_pg_naming(self, is_pg=True):
+        if is_pg:
+            self.dataset_tablename = "t_ili2db_dataset"
+            self.basket_fieldname = "t_basket"
+            self.type_fieldname = "t_type"
+        else:
+            self.dataset_tablename = "T_ILI2DB_DATASET"
+            self.basket_fieldname = "T_basket"
+            self.type_fieldname = "T_Type"
 
     def print_info(self, text):
         logging.info(text)

--- a/tests/test_projectgen_oids.py
+++ b/tests/test_projectgen_oids.py
@@ -62,6 +62,8 @@ class TestProjectOIDs(unittest.TestCase):
     """
 
     def test_oids_tids_postgis(self):
+        self._set_pg_naming()
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool)
@@ -121,6 +123,8 @@ class TestProjectOIDs(unittest.TestCase):
         self._oids_tids_hide(generator, strategy)
 
     def test_oids_tids_geopackage(self):
+        self._set_pg_naming(False)
+
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
         importer.configuration = iliimporter_config(importer.tool)
@@ -153,7 +157,7 @@ class TestProjectOIDs(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._oids_tids_none(generator, strategy, True)
+        self._oids_tids_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -166,7 +170,7 @@ class TestProjectOIDs(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._oids_tids_group(generator, strategy, True)
+        self._oids_tids_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -179,9 +183,10 @@ class TestProjectOIDs(unittest.TestCase):
             consider_basket_handling=True,
         )
 
-        self._oids_tids_hide(generator, strategy, True)
+        self._oids_tids_hide(generator, strategy)
 
     def test_oids_tids_mssql(self):
+        self._set_pg_naming(False)
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
@@ -219,7 +224,7 @@ class TestProjectOIDs(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._oids_tids_none(generator, strategy, True)
+        self._oids_tids_none(generator, strategy)
 
         ### 2. OptimizeStrategy.GROUP ###
         strategy = OptimizeStrategy.GROUP
@@ -233,7 +238,7 @@ class TestProjectOIDs(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._oids_tids_group(generator, strategy, True)
+        self._oids_tids_group(generator, strategy)
 
         ### 3. OptimizeStrategy.HIDE ###
         strategy = OptimizeStrategy.HIDE
@@ -247,9 +252,9 @@ class TestProjectOIDs(unittest.TestCase):
             optimize_strategy=strategy,
         )
 
-        self._oids_tids_hide(generator, strategy, True)
+        self._oids_tids_hide(generator, strategy)
 
-    def _oids_tids_none(self, generator, strategy, not_pg=False):
+    def _oids_tids_none(self, generator, strategy):
 
         project = Project(
             optimize_strategy=strategy,
@@ -268,11 +273,12 @@ class TestProjectOIDs(unittest.TestCase):
         project.create(None, qgis_project)
 
         # values
-        t_id_name = "T_Id" if not_pg else "t_id"
-        t_ili_tid_name = "T_Ili_Tid" if not_pg else "t_ili_tid"
+
         expected_uuid_expression = "uuid('WithoutBraces')"
-        expected_i32_expression = t_id_name
-        expected_standard_expression = f"'ch100000' || lpad( {t_id_name}, 8, 0 )"
+        expected_i32_expression = self.tid_fieldname
+        expected_standard_expression = (
+            f"'ch100000' || lpad( {self.tid_fieldname}, 8, 0 )"
+        )
         expected_other_expression = "'_' || uuid('WithoutBraces')"
 
         # check layertree
@@ -301,7 +307,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -323,7 +329,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -349,7 +355,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -374,7 +380,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -397,7 +403,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -420,7 +426,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -439,7 +445,7 @@ class TestProjectOIDs(unittest.TestCase):
         # change expression of Parkplatz
         oid_settings["Parkplatz"][
             "default_value_expression"
-        ] = f"'chMBaker' || lpad( {t_id_name}, 8, 0 )"
+        ] = f"'chMBaker' || lpad( {self.tid_fieldname}, 8, 0 )"
         # change expression of See
         oid_settings["See"][
             "default_value_expression"
@@ -462,20 +468,20 @@ class TestProjectOIDs(unittest.TestCase):
             if tree_layer.layer().name() == "Parkplatz":
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression()
-                    == f"'chMBaker' || lpad( {t_id_name}, 8, 0 )"
+                    == f"'chMBaker' || lpad( {self.tid_fieldname}, 8, 0 )"
                 )
                 count += 1
             if tree_layer.layer().name() == "See":
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -508,7 +514,7 @@ class TestProjectOIDs(unittest.TestCase):
 
         QgsProject.instance().clear()
 
-    def _oids_tids_group(self, generator, strategy, not_pg=False):
+    def _oids_tids_group(self, generator, strategy):
 
         project = Project(
             optimize_strategy=strategy,
@@ -533,11 +539,11 @@ class TestProjectOIDs(unittest.TestCase):
         tree_layers = root.findLayers()
         assert len(tree_layers) == 17
 
-        t_id_name = "T_Id" if not_pg else "t_id"
-        t_ili_tid_name = "T_Ili_Tid" if not_pg else "t_ili_tid"
         expected_uuid_expression = "uuid('WithoutBraces')"
-        expected_i32_expression = t_id_name
-        expected_standard_expression = f"'ch100000' || lpad( {t_id_name}, 8, 0 )"
+        expected_i32_expression = self.tid_fieldname
+        expected_standard_expression = (
+            f"'ch100000' || lpad( {self.tid_fieldname}, 8, 0 )"
+        )
         expected_other_expression = "'_' || uuid('WithoutBraces')"
 
         count = 0
@@ -559,7 +565,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -581,7 +587,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -607,7 +613,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -632,7 +638,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -655,7 +661,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -678,7 +684,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -697,7 +703,7 @@ class TestProjectOIDs(unittest.TestCase):
         # change expression of Parkplatz
         oid_settings["Parkplatz"][
             "default_value_expression"
-        ] = f"'chMBaker' || lpad( {t_id_name}, 8, 0 )"
+        ] = f"'chMBaker' || lpad( {self.tid_fieldname}, 8, 0 )"
         # change expression of See
         oid_settings["See"][
             "default_value_expression"
@@ -720,20 +726,20 @@ class TestProjectOIDs(unittest.TestCase):
             if tree_layer.layer().name() == "Parkplatz":
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression()
-                    == f"'chMBaker' || lpad( {t_id_name}, 8, 0 )"
+                    == f"'chMBaker' || lpad( {self.tid_fieldname}, 8, 0 )"
                 )
                 count += 1
             if tree_layer.layer().name() == "See":
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -766,7 +772,7 @@ class TestProjectOIDs(unittest.TestCase):
         assert count == 3
         QgsProject.instance().clear()
 
-    def _oids_tids_hide(self, generator, strategy, not_pg=False):
+    def _oids_tids_hide(self, generator, strategy):
 
         project = Project(
             optimize_strategy=strategy,
@@ -791,11 +797,11 @@ class TestProjectOIDs(unittest.TestCase):
         tree_layers = root.findLayers()
         assert len(tree_layers) == 16
 
-        t_id_name = "T_Id" if not_pg else "t_id"
-        t_ili_tid_name = "T_Ili_Tid" if not_pg else "t_ili_tid"
         expected_uuid_expression = "uuid('WithoutBraces')"
-        expected_i32_expression = t_id_name
-        expected_standard_expression = f"'ch100000' || lpad( {t_id_name}, 8, 0 )"
+        expected_i32_expression = self.tid_fieldname
+        expected_standard_expression = (
+            f"'ch100000' || lpad( {self.tid_fieldname}, 8, 0 )"
+        )
         expected_other_expression = "'_' || uuid('WithoutBraces')"
 
         # "Wohnraum.Gebaeude" is hidden because of the strategy
@@ -818,7 +824,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -840,7 +846,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -862,7 +868,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -887,7 +893,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -910,7 +916,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -933,7 +939,7 @@ class TestProjectOIDs(unittest.TestCase):
 
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -952,7 +958,7 @@ class TestProjectOIDs(unittest.TestCase):
         # change expression of Parkplatz
         oid_settings["Parkplatz"][
             "default_value_expression"
-        ] = f"'chMBaker' || lpad( {t_id_name}, 8, 0 )"
+        ] = f"'chMBaker' || lpad( {self.tid_fieldname}, 8, 0 )"
         # change expression of See
         oid_settings["See"][
             "default_value_expression"
@@ -975,20 +981,20 @@ class TestProjectOIDs(unittest.TestCase):
             if tree_layer.layer().name() == "Parkplatz":
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression()
-                    == f"'chMBaker' || lpad( {t_id_name}, 8, 0 )"
+                    == f"'chMBaker' || lpad( {self.tid_fieldname}, 8, 0 )"
                 )
                 count += 1
             if tree_layer.layer().name() == "See":
                 # have look at the t_ili_tid field
                 fields = tree_layer.layer().fields()
-                field_idx = fields.lookupField(t_ili_tid_name)
+                field_idx = fields.lookupField(self.tilitid_fieldname)
                 t_ili_tid_field = fields.field(field_idx)
                 # check default value expression
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
@@ -1020,6 +1026,14 @@ class TestProjectOIDs(unittest.TestCase):
         assert count == 3
 
         QgsProject.instance().clear()
+
+    def _set_pg_naming(self, is_pg=True):
+        if is_pg:
+            self.tilitid_fieldname = "t_ili_tid"
+            self.tid_fieldname = "t_id"
+        else:
+            self.tilitid_fieldname = "T_Ili_Tid"
+            self.tid_fieldname = "T_Id"
 
     def print_info(self, text):
         logging.info(text)


### PR DESCRIPTION
### `t_type` Field

Get possible values for ` t_type` value relation for **gpkg** and **mssql**.

This is done over the `t_ili2db_column_prop` table, where  the values are provided for every system.

*With PG it used to parse the check constraint for that in `get_value_map_info`, not sure if this becomes obsolete now, but I keep it for the moment.*

Where this functionality is implemented https://github.com/claeis/ili2db/pull/241
Where it was implemented differently for pg https://github.com/opengisch/QgisModelBaker/pull/389
Where it has been discussed https://github.com/opengisch/QgisModelBaker/issues/134

And this here resolves https://github.com/opengisch/QgisModelBaker/issues/797

### Beautify naming

Since the value in `t_type` used to be an sql-table name describing the class (but neither an existing table (because it's not created with smart1) nor a proper ili-name), it's now displayed as the Ili-Element-name.

![image](https://github.com/opengisch/QgisModelBakerLibrary/assets/28384354/2d3bf3bc-4d25-4801-839f-3b8bcbf37a61)

### Optimize Strategy

With Smart1 a strategy named **GROUP** makes no sense: There is **HIDE** or **NONE**, while **HIDE** hides all the irrelevant values for `t_type` and provides only the relevant baskets.
