### PR TITLE
Force to take default or manually set parameters

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -314,9 +314,11 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         elif self.db_ili_version is None or self.db_ili_version > 3:
             self.append_args(args, ["--createBasketCol=False"])
 
-        self.append_args(args, ["--defaultSrsAuth", self.srs_auth])
+        self.append_args(args, ["--defaultSrsAuth", self.srs_auth], force_append=True)
 
-        self.append_args(args, ["--defaultSrsCode", "{}".format(self.srs_code)])
+        self.append_args(
+            args, ["--defaultSrsCode", "{}".format(self.srs_code)], force_append=True
+        )
 
         if self.pre_script:
             self.append_args(args, ["--preScript", self.pre_script], force_append=True)


### PR DESCRIPTION
srs info are not exported in the metaconfig, this is why we forse it to be able to use onlyMetaConfig