### PR TITLE
Paramter handling with metaconfig

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -144,10 +144,14 @@ class Ili2DbCommandConfiguration:
 
     def append_args(self, args, values, consider_metaconfig=False, force_append=False):
 
-        if not force_append and self.metaconfig and self.metaconfig_id and values:
+        if not force_append and self.metaconfig_id and values:
             if self.metaconfig_params_only:
                 return
-            if consider_metaconfig and "ch.ehi.ili2db" in self.metaconfig.sections():
+            if (
+                consider_metaconfig
+                and self.metaconfig
+                and "ch.ehi.ili2db" in self.metaconfig.sections()
+            ):
                 metaconfig_ili2db_params = self.metaconfig["ch.ehi.ili2db"]
                 if values[0][2:] in metaconfig_ili2db_params.keys():
                     # if the value is set in the metaconfig, then we do consider it instead

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -319,12 +319,14 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         self.append_args(args, ["--defaultSrsCode", "{}".format(self.srs_code)])
 
         if self.pre_script:
-            self.append_args(args, ["--preScript", self.pre_script])
+            self.append_args(args, ["--preScript", self.pre_script], force_append=True)
         elif self.db_ili_version is None or self.db_ili_version > 3:
             self.append_args(args, ["--preScript", "NULL"])
 
         if self.post_script:
-            self.append_args(args, ["--postScript", self.post_script])
+            self.append_args(
+                args, ["--postScript", self.post_script], force_append=True
+            )
         elif self.db_ili_version is None or self.db_ili_version > 3:
             self.append_args(args, ["--postScript", "NULL"])
 

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -175,7 +175,7 @@ class Ili2DbCommandConfiguration:
             )
 
         if self.ilimodels:
-            self.append_args(args, ["--models", self.ilimodels])
+            self.append_args(args, ["--models", self.ilimodels], force_append=True)
 
         if self.tomlfile:
             self.append_args(args, ["--iliMetaAttrs", self.tomlfile])


### PR DESCRIPTION
- a metaconfig **id** should be allowed even without a metaconfig parameter to be able to use it with `metaconfig_params_only`
- models should be forced as well as pre- and post-scripts (since they can be individual from the other settings), if they are null, they can still be considered from the metaconfig
