### PR TITLE
For toppings avoid issues with backslashes

### DIFF
--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -875,7 +875,9 @@ class GPKGConnector(DBConnector):
         return False, self.tr('Could not rename dataset to "{}".').format(datasetname)
 
     def get_topics_info(self):
-        if self._table_exists("T_ILI2DB_CLASSNAME"):
+        if self._table_exists("T_ILI2DB_CLASSNAME") and self._table_exists(
+            GPKG_METAATTRS_TABLE
+        ):
             cursor = self.conn.cursor()
             cursor.execute(
                 """

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -993,7 +993,11 @@ WHERE TABLE_SCHEMA='{schema}'
 
     def get_topics_info(self):
         result = {}
-        if self.schema and self._table_exists("t_ili2db_classname"):
+        if (
+            self.schema
+            and self._table_exists("t_ili2db_classname")
+            and self._table_exists(METAATTRS_TABLE)
+        ):
             cur = self.conn.cursor()
             cur.execute(
                 """

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -1076,7 +1076,11 @@ class PGConnector(DBConnector):
         return False, self.tr('Could not rename dataset "{}".').format(datasetname)
 
     def get_topics_info(self):
-        if self.schema and self._table_exists("t_ili2db_classname"):
+        if (
+            self.schema
+            and self._table_exists("t_ili2db_classname")
+            and self._table_exists(PG_METAATTRS_TABLE)
+        ):
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
             cur.execute(
                 sql.SQL(

--- a/modelbaker/ilitoppingmaker/ilitarget.py
+++ b/modelbaker/ilitoppingmaker/ilitarget.py
@@ -19,6 +19,7 @@
 
 import datetime
 import os
+import pathlib
 
 from ..libs.toppingmaker import Target
 from ..libs.toppingmaker.utils import slugify
@@ -62,7 +63,9 @@ class IliTarget(Target):
         _, relative_filedir_path = target.filedir_path(type)
 
         id = target.unique_id_in_target_scope(target, slugify(f"{type}_{name}_001"))
-        path = os.path.join(relative_filedir_path, name).replace("\\", "/")
+        path = pathlib.PureWindowsPath(
+            os.path.join(relative_filedir_path, name)
+        ).as_posix()
         type = type
         toppingfile = {"id": id, "path": path, "type": type}
         target.toppingfileinfo_list.append(toppingfile)

--- a/modelbaker/ilitoppingmaker/ilitarget.py
+++ b/modelbaker/ilitoppingmaker/ilitarget.py
@@ -62,7 +62,7 @@ class IliTarget(Target):
         _, relative_filedir_path = target.filedir_path(type)
 
         id = target.unique_id_in_target_scope(target, slugify(f"{type}_{name}_001"))
-        path = os.path.join(relative_filedir_path, name)
+        path = os.path.join(relative_filedir_path, name).replace("\\", "/")
         type = type
         toppingfile = {"id": id, "path": path, "type": type}
         target.toppingfileinfo_list.append(toppingfile)

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -19,6 +19,7 @@
 import glob
 import logging
 import os
+import pathlib
 import re
 import shutil
 import urllib.parse
@@ -699,7 +700,7 @@ class IliDataCache(IliCache):
             file_dir = os.path.dirname(file_path)
             os.makedirs(file_dir, exist_ok=True)
             # in case there are backslashes in the url, remove them
-            file_url = file_url.replace("\\", "/")
+            file_url = pathlib.PureWindowsPath(file_url).as_posix()
             download_file(
                 file_url,
                 file_path,

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -685,20 +685,21 @@ class IliDataCache(IliCache):
         file_url = self.file_url(url, file)
 
         if url is None or os.path.isdir(url):
-            file_path = file_url
+            file_path = os.path.normpath(file_url)
             # continue with the local file
-            if os.path.exists(file_url):
-                self.file_download_succeeded.emit(dataset_id, file_url)
+            if os.path.exists(file_path):
+                self.file_download_succeeded.emit(dataset_id, file_path)
             else:
                 self.file_download_failed.emit(
                     dataset_id,
-                    self.tr("Could not find local file  {}").format(file_url),
+                    self.tr("Could not find local file  {}").format(file_path),
                 )
         else:
-            file_path = os.path.join(self.CACHE_PATH, netloc, file)
+            file_path = os.path.normpath(os.path.join(self.CACHE_PATH, netloc, file))
             file_dir = os.path.dirname(file_path)
             os.makedirs(file_dir, exist_ok=True)
-
+            # in case there are backslashes in the url, remove them
+            file_url = file_url.replace("\\", "/")
             download_file(
                 file_url,
                 file_path,


### PR DESCRIPTION
On windows backslashes where created with topping exporter file paths. 
This leaded to issues when the relative path has been attached to an url.

The IliDataCache.download_file now:
- replaces the backslashes with slashes on URL
- normalizes the path to the current system

Still ili2db does not that.

The IliToppingMaker creating those paths is now storing everything with backslashes as well, nerveless if it's an url or a file path (because it cannot know that). 

Windows can handel slashes in the path as well AFAIK, what means it's more stable to have slashes.