### PR TITLE
Smart1 optimization

### DIFF
--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -319,6 +319,12 @@ class DBConnector(QObject):
         """
         return {}
 
+    def get_irrelevant_tables(self):
+        """
+        Returns all irrelevant tables
+        """
+        return {}
+
     def create_basket(self, dataset_tid, topic, tilitid_value=None):
         """
         Returns the state and the errormessage

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -336,10 +336,13 @@ class Generator(QObject):
                         )
 
                 if column_name in value_map_info:
+                    irrelevant_tables = self.get_irrelevant_tables()
                     field.widget = "ValueMap"
-                    field.widget_config["map"] = [
-                        {val: val} for val in value_map_info[column_name]
-                    ]
+                    field.widget_config["map"] = []
+                    for val in value_map_info[column_name]:
+                        if val not in irrelevant_tables.values():
+                            field.widget_config["map"].append({val: val})
+                            field.default_value_expression = f"'{val}'"
 
                 if "attr_mapping" in fielddef and fielddef["attr_mapping"] == "ARRAY":
                     field.widget = "List"
@@ -890,3 +893,6 @@ class Generator(QObject):
 
     def get_basket_handling(self):
         return self._db_connector.get_basket_handling()
+
+    def get_irrelevant_tables(self):
+        return self._db_connector.get_irrelevant_tables()


### PR DESCRIPTION
Draft to remove irrelevant layers from t_type

- While we pack the tables relevance 
- [ ] pg and mssql part
- [ ] tests

Then we have to react according to the optimization (or do we remove the optimization selection)? At least we should have no-optimization and "hide unused base class layers" precice ... in t_type column or similar...

- [ ] don't hide or group the layers