### PR TITLE
introduce new actiontype SCHEMA_IMPORT

### DIFF
--- a/modelbaker/utils/globals.py
+++ b/modelbaker/utils/globals.py
@@ -20,11 +20,12 @@ from enum import Enum
 
 
 class DbActionType(Enum):
-    """Defines constants for generate, import data, or export actions of modelbaker."""
+    """Defines constants for generate, schema_import, import data, or export actions of modelbaker."""
 
     GENERATE = 1
     IMPORT_DATA = 2
     EXPORT = 3
+    SCHEMA_IMPORT = 4
 
 
 class OptimizeStrategy(Enum):


### PR DESCRIPTION
Before for the use case of schema import we used sometimes GENERATE and sometimes IMPORT_DATA depending on the situation. This is clearer now, and we better can divert.

(it's historical, that GENERATE included schema-import)
