### PR TITLE
Set unique and not-null constraint on defined OID domains

### DIFF
--- a/modelbaker/dataobjects/fields.py
+++ b/modelbaker/dataobjects/fields.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from qgis.core import QgsDefaultValue, QgsEditorWidgetSetup
+from qgis.core import QgsDefaultValue, QgsEditorWidgetSetup, QgsFieldConstraints
 
 if TYPE_CHECKING:
     from modelbaker.dataobjects.layers import Layer
@@ -61,3 +61,16 @@ class Field:
         if self.default_value_expression:
             default_value = QgsDefaultValue(self.default_value_expression)
             layer.layer.setDefaultValueDefinition(field_idx, default_value)
+
+        if self.oid_domain:
+            # if defined, then set not null and unique constraints
+            layer.layer.setFieldConstraint(
+                field_idx,
+                QgsFieldConstraints.ConstraintNotNull,
+                QgsFieldConstraints.ConstraintStrengthHard,
+            )
+            layer.layer.setFieldConstraint(
+                field_idx,
+                QgsFieldConstraints.ConstraintUnique,
+                QgsFieldConstraints.ConstraintStrengthHard,
+            )

--- a/tests/test_projectgen_oids.py
+++ b/tests/test_projectgen_oids.py
@@ -23,7 +23,7 @@ import os
 import pathlib
 import tempfile
 
-from qgis.core import QgsExpressionContextUtils, QgsProject
+from qgis.core import QgsExpressionContextUtils, QgsFieldConstraints, QgsProject
 from qgis.testing import start_app, unittest
 
 from modelbaker.dataobjects.project import Project
@@ -315,6 +315,15 @@ class TestProjectOIDs(unittest.TestCase):
                 assert (
                     default_value_definition.expression() == expected_other_expression
                 )
+                # check if not null and unique constraints are set (shouldn't be)
+                assert not (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert not (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
                 count += 1
             # ANYOID
             if tree_layer.layer().name() in ["BesitzerIn"]:
@@ -336,6 +345,27 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression() == expected_other_expression
+                )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
                 )
                 count += 1
             # UUIDOID
@@ -361,6 +391,27 @@ class TestProjectOIDs(unittest.TestCase):
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_uuid_expression
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # STANARDOID
             if tree_layer.layer().name() in [
@@ -389,6 +440,27 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression()
                     == expected_standard_expression
                 )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # I32OID
             if tree_layer.layer().name() in ["Wiese", "Spass.Gebaeude"]:
@@ -409,6 +481,27 @@ class TestProjectOIDs(unittest.TestCase):
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_i32_expression
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # OIDMadness_V1.TypeID or OIDMadness_V1.TypeIDShort
             if tree_layer.layer().name() in ["See", "Fluss"]:
@@ -433,6 +526,27 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression() == expected_other_expression
+                )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
                 )
                 count += 1
 
@@ -573,6 +687,15 @@ class TestProjectOIDs(unittest.TestCase):
                 assert (
                     default_value_definition.expression() == expected_other_expression
                 )
+                # check if not null and unique constraints are set (shouldn't)
+                assert not (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert not (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
                 count += 1
             # ANYOID
             if tree_layer.layer().name() in ["BesitzerIn"]:
@@ -594,6 +717,27 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression() == expected_other_expression
+                )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
                 )
                 count += 1
             # UUIDOID
@@ -619,6 +763,27 @@ class TestProjectOIDs(unittest.TestCase):
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_uuid_expression
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # STANARDOID
             if tree_layer.layer().name() in [
@@ -647,6 +812,27 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression()
                     == expected_standard_expression
                 )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # I32OID
             if tree_layer.layer().name() in ["Wiese", "Spass.Gebaeude"]:
@@ -667,6 +853,27 @@ class TestProjectOIDs(unittest.TestCase):
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_i32_expression
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # OIDMadness_V1.TypeID or OIDMadness_V1.TypeIDShort
             if tree_layer.layer().name() in ["See", "Fluss"]:
@@ -691,6 +898,27 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression() == expected_other_expression
+                )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
                 )
                 count += 1
 
@@ -832,6 +1060,15 @@ class TestProjectOIDs(unittest.TestCase):
                 assert (
                     default_value_definition.expression() == expected_other_expression
                 )
+                # check if not null and unique constraints are set (shouldn't)
+                assert not (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert not (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
                 count += 1
             # ANYOID
             if tree_layer.layer().name() in ["BesitzerIn"]:
@@ -854,6 +1091,27 @@ class TestProjectOIDs(unittest.TestCase):
                 assert (
                     default_value_definition.expression() == expected_other_expression
                 )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # UUIDOID
             if tree_layer.layer().name() in ["Quartier.Gebaeude", "Wald"]:
@@ -874,6 +1132,27 @@ class TestProjectOIDs(unittest.TestCase):
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_uuid_expression
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # STANARDOID
             if tree_layer.layer().name() in [
@@ -902,6 +1181,27 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression()
                     == expected_standard_expression
                 )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # I32OID
             if tree_layer.layer().name() in ["Wiese", "Spass.Gebaeude"]:
@@ -922,6 +1222,27 @@ class TestProjectOIDs(unittest.TestCase):
                 default_value_definition = t_ili_tid_field.defaultValueDefinition()
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_i32_expression
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
                 count += 1
             # OIDMadness_V1.TypeID or OIDMadness_V1.TypeIDShort
             if tree_layer.layer().name() in ["See", "Fluss"]:
@@ -946,6 +1267,27 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert (
                     default_value_definition.expression() == expected_other_expression
+                )
+                # check if not null and unique constraints are set
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintUnique
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraints()
+                    & QgsFieldConstraints.ConstraintNotNull
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintUnique
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
+                )
+                assert (
+                    t_ili_tid_field.constraints().constraintStrength(
+                        QgsFieldConstraints.ConstraintNotNull
+                    )
+                    == QgsFieldConstraints.ConstraintStrengthHard
                 )
                 count += 1
 

--- a/tests/test_projectgen_oids.py
+++ b/tests/test_projectgen_oids.py
@@ -347,26 +347,7 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression() == expected_other_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # UUIDOID
             if tree_layer.layer().name() in [
@@ -392,26 +373,7 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_uuid_expression
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # STANARDOID
             if tree_layer.layer().name() in [
@@ -441,26 +403,7 @@ class TestProjectOIDs(unittest.TestCase):
                     == expected_standard_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # I32OID
             if tree_layer.layer().name() in ["Wiese", "Spass.Gebaeude"]:
@@ -482,26 +425,7 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_i32_expression
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # OIDMadness_V1.TypeID or OIDMadness_V1.TypeIDShort
             if tree_layer.layer().name() in ["See", "Fluss"]:
@@ -528,26 +452,7 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression() == expected_other_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
 
         # should find 15
@@ -719,26 +624,7 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression() == expected_other_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # UUIDOID
             if tree_layer.layer().name() in [
@@ -764,26 +650,7 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_uuid_expression
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # STANARDOID
             if tree_layer.layer().name() in [
@@ -813,26 +680,7 @@ class TestProjectOIDs(unittest.TestCase):
                     == expected_standard_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # I32OID
             if tree_layer.layer().name() in ["Wiese", "Spass.Gebaeude"]:
@@ -854,26 +702,7 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_i32_expression
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # OIDMadness_V1.TypeID or OIDMadness_V1.TypeIDShort
             if tree_layer.layer().name() in ["See", "Fluss"]:
@@ -900,26 +729,7 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression() == expected_other_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
 
         # should find 15
@@ -1092,26 +902,7 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression() == expected_other_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # UUIDOID
             if tree_layer.layer().name() in ["Quartier.Gebaeude", "Wald"]:
@@ -1133,26 +924,7 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_uuid_expression
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # STANARDOID
             if tree_layer.layer().name() in [
@@ -1182,26 +954,7 @@ class TestProjectOIDs(unittest.TestCase):
                     == expected_standard_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # I32OID
             if tree_layer.layer().name() in ["Wiese", "Spass.Gebaeude"]:
@@ -1223,26 +976,7 @@ class TestProjectOIDs(unittest.TestCase):
                 assert default_value_definition is not None
                 assert default_value_definition.expression() == expected_i32_expression
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
             # OIDMadness_V1.TypeID or OIDMadness_V1.TypeIDShort
             if tree_layer.layer().name() in ["See", "Fluss"]:
@@ -1269,26 +1003,7 @@ class TestProjectOIDs(unittest.TestCase):
                     default_value_definition.expression() == expected_other_expression
                 )
                 # check if not null and unique constraints are set
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintUnique
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
-                assert (
-                    t_ili_tid_field.constraints().constraintStrength(
-                        QgsFieldConstraints.ConstraintNotNull
-                    )
-                    == QgsFieldConstraints.ConstraintStrengthHard
-                )
+                self._check_t_ili_tid_field_constraints(t_ili_tid_field)
                 count += 1
 
         # should find 14
@@ -1368,6 +1083,28 @@ class TestProjectOIDs(unittest.TestCase):
         assert count == 3
 
         QgsProject.instance().clear()
+
+    def _check_t_ili_tid_field_constraints(self, t_ili_tid_field):
+        assert (
+            t_ili_tid_field.constraints().constraints()
+            & QgsFieldConstraints.ConstraintUnique
+        )
+        assert (
+            t_ili_tid_field.constraints().constraints()
+            & QgsFieldConstraints.ConstraintNotNull
+        )
+        assert (
+            t_ili_tid_field.constraints().constraintStrength(
+                QgsFieldConstraints.ConstraintUnique
+            )
+            == QgsFieldConstraints.ConstraintStrengthHard
+        )
+        assert (
+            t_ili_tid_field.constraints().constraintStrength(
+                QgsFieldConstraints.ConstraintNotNull
+            )
+            == QgsFieldConstraints.ConstraintStrengthHard
+        )
 
     def _set_pg_naming(self, is_pg=True):
         if is_pg:


### PR DESCRIPTION
But if no OIDs are defined in the model, we don't set the constraints on the `t_ili_tid`. 

