### PR TITLE
Consider order in Enumerations

### DIFF
--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -72,6 +72,7 @@ class Layer:
         definitionfile: Optional[str] = None,
         qmlstylefile: Optional[str] = None,
         styles: dict[str, dict[str, str]] = {},
+        is_enum: bool = False,
     ) -> None:
         self.provider = provider
         self.uri = uri
@@ -92,6 +93,7 @@ class Layer:
         self.fields = list()
         self.is_domain = is_domain
         self.is_structure = is_structure
+        self.is_enum = is_enum
 
         self.is_nmrel = is_nmrel
         self.srid = srid
@@ -128,6 +130,7 @@ class Layer:
         definition["uri"] = self.uri
         definition["isdomain"] = self.is_domain
         definition["isstructure"] = self.is_structure
+        definition["isenum"] = self.is_enum
         definition["isnmrel"] = self.is_nmrel
         definition["isbaskettable"] = self.is_basket_table
         definition["isdatasettable"] = self.is_dataset_table
@@ -148,6 +151,7 @@ class Layer:
         self.uri = definition["uri"]
         self.is_domain = definition["isdomain"]
         self.is_structure = definition["isstructure"]
+        self.is_enum = definition["isenum"]
         self.is_nmrel = definition["isnmrel"]
         self.is_basket_table = definition["isbaskettable"]
         self.is_dataset_table = definition["isdatasettable"]

--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -54,7 +54,7 @@ class Layer:
         geometry_column: str = None,
         wkb_type: QgsWkbTypes = QgsWkbTypes.Unknown,
         alias: Optional[str] = None,
-        is_domain: bool = False,
+        is_domain: bool = False,  # is enumeration or catalogue
         is_structure: bool = False,
         is_nmrel: bool = False,
         display_expression: str = None,

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -171,7 +171,6 @@ class Project(QObject):
                     LogLevel.ERROR,
                 )
                 continue
-            qgis_relations.append(rel)
 
             referenced_layer = dict_layers.get(rel.referencedLayerId(), None)
             referencing_layer = dict_layers.get(rel.referencingLayerId(), None)
@@ -221,6 +220,8 @@ class Project(QObject):
                         "FilterFields": list(),
                     },
                 )
+
+                qgis_relations.append(rel)
             elif referenced_layer and referenced_layer.is_basket_table:
                 # list the topics we filter the basket with. On NONE strategy those should be all topics the class could be in. On optimized strategies GROUP/HIDE only the relevant topics should be listed.
                 filter_topics = (
@@ -252,6 +253,7 @@ class Project(QObject):
                         "FilterFields": list(),
                     },
                 )
+                qgis_relations.append(rel)
             else:
                 editor_widget_setup = QgsEditorWidgetSetup(
                     "RelationReference",
@@ -264,6 +266,7 @@ class Project(QObject):
                         "AllowNULL": True,
                     },
                 )
+                qgis_relations.append(rel)
 
             referencing_layer = rel.referencingLayer()
             referencing_layer.setEditorWidgetSetup(

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -188,7 +188,9 @@ class Project(QObject):
                         "AllowMulti": False,
                         "UseCompleter": False,
                         "Value": "dispName",
-                        "OrderByValue": False,
+                        "OrderByValue": False
+                        if Qgis.QGIS_VERSION_INT >= 34200
+                        else True,  # order by value if order by field is not available yet
                         "AllowNull": True,
                         "Layer": rel.referencedLayerId(),
                         "FilterExpression": "\"{}\" = '{}'".format(
@@ -198,6 +200,8 @@ class Project(QObject):
                         else "",
                         "Key": "t_id",
                         "NofColumns": 1,
+                        "OrderByField": True,
+                        "OrderByFieldName": "seq",
                     },
                 )
             elif referenced_layer and referenced_layer.is_domain:

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -175,7 +175,7 @@ class Project(QObject):
             referenced_layer = dict_layers.get(rel.referencedLayerId(), None)
             referencing_layer = dict_layers.get(rel.referencingLayerId(), None)
 
-            # on enumeration tables we use value relation, because it's less ressource intensive - still when it has a display expression (defined by meta attribute or because it's a translated model, we still use relation reference)
+            # on enumeration tables we use value relation, because it's less resource intensive - still when it has a display expression (defined by meta attribute or because it's a translated model, we still use relation reference)
             if (
                 referenced_layer
                 and referenced_layer.is_enum

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -176,7 +176,31 @@ class Project(QObject):
             referenced_layer = dict_layers.get(rel.referencedLayerId(), None)
             referencing_layer = dict_layers.get(rel.referencingLayerId(), None)
 
-            if referenced_layer and referenced_layer.is_domain:
+            # on enumeration tables we use value relation, because it's less ressource intensive - still when it has a display expression (defined by meta attribute or because it's a translated model, we still use relation reference)
+            if (
+                referenced_layer
+                and referenced_layer.is_enum
+                and not referenced_layer.display_expression
+            ):
+                editor_widget_setup = QgsEditorWidgetSetup(
+                    "ValueRelation",
+                    {
+                        "AllowMulti": False,
+                        "UseCompleter": False,
+                        "Value": "dispName",
+                        "OrderByValue": False,
+                        "AllowNull": True,
+                        "Layer": rel.referencedLayerId(),
+                        "FilterExpression": "\"{}\" = '{}'".format(
+                            ENUM_THIS_CLASS_COLUMN, relation.child_domain_name
+                        )
+                        if relation.child_domain_name
+                        else "",
+                        "Key": "t_id",
+                        "NofColumns": 1,
+                    },
+                )
+            elif referenced_layer and referenced_layer.is_domain:
                 editor_widget_setup = QgsEditorWidgetSetup(
                     "RelationReference",
                     {

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -1263,7 +1263,11 @@ class GPKGConnector(DBConnector):
         return [record["lang"] for record in records]
 
     def get_domain_dispnames(self, tablename):
-        if not self._table_exists or not self._table_exists(GPKG_NLS_TABLE):
+        if (
+            not self._table_exists
+            or not self._table_exists(GPKG_NLS_TABLE)
+            or self._lang == ""
+        ):
             return []
 
         cursor = self.conn.cursor()

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -1401,7 +1401,12 @@ class PGConnector(DBConnector):
         return []
 
     def get_domain_dispnames(self, tablename):
-        if self.schema and self._table_exists and self._table_exists(PG_NLS_TABLE):
+        if (
+            self.schema
+            and self._table_exists
+            and self._table_exists(PG_NLS_TABLE)
+            and self._lang != ""
+        ):
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
             cur.execute(
                 sql.SQL(

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -134,10 +134,8 @@ class Generator(QObject):
             if filter_layer_list and record["tablename"] not in filter_layer_list:
                 continue
 
-            is_domain = (
-                record.get("kind_settings") == "ENUM"
-                or record.get("kind_settings") == "CATALOGUE"
-            )
+            is_enum = record.get("kind_settings") == "ENUM"
+            is_domain = is_enum or record.get("kind_settings") == "CATALOGUE"
             is_attribute = bool(record.get("attribute_name"))
             is_structure = record.get("kind_settings") == "STRUCTURE"
             is_nmrel = record.get("kind_settings") == "ASSOCIATION"
@@ -260,7 +258,7 @@ class Generator(QObject):
                     ]:
                         display_expression = attr_record["attr_value"]
 
-                # for the enumeration domain we create a translated mapping expression in case there is not yet a displayexpression defined (by metaattribute)
+                # for the enumeration domain we create a translated mapping expression in case there is not yet a displayexpression defined (by metaattribute) and a translation is required
                 if not display_expression and record.get("kind_settings") == "ENUM":
                     mapped_dispnames = self.get_domain_dispnames(record["tablename"])
                     if mapped_dispnames:
@@ -313,6 +311,7 @@ class Generator(QObject):
                 is_relevant,
                 all_topics,
                 relevant_topics,
+                is_enum=is_enum,
             )
 
             # Configure fields for current table

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -53,7 +53,7 @@ class Generator(QObject):
         mgmt_uri: Optional[str] = None,
         consider_basket_handling: bool = False,
         optimize_strategy: OptimizeStrategy = OptimizeStrategy.NONE,
-        preferred_language: str = "",
+        preferred_language: str = "__",
         raw_naming=False,
     ) -> None:
         """

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -22,7 +22,7 @@ import os
 import shutil
 import tempfile
 
-from qgis.core import QgsProject
+from qgis.core import Qgis, QgsProject
 from qgis.testing import start_app, unittest
 
 from modelbaker.dataobjects.project import Project
@@ -3981,7 +3981,7 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.name == "Cats":
+            if layer.name == "cat":
                 # the catalogue should be a relation reference
                 field = layer.layer.fields().field("cataloguebreed")
                 type = field.editorWidgetSetup().type()
@@ -4049,7 +4049,7 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.name == "Cats":
+            if layer.name == "cat":
                 # the catalogue should be a relation reference
                 field = layer.layer.fields().field("cataloguebreed")
                 type = field.editorWidgetSetup().type()

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4001,6 +4001,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["Value"] == "dispName"
 
                 if Qgis.QGIS_VERSION_INT >= 34200:
+                    assert not config["OrderByValue"]
                     assert config["OrderByField"]
                     assert config["OrderByFieldName"] == "seq"
                 else:
@@ -4069,6 +4070,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["Value"] == "dispName"
 
                 if Qgis.QGIS_VERSION_INT >= 34200:
+                    assert not config["OrderByValue"]
                     assert config["OrderByField"]
                     assert config["OrderByFieldName"] == "seq"
                 else:

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4000,6 +4000,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert config["Value"] == "dispName"
 
+                if Qgis.QGIS_VERSION_INT >= 34200:
+                    assert config["OrderByField"]
+                    assert config["OrderByFieldName"] == "seq"
+                else:
+                    assert config["OrderByValue"]
+
                 count += 1
 
         assert count == 1
@@ -4062,6 +4068,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert config["Value"] == "dispName"
 
+                if Qgis.QGIS_VERSION_INT >= 34200:
+                    assert config["OrderByField"]
+                    assert config["OrderByFieldName"] == "seq"
+                else:
+                    assert config["OrderByValue"]
                 count += 1
 
         assert count == 1

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -150,7 +150,7 @@ class TestProjectGen(unittest.TestCase):
                     belasteter_standort_polygon_layer.layer
                 )
             )
-            > 2
+            == 1  # only zuständigkeit kataster - the others are enum value relation
         )
         assert (
             len(
@@ -166,7 +166,7 @@ class TestProjectGen(unittest.TestCase):
                     belasteter_standort_punkt_layer.layer
                 )
             )
-            > 2
+            == 1  # only zuständigkeit kataster - the others are enum value relation
         )
         assert (
             len(
@@ -269,7 +269,7 @@ class TestProjectGen(unittest.TestCase):
                     belasteter_standort_polygon_layer.layer
                 )
             )
-            > 2
+            == 1  # only zuständigkeit kataster - the others are enum value relation
         )
         assert (
             len(
@@ -285,7 +285,7 @@ class TestProjectGen(unittest.TestCase):
                     belasteter_standort_punkt_layer.layer
                 )
             )
-            > 2
+            == 1  # only zuständigkeit kataster - the others are enum value relation
         )
         assert (
             len(

--- a/tests/testdata/ilimodels/EnumsAndCats.ili
+++ b/tests/testdata/ilimodels/EnumsAndCats.ili
@@ -1,0 +1,56 @@
+INTERLIS 2.3;
+
+MODEL EnumsAndCats_V1 (en)
+AT "mailto:U80863546@localhost"
+VERSION "2021-12-15"  =
+IMPORTS CatalogueObjectTrees_V1,CatalogueObjects_V1;
+
+  DOMAIN
+    !!@qgis.modelbaker.dispExpression="dispName||' ('||ilicode||')'"
+    CharacterTypeWithDispExpression = (
+      !!@ili2db.dispName="X Type"
+      x,
+      !!@ili2db.dispName="Y Type"
+      y,
+      !!@ili2db.dispName="Z Type"
+      z,
+      !!@ili2db.dispName="All other types"
+      others
+    );
+
+    CharacterType = (
+      !!@ili2db.dispName="X Type"
+      x,
+      !!@ili2db.dispName="Y Type"
+      y,
+      !!@ili2db.dispName="Z Type"
+      z,
+      !!@ili2db.dispName="All other types"
+      others
+    );
+
+  TOPIC Catalogues =
+
+	CLASS BreedItem
+    EXTENDS CatalogueObjects_V1.Catalogues.Item =
+        Code : 0 .. 9999;
+        Name : MANDATORY TEXT;
+    END BreedItem;
+
+    STRUCTURE BreedRef
+    EXTENDS CatalogueObjects_V1.Catalogues.CatalogueReference =
+      Reference (EXTENDED) : REFERENCE TO (EXTERNAL) BreedItem;
+    END BreedRef;
+  END Catalogues;
+
+  TOPIC Cats =
+  DEPENDS ON Catalogues;
+	CLASS Cat =
+	  Cat_Name : TEXT;
+	  CatalogueBreed : EnumsAndCats_V1.Catalogues.BreedRef;
+	  EnumCharacterWithDispExpression : EnumsAndCats_V1.CharacterTypeWithDispExpression;
+	  EnumCharacter : EnumsAndCats_V1.CharacterType;
+	END Cat;
+  END Cats;
+
+END EnumsAndCats_V1.


### PR DESCRIPTION
Enumeration domain tables contain the field `seq` that defines the order. This is implemented in ili2db since https://github.com/claeis/ili2db/commit/1d82bef38812d2430c7a1f59f449713aefdae8dd

Model Baker needs to create a widget that concerns this order. The relation reference widget is not yet able to do so: https://github.com/qgis/QGIS/issues/48191 but the value relation is since 3.42 https://qgis.org/project/visual-changelogs/visualchangelog342/#feature-additional-sorting-options-on-value-relation-widget

Because enumerations don't really need the power of relation reference widgets and value relations perform better, we decided to go with value relations on enumerations. Exceptions are, when we need a display expression, in case of:
- defined `qgis.modelbaker.dispExpression` meta attribute
- translated models
 
...because the value relation is not able to handle a display expression.

This fixes 
https://github.com/opengisch/QgisModelBaker/issues/940


- [x] Relations of Enums are not needed anymore with this (only to create the widget). Maybe it can be removed...

### Concerning relation reference

Still https://github.com/qgis/QGIS/issues/48191 would make sense to be able to order catalogue-dropdowns as well.