### PR TITLE
don't set None when no fallback user active

### DIFF
--- a/modelbaker/db_factory/pg_command_config_manager.py
+++ b/modelbaker/db_factory/pg_command_config_manager.py
@@ -100,7 +100,10 @@ class PgCommandConfigManager(DbCommandConfigManager):
                 uri += ["password={}".format(authconfig_map.get("password"))]
         else:
             if not service_config or not service_config.get("user", None):
-                uri += ["user={}".format(self.configuration.dbusr or fallback_user)]
+                if self.configuration.dbusr:
+                    uri += ["user={}".format(self.configuration.dbusr)]
+                elif fallback_user:
+                    uri += ["user={}".format(fallback_user)]
             if not service_config or not service_config.get("password", None):
                 if self.configuration.dbpwd:
                     uri += ["password={}".format(self.configuration.dbpwd)]


### PR DESCRIPTION
there are systems that not need any credentials