### PR TITLE
Specific assocciations should be handled as compositions in QGIS

### DIFF
--- a/modelbaker/dataobjects/relations.py
+++ b/modelbaker/dataobjects/relations.py
@@ -12,6 +12,7 @@ class Relation:
         self.name = None
         self.strength = QgsRelation.Association
         self.cardinality_max = None
+        self.cardinality_min = None
         self.child_domain_name = None
         self.qgis_relation = None
         self._id = None
@@ -25,6 +26,7 @@ class Relation:
         definition["referencedField"] = self.referenced_field
         definition["strength"] = self.strength
         definition["cardinality_max"] = self.cardinality_max
+        definition["cardinality_min"] = self.cardinality_min
         definition["child_domain_name"] = self.child_domain_name
 
         return definition
@@ -36,6 +38,7 @@ class Relation:
         self.referenced_field = definition["referencedField"]
         self.strength = definition["strength"]
         self.cardinality_max = definition["cardinality_max"]
+        self.cardinality_min = definition["cardinality_min"]
         self.child_domain_name = definition["child_domain_name"]
 
     def create(

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -174,6 +174,7 @@ class DBConnector(QObject):
                 referenced_column_name
                 strength
                 cardinality_max
+                cardinality_min
         """
         return []
 

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -573,10 +573,16 @@ class GPKGConnector(DBConnector):
 
                     # Get cardinality max
                     cursor.execute(
-                        """SELECT META_ATTRS.attr_value as cardinality_max
+                        """SELECT META_ATTRS_ATTR_MAX.attr_value as attr_cardinality_max, META_ATTRS_ATTR_MIN.attr_value as attr_cardinality_min, META_ATTRS_ASSOC_MAX.attr_value as assoc_cardinality_max, META_ATTRS_ASSOC_MIN.attr_value as assoc_cardinality_min
                         FROM T_ILI2DB_ATTRNAME AS ATTRNAME
-                        INNER JOIN T_ILI2DB_META_ATTRS AS META_ATTRS
-                        ON META_ATTRS.ilielement = ATTRNAME.iliname AND META_ATTRS.attr_name = 'ili2db.ili.attrCardinalityMax'
+                        LEFT JOIN T_ILI2DB_META_ATTRS AS META_ATTRS_ATTR_MAX
+                        ON META_ATTRS_ATTR_MAX.ilielement = ATTRNAME.iliname AND META_ATTRS_ATTR_MAX.attr_name = 'ili2db.ili.attrCardinalityMax'
+                        LEFT JOIN T_ILI2DB_META_ATTRS AS META_ATTRS_ATTR_MIN
+                        ON META_ATTRS_ATTR_MIN.ilielement = ATTRNAME.iliname AND META_ATTRS_ATTR_MIN.attr_name = 'ili2db.ili.attrCardinalityMin'
+                        LEFT JOIN T_ILI2DB_META_ATTRS AS META_ATTRS_ASSOC_MAX
+                        ON META_ATTRS_ASSOC_MAX.ilielement = ATTRNAME.iliname AND META_ATTRS_ASSOC_MAX.attr_name = 'ili2db.ili.assocCardinalityMax'
+                        LEFT JOIN T_ILI2DB_META_ATTRS AS META_ATTRS_ASSOC_MIN
+                        ON META_ATTRS_ASSOC_MIN.ilielement = ATTRNAME.iliname AND META_ATTRS_ASSOC_MIN.attr_name = 'ili2db.ili.assocCardinalityMin'
                         WHERE ATTRNAME.sqlname = ? AND ATTRNAME.{colowner} = ? AND ATTRNAME.target = ?;
                         """.format(
                             colowner="owner" if self.ili_version() == 3 else "colowner"
@@ -587,13 +593,27 @@ class GPKGConnector(DBConnector):
                             foreign_key["table"],
                         ),
                     )
-                    cardinality_max_record = cursor.fetchone()
+                    cardinality_record = cursor.fetchone()
                     record["cardinality_max"] = (
-                        cardinality_max_record["cardinality_max"]
-                        if cardinality_max_record
+                        cardinality_record["attr_cardinality_max"]
+                        if cardinality_record
                         else ""
                     )
-
+                    record["cardinality_min"] = (
+                        cardinality_record["attr_cardinality_min"]
+                        if cardinality_record
+                        else ""
+                    )
+                    record["assoc_cardinality_max"] = (
+                        cardinality_record["assoc_cardinality_max"]
+                        if cardinality_record
+                        else ""
+                    )
+                    record["assoc_cardinality_min"] = (
+                        cardinality_record["assoc_cardinality_min"]
+                        if cardinality_record
+                        else ""
+                    )
                 complete_records.append(record)
 
         cursor.close()

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -723,9 +723,9 @@ class PGConnector(DBConnector):
             strength_field = ""
             strength_join = ""
             strength_group_by = ""
-            cardinality_max_field = ""
-            cardinality_max_join = ""
-            cardinality_max_group_by = ""
+            cardinality_fields = ""
+            cardinality_join = ""
+            cardinality_group_bys = ""
             translate = ""
 
             if self._table_exists(PG_METAATTRS_TABLE):
@@ -741,26 +741,36 @@ class PGConnector(DBConnector):
                 )
                 strength_group_by = ", META_ATTRS.attr_value"
 
-                cardinality_max_field = (
-                    ", META_ATTRS_CARDINALITY.attr_value as cardinality_max"
-                )
-                cardinality_max_join = """
+                cardinality_fields = """
+                            , META_ATTRS_ATTR_CARDINALITY_MAX.attr_value as cardinality_max, META_ATTRS_ATTR_CARDINALITY_MIN.attr_value as cardinality_min
+                            , META_ATTRS_ASSOC_CARDINALITY_MAX.attr_value as assoc_cardinality_max, META_ATTRS_ASSOC_CARDINALITY_MIN.attr_value as assoc_cardinality_min
+                            """
+                cardinality_join = """
                             LEFT JOIN {schema}.t_ili2db_attrname AS ATTRNAME_CARDINALITY
                              ON ATTRNAME_CARDINALITY.sqlname = KCU1.COLUMN_NAME AND ATTRNAME_CARDINALITY.{colowner} = KCU1.TABLE_NAME AND ATTRNAME_CARDINALITY.target = KCU2.TABLE_NAME
-                            LEFT JOIN {schema}.{t_ili2db_meta_attrs} AS META_ATTRS_CARDINALITY
-                             ON META_ATTRS_CARDINALITY.ilielement = ATTRNAME_CARDINALITY.iliname AND META_ATTRS_CARDINALITY.attr_name = 'ili2db.ili.attrCardinalityMax'""".format(
+                            LEFT JOIN {schema}.{t_ili2db_meta_attrs} AS META_ATTRS_ATTR_CARDINALITY_MAX
+                             ON META_ATTRS_ATTR_CARDINALITY_MAX.ilielement = ATTRNAME_CARDINALITY.iliname AND META_ATTRS_ATTR_CARDINALITY_MAX.attr_name = 'ili2db.ili.attrCardinalityMax'
+                            LEFT JOIN {schema}.{t_ili2db_meta_attrs} AS META_ATTRS_ATTR_CARDINALITY_MIN
+                             ON META_ATTRS_ATTR_CARDINALITY_MIN.ilielement = ATTRNAME_CARDINALITY.iliname AND META_ATTRS_ATTR_CARDINALITY_MIN.attr_name = 'ili2db.ili.attrCardinalityMin'
+                            LEFT JOIN {schema}.{t_ili2db_meta_attrs} AS META_ATTRS_ASSOC_CARDINALITY_MAX
+                             ON META_ATTRS_ASSOC_CARDINALITY_MAX.ilielement = ATTRNAME_CARDINALITY.iliname AND META_ATTRS_ASSOC_CARDINALITY_MAX.attr_name = 'ili2db.ili.assocCardinalityMax'
+                            LEFT JOIN {schema}.{t_ili2db_meta_attrs} AS META_ATTRS_ASSOC_CARDINALITY_MIN
+                             ON META_ATTRS_ASSOC_CARDINALITY_MIN.ilielement = ATTRNAME_CARDINALITY.iliname AND META_ATTRS_ASSOC_CARDINALITY_MIN.attr_name = 'ili2db.ili.assocCardinalityMin'""".format(
                     schema=self.schema,
                     t_ili2db_meta_attrs=PG_METAATTRS_TABLE,
                     colowner="owner" if self.ili_version() == 3 else "colowner",
                 )
-                cardinality_max_group_by = ", META_ATTRS_CARDINALITY.attr_value"
+                cardinality_group_bys = """
+                            , META_ATTRS_ATTR_CARDINALITY_MAX.attr_value, META_ATTRS_ATTR_CARDINALITY_MIN.attr_value
+                            , META_ATTRS_ASSOC_CARDINALITY_MAX.attr_value, META_ATTRS_ASSOC_CARDINALITY_MIN.attr_value
+                            """
 
                 translate = (
                     ", true AS tr_enabled" if self.get_translation_handling()[0] else ""
                 )
 
             cur.execute(
-                """SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION{strength_field}{cardinality_max_field}{translate}
+                """SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION{strength_field}{cardinality_fields}{translate}
                             FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC
                             INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1
                              ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME {schema_where1} {filter_layer_where}
@@ -768,8 +778,8 @@ class PGConnector(DBConnector):
                              ON KCU2.CONSTRAINT_CATALOG = RC.UNIQUE_CONSTRAINT_CATALOG AND KCU2.CONSTRAINT_SCHEMA = RC.UNIQUE_CONSTRAINT_SCHEMA AND KCU2.CONSTRAINT_NAME = RC.UNIQUE_CONSTRAINT_NAME
                              AND KCU2.ORDINAL_POSITION = KCU1.ORDINAL_POSITION {schema_where2}
                             {strength_join}
-                            {cardinality_max_join}
-                            GROUP BY RC.CONSTRAINT_NAME, KCU1.TABLE_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION{strength_group_by}{cardinality_max_group_by}
+                            {cardinality_join}
+                            GROUP BY RC.CONSTRAINT_NAME, KCU1.TABLE_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION{strength_group_by}{cardinality_group_bys}
                             ORDER BY KCU1.ORDINAL_POSITION
                             """.format(
                     schema_where1=schema_where1,
@@ -778,9 +788,9 @@ class PGConnector(DBConnector):
                     strength_field=strength_field,
                     strength_join=strength_join,
                     strength_group_by=strength_group_by,
-                    cardinality_max_field=cardinality_max_field,
-                    cardinality_max_join=cardinality_max_join,
-                    cardinality_max_group_by=cardinality_max_group_by,
+                    cardinality_fields=cardinality_fields,
+                    cardinality_join=cardinality_join,
+                    cardinality_group_bys=cardinality_group_bys,
                     translate=translate,
                 )
             )

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -570,21 +570,16 @@ class Generator(QObject):
                         relation.referenced_field = record["referenced_column"]
                         relation.name = record["constraint_name"]
                         relation.translate_name = record.get("tr_enabled", False)
-                        # the cardinality is read from the attr.cardinality or the assoc.cardinality depending if it's a structure or an association
-                        if relation.referencing_layer.is_structure:
-                            relation.cardinality_max = record.get(
-                                "cardinality_max", None
-                            )
-                            relation.cardinality_min = record.get(
-                                "cardinality_min", None
-                            )
-                        else:
-                            relation.cardinality_max = record.get(
-                                "assoc_cardinality_max", None
-                            )
-                            relation.cardinality_min = record.get(
-                                "assoc_cardinality_min", None
-                            )
+                        relation.cardinality_max = record.get("cardinality_max", None)
+                        relation.cardinality_min = record.get("cardinality_min", None)
+
+                        # cardinalities of associations are not (yet) exposed by relation and only used for the strength below
+                        association_cardinality_max = record.get(
+                            "assoc_cardinality_max", None
+                        )
+                        association_cardinality_min = record.get(
+                            "assoc_cardinality_min", None
+                        )
 
                         relation.strength = QgsRelation.Association
                         if (
@@ -599,16 +594,12 @@ class Generator(QObject):
                             )
                             # or if it's a ..{1} cardinality it depends on a parent...
                             or (
-                                relation.cardinality_max == "1"
-                                and relation.cardinality_min == "1"
+                                association_cardinality_max == "1"
+                                and association_cardinality_min == "1"
                             )
                         ):
                             # ...then it's a composition in QGIS
                             relation.strength = QgsRelation.Composition
-
-                        print(
-                            f"{relation.referencing_layer.name} - {relation.referencing_field}: {relation.cardinality_min} - {relation.cardinality_max}, results in {relation.strength}"
-                        )
 
                         # For domain-class relations, if we have an extended domain, get its child name
                         child_name = None

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -570,14 +570,28 @@ class Generator(QObject):
                         relation.referenced_field = record["referenced_column"]
                         relation.name = record["constraint_name"]
                         relation.translate_name = record.get("tr_enabled", False)
-                        relation.strength = (
-                            QgsRelation.Composition
-                            if "strength" in record
-                            and record["strength"] == "COMPOSITE"
-                            or referencing_layer.is_structure
-                            else QgsRelation.Association
-                        )
                         relation.cardinality_max = record.get("cardinality_max", None)
+                        relation.cardinality_min = record.get("cardinality_min", None)
+
+                        relation.strength = QgsRelation.Association
+                        if (
+                            # if it's a defined composition...
+                            record.get("strength", None) == "COMPOSITE"
+                            # or if it's a structure it depends on a parent...
+                            or referencing_layer.is_structure
+                            # or if the child-table is a join-table and the parent-table is not the basket-table...
+                            or (
+                                referencing_layer.is_nmrel
+                                and not referenced_layer.is_basket_table
+                            )
+                            # or if it's a ..{1} cardinality it depends on a parent...
+                            or (
+                                relation.cardinality_max == 1
+                                and relation.cardinality_min == 1
+                            )
+                        ):
+                            # ...then it's a composition in QGIS
+                            relation.strength = QgsRelation.Composition
 
                         # For domain-class relations, if we have an extended domain, get its child name
                         child_name = None

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -570,8 +570,21 @@ class Generator(QObject):
                         relation.referenced_field = record["referenced_column"]
                         relation.name = record["constraint_name"]
                         relation.translate_name = record.get("tr_enabled", False)
-                        relation.cardinality_max = record.get("cardinality_max", None)
-                        relation.cardinality_min = record.get("cardinality_min", None)
+                        # the cardinality is read from the attr.cardinality or the assoc.cardinality depending if it's a structure or an association
+                        if relation.referencing_layer.is_structure:
+                            relation.cardinality_max = record.get(
+                                "cardinality_max", None
+                            )
+                            relation.cardinality_min = record.get(
+                                "cardinality_min", None
+                            )
+                        else:
+                            relation.cardinality_max = record.get(
+                                "assoc_cardinality_max", None
+                            )
+                            relation.cardinality_min = record.get(
+                                "assoc_cardinality_min", None
+                            )
 
                         relation.strength = QgsRelation.Association
                         if (
@@ -586,12 +599,16 @@ class Generator(QObject):
                             )
                             # or if it's a ..{1} cardinality it depends on a parent...
                             or (
-                                relation.cardinality_max == 1
-                                and relation.cardinality_min == 1
+                                relation.cardinality_max == "1"
+                                and relation.cardinality_min == "1"
                             )
                         ):
                             # ...then it's a composition in QGIS
                             relation.strength = QgsRelation.Composition
+
+                        print(
+                            f"{relation.referencing_layer.name} - {relation.referencing_field}: {relation.cardinality_min} - {relation.cardinality_max}, results in {relation.strength}"
+                        )
 
                         # For domain-class relations, if we have an extended domain, get its child name
                         child_name = None

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -2962,7 +2962,7 @@ class TestProjectGen(unittest.TestCase):
 
         for child in tab_ahvnr.children():
             if "one_to_one" in child.relationEditorConfiguration():
-                self.assertTrue(child.relationEditorConfiguration()["one_to_one"])
+                self.assertFalse(child.relationEditorConfiguration()["one_to_one"])
 
         for child in tab_job.children():
             if "one_to_one" in child.relationEditorConfiguration():
@@ -3051,7 +3051,7 @@ class TestProjectGen(unittest.TestCase):
 
         for child in tab_ahvnr.children():
             if "one_to_one" in child.relationEditorConfiguration():
-                self.assertTrue(child.relationEditorConfiguration()["one_to_one"])
+                self.assertFalse(child.relationEditorConfiguration()["one_to_one"])
 
         for child in tab_job.children():
             if "one_to_one" in child.relationEditorConfiguration():
@@ -3142,7 +3142,7 @@ class TestProjectGen(unittest.TestCase):
 
         for child in tab_ahvnr.children():
             if "one_to_one" in child.relationEditorConfiguration():
-                self.assertTrue(child.relationEditorConfiguration()["one_to_one"])
+                self.assertFalse(child.relationEditorConfiguration()["one_to_one"])
 
         for child in tab_job.children():
             if "one_to_one" in child.relationEditorConfiguration():

--- a/tests/testdata/ilimodels/CompAssoc23.ili
+++ b/tests/testdata/ilimodels/CompAssoc23.ili
@@ -1,0 +1,41 @@
+INTERLIS 2.3;
+
+MODEL CompAssoc
+  AT "http://modelbaker.ch" VERSION "2025-06-10" =
+
+  TOPIC Test =
+
+    CLASS ClassA1=
+    END ClassA1;
+
+    CLASS ClassB1 =
+    END ClassB1;
+
+    /* Composition and fake composition leading to QGIS compositions */
+
+    !! Real composition
+    ASSOCIATION comp =
+      comp_a -<#> {1} ClassA1;
+      comp_b -- {0..*} ClassB1;
+    END comp;
+
+    !! Association that leads to QGIS composition
+    ASSOCIATION fakecomp1 =
+      fakecomp_1a -- {1} ClassA1;
+      fakecomp_1b -- {0..*} ClassB1;
+    END fakecomp1;
+
+    ASSOCIATION fakecomp2 =
+      fakecomp_2a -<> {1} ClassA1;
+      fakecomp_2b -- {0..*} ClassB1;
+    END fakecomp2;
+
+    /* Association leading to two QGIS compositions (because normalized the relations from the linking table are compositions) */
+
+    ASSOCIATION assoc =
+      assoc_a -- {0..*} ClassA1;
+      assoc_b -- {0..*} ClassB1;
+    END assoc;
+
+  END Test;
+END CompAssoc.


### PR DESCRIPTION
In INTERLIS you can define three types of strengths in an ASSOCIATION:

- Association `..` : objects exist independently
- Aggregation `.<>` : Child objects belong to one (or no) parent. They should be copied with the parent, but not deleted.
- Composition `.<#>`: Child objects belong to a parent. They should be copied with the parent and also deleted.

Normally the QGIS relations of such compositions also become compositions in QGIS and associations become associations. Aggregations - i.e. the use case with copying but not deleting - are not supported in QGIS, which is why they also become associations.

However, new associations or aggregations sometimes also become compositions in QGIS.

1. if the cardinality is exactly 1:
```
    ASSOCIATION fakecomp1 =
      fakecomp_1a -- {1} ClassA1;
      fakecomp_1b -- {0..*} ClassB1;
    END fakecomp1;
```
or
```
    ASSOCIATION fakecomp2 =
      fakecomp_2a -<> {1} ClassA1;
      fakecomp_2b -- {0..*} ClassB1;
    END fakecomp2;
```

Because such an object cannot exist without a parent. This fixes 

2. if it is a linking table:

```
    ASSOCIATION assoc =
      assoc_a -- {0..*} ClassA1;
      assoc_b -- {0..*} ClassB1;
    END assoc;
```

Which results in two QGIS relations (normalized) with a linking table.

If one of the parents is deleted, the linking table entry is also deleted (but not the other linked parent).
