### PR TITLE
Fix when multiple bagofenums in the same layer

### DIFF
--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -236,6 +236,7 @@ class Project(QObject):
 
         # Set Bag of Enum widget
         for layer_name, bag_of_enum in self.bags_of_enum.items():
+            current_layer = None
             for attribute, bag_of_enum_info in bag_of_enum.items():
                 layer_obj = bag_of_enum_info[0]
                 cardinality = bag_of_enum_info[1]
@@ -245,7 +246,9 @@ class Project(QObject):
 
                 minimal_selection = cardinality.startswith("1")
 
-                current_layer = layer_obj.create()
+                if not current_layer:
+                    # create the layer only once
+                    current_layer = layer_obj.create()
 
                 field_widget = "ValueRelation"
                 field_widget_config = {

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -2107,9 +2107,22 @@ class TestProjectGen(unittest.TestCase):
 
         assert count == 2
 
-        # Test constraints
+        # Test type and constraints
         for layer in available_layers:
             if layer.name == "fische":
+                assert (
+                    layer.layer.editorWidgetSetup(
+                        layer.layer.fields().indexOf("valuerelation_0")
+                    ).type()
+                    == "ValueRelation"
+                )
+                assert (
+                    layer.layer.editorWidgetSetup(
+                        layer.layer.fields().indexOf("valuerelation_1")
+                    ).type()
+                    == "ValueRelation"
+                )
+
                 assert (
                     layer.layer.constraintExpression(
                         layer.layer.fields().indexOf("valuerelation_0")
@@ -2189,9 +2202,22 @@ class TestProjectGen(unittest.TestCase):
 
         assert count == 2
 
-        # Test constraints
+        # Test type and constraints
         for layer in available_layers:
             if layer.name == "fische":
+                assert (
+                    layer.layer.editorWidgetSetup(
+                        layer.layer.fields().indexOf("valuerelation_0")
+                    ).type()
+                    == "ValueRelation"
+                )
+                assert (
+                    layer.layer.editorWidgetSetup(
+                        layer.layer.fields().indexOf("valuerelation_1")
+                    ).type()
+                    == "ValueRelation"
+                )
+
                 assert (
                     layer.layer.constraintExpression(
                         layer.layer.fields().indexOf("valuerelation_0")


### PR DESCRIPTION
The layer settings where overwritten with the second bagofenum. This is fixed now.