### PR TITLE
Fix: Load style for raster layers as well

### DIFF
--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -274,8 +274,8 @@ class Project(QObject):
             if layer.layer.type() == QgsMapLayer.VectorLayer:
                 # even when a style will be loaded we create the form because not sure if the style contains form settngs
                 layer.create_form(self)
-                layer.load_styles()
                 layer.store_variables(self)
+            layer.load_styles()
 
         if self.legend:
             self.legend.create(qgis_project, group)


### PR DESCRIPTION
Raster layer styles where not considered when they have been loaded with UsabILIty Hub workflow. 

We check there if it's a vector layer, to create the form an store the variables. But styles should be loaded for raster as well.