### PR TITLE
Qt6 (QGIS 4) compatibility

### DIFF
--- a/modelbaker/dataobjects/fields.py
+++ b/modelbaker/dataobjects/fields.py
@@ -66,11 +66,11 @@ class Field:
             # if defined, then set not null and unique constraints
             layer.layer.setFieldConstraint(
                 field_idx,
-                QgsFieldConstraints.ConstraintNotNull,
-                QgsFieldConstraints.ConstraintStrengthHard,
+                QgsFieldConstraints.Constraint.ConstraintNotNull,
+                QgsFieldConstraints.ConstraintStrength.ConstraintStrengthHard,
             )
             layer.layer.setFieldConstraint(
                 field_idx,
-                QgsFieldConstraints.ConstraintUnique,
-                QgsFieldConstraints.ConstraintStrengthHard,
+                QgsFieldConstraints.Constraint.ConstraintUnique,
+                QgsFieldConstraints.ConstraintStrength.ConstraintStrengthHard,
             )

--- a/modelbaker/dataobjects/form.py
+++ b/modelbaker/dataobjects/form.py
@@ -116,7 +116,7 @@ class Form:
         root_container.clear()
         for element in self.__elements:
             root_container.addChildElement(element.create(root_container, qgis_layer))
-        edit_form_config.setLayout(QgsEditFormConfig.TabLayout)
+        edit_form_config.setLayout(QgsEditFormConfig.EditorLayout.TabLayout)
         # set nm-rel if referencing tables are junction table
         for relation in project.relations:
             if relation.referenced_layer == layer:

--- a/modelbaker/dataobjects/layers.py
+++ b/modelbaker/dataobjects/layers.py
@@ -52,7 +52,7 @@ class Layer:
         srid: Optional[int] = None,
         extent: Optional[str] = None,
         geometry_column: str = None,
-        wkb_type: QgsWkbTypes = QgsWkbTypes.Unknown,
+        wkb_type: QgsWkbTypes = QgsWkbTypes.Type.Unknown,
         alias: Optional[str] = None,
         is_domain: bool = False,  # is enumeration or catalogue
         is_structure: bool = False,

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -316,7 +316,7 @@ class Project(QObject):
                     )
 
         for layer in self.layers:
-            if layer.layer.type() == QgsMapLayer.VectorLayer:
+            if layer.layer.type() == QgsMapLayer.LayerType.VectorLayer:
                 # even when a style will be loaded we create the form because not sure if the style contains form settngs
                 layer.create_form(self)
                 layer.store_variables(self)

--- a/modelbaker/dataobjects/relations.py
+++ b/modelbaker/dataobjects/relations.py
@@ -10,7 +10,7 @@ class Relation:
         self.referencing_field = None
         self.referenced_field = None
         self.name = None
-        self.strength = QgsRelation.Association
+        self.strength = QgsRelation.RelationStrength.Association
         self.cardinality_max = None
         self.cardinality_min = None
         self.child_domain_name = None

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -775,7 +775,7 @@ class GPKGConnector(DBConnector):
         cursor.close()
         if result > 1:
             self.new_message.emit(
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
                 "DB schema created with ili2db version 3. Better use version 4.",
             )
             return 3

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -892,7 +892,7 @@ WHERE TABLE_SCHEMA='{schema}'
         res = cur.fetchone()[0]
         if res > 0:
             self.new_message.emit(
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
                 "DB schema created with ili2db version 3. Better use version 4.",
             )
             return 3

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -983,7 +983,7 @@ class PGConnector(DBConnector):
         )
         if cur.rowcount > 1:
             self.new_message.emit(
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
                 "DB schema created with ili2db version 3. Better use version 4.",
             )
             return 3

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -303,7 +303,7 @@ class Generator(QObject):
                 record.get("srid"),
                 record.get("extent"),
                 record.get("geometry_column"),
-                QgsWkbTypes.parseType(record["type"]) or QgsWkbTypes.Unknown,
+                QgsWkbTypes.parseType(record["type"]) or QgsWkbTypes.Type.Unknown,
                 alias,
                 is_domain,
                 is_structure,
@@ -437,14 +437,14 @@ class Generator(QObject):
                     field.widget_config["calendar_popup"] = True
 
                     dateFormat = QLocale(QgsApplication.instance().locale()).dateFormat(
-                        QLocale.ShortFormat
+                        QLocale.FormatType.ShortFormat
                     )
                     timeFormat = QLocale(QgsApplication.instance().locale()).timeFormat(
-                        QLocale.ShortFormat
+                        QLocale.FormatType.ShortFormat
                     )
                     dateTimeFormat = QLocale(
                         QgsApplication.instance().locale()
-                    ).dateTimeFormat(QLocale.ShortFormat)
+                    ).dateTimeFormat(QLocale.FormatType.ShortFormat)
 
                     if data_type == self._db_connector.QGIS_TIME_TYPE:
                         field.widget_config["display_format"] = timeFormat
@@ -585,7 +585,7 @@ class Generator(QObject):
                             "assoc_cardinality_min", None
                         )
 
-                        relation.strength = QgsRelation.Association
+                        relation.strength = QgsRelation.RelationStrength.Association
                         if (
                             # if it's a defined composition...
                             record.get("strength", None) == "COMPOSITE"
@@ -603,7 +603,7 @@ class Generator(QObject):
                             )
                         ):
                             # ...then it's a composition in QGIS
-                            relation.strength = QgsRelation.Composition
+                            relation.strength = QgsRelation.RelationStrength.Composition
 
                         # For domain-class relations, if we have an extended domain, get its child name
                         child_name = None
@@ -968,11 +968,11 @@ class Generator(QObject):
         for layer in layers:
             if layer.geometry_column:
                 geometry_type = QgsWkbTypes.geometryType(layer.wkb_type)
-                if geometry_type == QgsWkbTypes.PointGeometry:
+                if geometry_type == QgsWkbTypes.GeometryType.PointGeometry:
                     point_layers.append(layer)
-                elif geometry_type == QgsWkbTypes.LineGeometry:
+                elif geometry_type == QgsWkbTypes.GeometryType.LineGeometry:
                     line_layers.append(layer)
-                elif geometry_type == QgsWkbTypes.PolygonGeometry:
+                elif geometry_type == QgsWkbTypes.GeometryType.PolygonGeometry:
                     polygon_layers.append(layer)
             else:
                 if layer.is_domain:

--- a/modelbaker/ilitoppingmaker/iliprojecttopping.py
+++ b/modelbaker/ilitoppingmaker/iliprojecttopping.py
@@ -73,12 +73,12 @@ class IliProjectTopping(ProjectTopping):
         Creates everything - generates all the files.
         Returns the path to the ilidata.xml file.
         """
-        self.stdout.emit(self.tr("Generate everything."), Qgis.Info)
+        self.stdout.emit(self.tr("Generate everything."), Qgis.MessageLevel.Info)
         ilidata_path = None
         if not project:
             self.stdout.emit(
                 self.tr("Cannot generate anything without having a QGIS project."),
-                Qgis.Warning,
+                Qgis.MessageLevel.Warning,
             )
             return False
         # Creates and sets the project_topping considering the passed QgsProject and the existing ExportSettings.
@@ -94,7 +94,9 @@ class IliProjectTopping(ProjectTopping):
 
         # generate metaconfig (topping) file
         if self.metaconfig.generate_files(self.target):
-            self.stdout.emit(self.tr("MetaConfig written to INI file."), Qgis.Info)
+            self.stdout.emit(
+                self.tr("MetaConfig written to INI file."), Qgis.MessageLevel.Info
+            )
 
         # generate ilidata
         ilidata = IliData()
@@ -104,7 +106,7 @@ class IliProjectTopping(ProjectTopping):
         if ilidata_path:
             self.stdout.emit(
                 self.tr("IliData written to XML file: {}").format(ilidata_path),
-                Qgis.Info,
+                Qgis.MessageLevel.Info,
             )
 
         return ilidata_path

--- a/modelbaker/iliwrapper/ili2dbargs.py
+++ b/modelbaker/iliwrapper/ili2dbargs.py
@@ -100,7 +100,7 @@ def _get_db_args(configuration, hide_password=False):
         if configuration.dbparam_map:
             temporary_filename = "{}/modelbaker-dbargs.conf".format(QDir.tempPath())
             temporary_file = QFile(temporary_filename)
-            if temporary_file.open(QFile.WriteOnly):
+            if temporary_file.open(QFile.OpenModeFlag.WriteOnly):
                 if configuration.dbparam_map:
                     for key in configuration.dbparam_map.keys():
                         temporary_file.write(

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -169,7 +169,7 @@ class Ili2DbCommandConfiguration:
         )
 
         proxy = QgsNetworkAccessManager.instance().fallbackProxy()
-        if proxy.type() == QNetworkProxy.HttpProxy:
+        if proxy.type() == QNetworkProxy.ProxyType.HttpProxy:
             self.append_args(args, ["--proxy", proxy.hostName()], force_append=True)
             self.append_args(
                 args, ["--proxyPort", str(proxy.port())], force_append=True

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -25,10 +25,17 @@ import urllib.parse
 import xml.etree.ElementTree as ET
 from enum import Enum
 
-from PyQt5.QtCore import QDir, QObject, QSortFilterProxyModel, Qt, QTimer, pyqtSignal
-from PyQt5.QtGui import QPalette, QRegion, QStandardItem, QStandardItemModel
-from PyQt5.QtWidgets import QGridLayout, QItemDelegate, QLabel, QStyle, QWidget
 from qgis.core import Qgis, QgsMessageLog
+from qgis.PyQt.QtCore import (
+    QDir,
+    QObject,
+    QSortFilterProxyModel,
+    Qt,
+    QTimer,
+    pyqtSignal,
+)
+from qgis.PyQt.QtGui import QPalette, QRegion, QStandardItem, QStandardItemModel
+from qgis.PyQt.QtWidgets import QGridLayout, QItemDelegate, QLabel, QStyle, QWidget
 
 from ..utils.qt_utils import download_file
 from .ili2dbutils import get_all_modeldir_in_path
@@ -50,7 +57,7 @@ class IliCache(QObject):
         self.model = IliModelItemModel()
         self.sorted_model = QSortFilterProxyModel()
         self.sorted_model.setSourceModel(self.model)
-        self.sorted_model.sort(0, Qt.AscendingOrder)
+        self.sorted_model.sort(0, Qt.SortOrder.AscendingOrder)
         self.directories = None
         if self.base_configuration:
             self.directories = self.base_configuration.model_directories
@@ -290,7 +297,7 @@ class IliCache(QObject):
             try:
                 fileModels = self.parse_ili_file(ilifile, "latin1")
                 self.new_message.emit(
-                    Qgis.Warning,
+                    Qgis.MessageLevel.Warning,
                     self.tr(
                         "Even though the ili file `{}` could be read, it is not in UTF-8. Please encode your ili models in UTF-8.".format(
                             os.path.basename(ilifile)
@@ -299,7 +306,7 @@ class IliCache(QObject):
                 )
             except UnicodeDecodeError as e:
                 self.new_message.emit(
-                    Qgis.Critical,
+                    Qgis.MessageLevel.Critical,
                     self.tr(
                         "Could not parse ili file `{}` with UTF-8 nor Latin-1 encodings. Please encode your ili models in UTF-8.".format(
                             os.path.basename(ilifile)
@@ -366,8 +373,8 @@ class IliCache(QObject):
 
 class IliModelItemModel(QStandardItemModel):
     class Roles(Enum):
-        ILIREPO = Qt.UserRole + 1
-        VERSION = Qt.UserRole + 2
+        ILIREPO = Qt.ItemDataRole.UserRole + 1
+        VERSION = Qt.ItemDataRole.UserRole + 2
 
         def __int__(self):
             return self.value
@@ -387,8 +394,10 @@ class IliModelItemModel(QStandardItemModel):
                     continue
 
                 item = QStandardItem()
-                item.setData(model["name"], int(Qt.DisplayRole))
-                item.setData(model["name"], int(Qt.EditRole))  # considered in completer
+                item.setData(model["name"], int(Qt.ItemDataRole.DisplayRole))
+                item.setData(
+                    model["name"], int(Qt.ItemDataRole.EditRole)
+                )  # considered in completer
                 item.setData(model["repository"], int(IliModelItemModel.Roles.ILIREPO))
                 item.setData(model["version"], int(IliModelItemModel.Roles.VERSION))
 
@@ -408,9 +417,9 @@ class ModelCompleterDelegate(QItemDelegate):
         self.widget.setLayout(QGridLayout())
         self.widget.layout().setContentsMargins(2, 0, 0, 0)
         self.model_label = QLabel()
-        self.model_label.setAttribute(Qt.WA_TranslucentBackground)
+        self.model_label.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.repository_label = QLabel()
-        self.repository_label.setAlignment(Qt.AlignRight)
+        self.repository_label.setAlignment(Qt.AlignmentFlag.AlignRight)
         self.widget.layout().addWidget(self.model_label, 0, 0)
         self.widget.layout().addWidget(self.repository_label, 0, 1)
 
@@ -430,13 +439,17 @@ class ModelCompleterDelegate(QItemDelegate):
         self.widget.setMinimumSize(rect.size())
 
         model_palette = option.palette
-        if option.state & QStyle.State_Selected:
+        if option.state & QStyle.StateFlag.State_Selected:
             model_palette.setColor(
-                QPalette.WindowText,
-                model_palette.color(QPalette.Active, QPalette.HighlightedText),
+                QPalette.ColorRole.WindowText,
+                model_palette.color(
+                    QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText
+                ),
             )
 
-        self.widget.render(painter, rect.topLeft(), QRegion(), QWidget.DrawChildren)
+        self.widget.render(
+            painter, rect.topLeft(), QRegion(), QWidget.RenderFlag.DrawChildren
+        )
 
 
 class IliDataCache(IliCache):
@@ -456,7 +469,7 @@ class IliDataCache(IliCache):
             lambda: self.model_refreshed.emit(self.model.rowCount())
         )
         self.sorted_model.setSourceModel(self.model)
-        self.sorted_model.sort(0, Qt.AscendingOrder)
+        self.sorted_model.sort(0, Qt.SortOrder.AscendingOrder)
         self.filter_models = models.split(";") if models else []
         self.type = type
         self.directories = (
@@ -718,16 +731,16 @@ class IliDataCache(IliCache):
 
 class IliDataItemModel(QStandardItemModel):
     class Roles(Enum):
-        ILIREPO = Qt.UserRole + 1
-        VERSION = Qt.UserRole + 2
-        MODELS = Qt.UserRole + 3
-        RELATIVEFILEPATH = Qt.UserRole + 4
-        OWNER = Qt.UserRole + 5
-        TITLE = Qt.UserRole + 6
-        ID = Qt.UserRole + 7
-        URL = Qt.UserRole + 8
-        MODEL_LINKS = Qt.UserRole + 9
-        SHORT_DESCRIPTION = Qt.UserRole + 10
+        ILIREPO = Qt.ItemDataRole.UserRole + 1
+        VERSION = Qt.ItemDataRole.UserRole + 2
+        MODELS = Qt.ItemDataRole.UserRole + 3
+        RELATIVEFILEPATH = Qt.ItemDataRole.UserRole + 4
+        OWNER = Qt.ItemDataRole.UserRole + 5
+        TITLE = Qt.ItemDataRole.UserRole + 6
+        ID = Qt.ItemDataRole.UserRole + 7
+        URL = Qt.ItemDataRole.UserRole + 8
+        MODEL_LINKS = Qt.ItemDataRole.UserRole + 9
+        SHORT_DESCRIPTION = Qt.ItemDataRole.UserRole + 10
 
         def __int__(self):
             return self.value
@@ -759,9 +772,9 @@ class IliDataItemModel(QStandardItemModel):
                 ):
                     short_description = dataitem["short_description"][0]["text"]
 
-                item.setData(display_value, int(Qt.DisplayRole))
-                item.setData(display_value, int(Qt.EditRole))
-                item.setData(short_description, int(Qt.ToolTipRole))
+                item.setData(display_value, int(Qt.ItemDataRole.DisplayRole))
+                item.setData(display_value, int(Qt.ItemDataRole.EditRole))
+                item.setData(short_description, int(Qt.ItemDataRole.ToolTipRole))
                 item.setData(dataitem["id"], int(IliDataItemModel.Roles.ID))
                 item.setData(
                     dataitem["repository"], int(IliDataItemModel.Roles.ILIREPO)
@@ -801,9 +814,9 @@ class IliDataFileCompleterDelegate(QItemDelegate):
         self.widget.setLayout(QGridLayout())
         self.widget.layout().setContentsMargins(2, 0, 0, 0)
         self.ilidatafile_label = QLabel()
-        self.ilidatafile_label.setAttribute(Qt.WA_TranslucentBackground)
+        self.ilidatafile_label.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
         self.repository_label = QLabel()
-        self.repository_label.setAlignment(Qt.AlignRight)
+        self.repository_label.setAlignment(Qt.AlignmentFlag.AlignRight)
         self.widget.layout().addWidget(self.ilidatafile_label, 0, 0)
         self.widget.layout().addWidget(self.repository_label, 0, 1)
 
@@ -813,7 +826,7 @@ class IliDataFileCompleterDelegate(QItemDelegate):
 
     def drawDisplay(self, painter, option, rect, text):
         repository = option.index.data(int(IliDataItemModel.Roles.ILIREPO))
-        display_text = option.index.data(int(Qt.DisplayRole))
+        display_text = option.index.data(int(Qt.ItemDataRole.DisplayRole))
 
         self.repository_label.setText(
             '<font color="#666666"><i>{repository}</i></font>'.format(
@@ -826,13 +839,17 @@ class IliDataFileCompleterDelegate(QItemDelegate):
         self.widget.setMinimumSize(rect.size())
 
         model_palette = option.palette
-        if option.state & QStyle.State_Selected:
+        if option.state & QStyle.StateFlag.State_Selected:
             model_palette.setColor(
-                QPalette.WindowText,
-                model_palette.color(QPalette.Active, QPalette.HighlightedText),
+                QPalette.ColorRole.WindowText,
+                model_palette.color(
+                    QPalette.ColorGroup.Active, QPalette.ColorRole.HighlightedText
+                ),
             )
 
-        self.widget.render(painter, rect.topLeft(), QRegion(), QWidget.DrawChildren)
+        self.widget.render(
+            painter, rect.topLeft(), QRegion(), QWidget.RenderFlag.DrawChildren
+        )
 
 
 class IliToppingFileCache(IliDataCache):
@@ -849,7 +866,7 @@ class IliToppingFileCache(IliDataCache):
         IliDataCache.__init__(self, configuration)
         self.model = IliToppingFileItemModel()
         self.sorted_model.setSourceModel(self.model)
-        self.sorted_model.sort(0, Qt.AscendingOrder)
+        self.sorted_model.sort(0, Qt.SortOrder.AscendingOrder)
         self.file_ids = file_ids
         self.tool_dir = (
             tool_dir
@@ -986,12 +1003,12 @@ class IliToppingFileCache(IliDataCache):
 
 class IliToppingFileItemModel(QStandardItemModel):
     class Roles(Enum):
-        ILIREPO = Qt.UserRole + 1
-        VERSION = Qt.UserRole + 2
-        RELATIVEFILEPATH = Qt.UserRole + 3
-        LOCALFILEPATH = Qt.UserRole + 4
-        OWNER = Qt.UserRole + 5
-        URL = Qt.UserRole + 6
+        ILIREPO = Qt.ItemDataRole.UserRole + 1
+        VERSION = Qt.ItemDataRole.UserRole + 2
+        RELATIVEFILEPATH = Qt.ItemDataRole.UserRole + 3
+        LOCALFILEPATH = Qt.ItemDataRole.UserRole + 4
+        OWNER = Qt.ItemDataRole.UserRole + 5
+        URL = Qt.ItemDataRole.UserRole + 6
 
         def __int__(self):
             return self.value
@@ -1009,8 +1026,8 @@ class IliToppingFileItemModel(QStandardItemModel):
                 if any(toppingfile["id"] == s for s in ids):
                     continue
                 item = QStandardItem()
-                item.setData(toppingfile["id"], int(Qt.DisplayRole))
-                item.setData(toppingfile["id"], int(Qt.EditRole))
+                item.setData(toppingfile["id"], int(Qt.ItemDataRole.DisplayRole))
+                item.setData(toppingfile["id"], int(Qt.ItemDataRole.EditRole))
                 item.setData(
                     toppingfile["repository"],
                     int(IliToppingFileItemModel.Roles.ILIREPO),

--- a/modelbaker/iliwrapper/ilivalidator.py
+++ b/modelbaker/iliwrapper/ilivalidator.py
@@ -20,8 +20,8 @@
 import xml.etree.ElementTree as CET
 from enum import Enum
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QStandardItem, QStandardItemModel
+from qgis.PyQt.QtCore import Qt
+from qgis.PyQt.QtGui import QStandardItem, QStandardItemModel
 
 from .ili2dbconfig import ValidateConfiguration
 from .iliexecutable import IliExecutable
@@ -53,21 +53,21 @@ class ValidationResultModel(QStandardItemModel):
     """
 
     class Roles(Enum):
-        ID = Qt.UserRole + 1
-        MESSAGE = Qt.UserRole + 2
-        TYPE = Qt.UserRole + 3
-        OBJ_TAG = Qt.UserRole + 4
-        TID = Qt.UserRole + 5
-        TECH_ID = Qt.UserRole + 6
-        USER_ID = Qt.UserRole + 7
-        ILI_Q_NAME = Qt.UserRole + 8
-        DATA_SOURCE = Qt.UserRole + 9
-        LINE = Qt.UserRole + 10
-        COORD_X = Qt.UserRole + 11
-        COORD_Y = Qt.UserRole + 12
-        TECH_DETAILS = Qt.UserRole + 13
+        ID = Qt.ItemDataRole.UserRole + 1
+        MESSAGE = Qt.ItemDataRole.UserRole + 2
+        TYPE = Qt.ItemDataRole.UserRole + 3
+        OBJ_TAG = Qt.ItemDataRole.UserRole + 4
+        TID = Qt.ItemDataRole.UserRole + 5
+        TECH_ID = Qt.ItemDataRole.UserRole + 6
+        USER_ID = Qt.ItemDataRole.UserRole + 7
+        ILI_Q_NAME = Qt.ItemDataRole.UserRole + 8
+        DATA_SOURCE = Qt.ItemDataRole.UserRole + 9
+        LINE = Qt.ItemDataRole.UserRole + 10
+        COORD_X = Qt.ItemDataRole.UserRole + 11
+        COORD_Y = Qt.ItemDataRole.UserRole + 12
+        TECH_DETAILS = Qt.ItemDataRole.UserRole + 13
 
-        FIXED = Qt.UserRole + 14
+        FIXED = Qt.ItemDataRole.UserRole + 14
 
         def __int__(self):
             return self.value

--- a/modelbaker/utils/ili2db_utils.py
+++ b/modelbaker/utils/ili2db_utils.py
@@ -57,7 +57,7 @@ class Ili2DbUtils(QObject):
         deleter.configuration = DeleteConfiguration(configuration)
         deleter.configuration.baskets = baskets
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self._connect_ili_executable_signals(deleter)
             self._log = ""
 
@@ -91,7 +91,7 @@ class Ili2DbUtils(QObject):
         deleter.configuration = DeleteConfiguration(configuration)
         deleter.configuration.dataset = dataset
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self._connect_ili_executable_signals(deleter)
             self._log = ""
 
@@ -125,7 +125,7 @@ class Ili2DbUtils(QObject):
         metaconfig_exporter.configuration = ExportMetaConfigConfiguration(configuration)
         metaconfig_exporter.configuration.metaconfigoutputfile = ini_file
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self._connect_ili_executable_signals(metaconfig_exporter)
             self._log = ""
 

--- a/modelbaker/utils/qgis_utils.py
+++ b/modelbaker/utils/qgis_utils.py
@@ -56,12 +56,12 @@ def get_first_index_for_layer_type(layer_type, group, ignore_node_names=None):
             # specific position (e.g., at the top), so, skip it to get indices
             continue
         if (
-            tree_node.nodeType() == QgsLayerTreeNode.NodeGroup
+            tree_node.nodeType() == QgsLayerTreeNode.NodeType.NodeGroup
             and layer_type != "unknown"
         ):
             return None
         elif (
-            tree_node.nodeType() == QgsLayerTreeNode.NodeGroup
+            tree_node.nodeType() == QgsLayerTreeNode.NodeType.NodeGroup
             and layer_type == "unknown"
         ):
             # We've reached the lowest index in the layer tree before a group
@@ -108,15 +108,15 @@ def get_layer_type(layer):
     """
     To deal with all layer types, map their types to known values
     """
-    if layer.type() == QgsMapLayer.VectorLayer:
+    if layer.type() == QgsMapLayer.LayerType.VectorLayer:
         if layer.isSpatial():
-            if layer.geometryType() == QgsWkbTypes.UnknownGeometry:
+            if layer.geometryType() == QgsWkbTypes.GeometryType.UnknownGeometry:
                 return "unknown"
             else:
                 return layer_order[layer.geometryType()]  # Point, Line or Polygon
         else:
             return "table"
-    elif layer.type() == QgsMapLayer.RasterLayer:
+    elif layer.type() == QgsMapLayer.LayerType.RasterLayer:
         return "raster"
     else:
         return "unknown"
@@ -162,7 +162,7 @@ class QgisProjectUtils:
         tree_layers = root.findLayers()
         for tree_layer in tree_layers:
             # get t_ili_tid field OID field
-            if tree_layer.layer().type() != QgsMapLayer.VectorLayer:
+            if tree_layer.layer().type() != QgsMapLayer.LayerType.VectorLayer:
                 continue
             fields = tree_layer.layer().fields()
             field_idx = fields.lookupField("t_ili_tid")
@@ -205,11 +205,11 @@ class QgisProjectUtils:
             # get the constraints
             oid_setting["not_null"] = bool(
                 t_ili_tid_field.constraints().constraints()
-                & QgsFieldConstraints.ConstraintNotNull
+                & QgsFieldConstraints.Constraint.ConstraintNotNull
             )
             oid_setting["unique"] = bool(
                 t_ili_tid_field.constraints().constraints()
-                & QgsFieldConstraints.ConstraintUnique
+                & QgsFieldConstraints.Constraint.ConstraintUnique
             )
 
             oid_settings[tree_layer.layer().name()] = oid_setting
@@ -268,48 +268,48 @@ class QgisProjectUtils:
                 if (
                     not bool(
                         t_ili_tid_field.constraints().constraints()
-                        & QgsFieldConstraints.ConstraintNotNull
+                        & QgsFieldConstraints.Constraint.ConstraintNotNull
                     )
                     and oid_setting["not_null"]
                 ):
                     layer.setFieldConstraint(
                         field_idx,
-                        QgsFieldConstraints.ConstraintNotNull,
-                        QgsFieldConstraints.ConstraintStrengthHard,
+                        QgsFieldConstraints.Constraint.ConstraintNotNull,
+                        QgsFieldConstraints.ConstraintStrength.ConstraintStrengthHard,
                     )
                 if (
                     bool(
                         t_ili_tid_field.constraints().constraints()
-                        & QgsFieldConstraints.ConstraintNotNull
+                        & QgsFieldConstraints.Constraint.ConstraintNotNull
                     )
                     and not oid_setting["not_null"]
                 ):
                     layer.removeFieldConstraint(
                         field_idx,
-                        QgsFieldConstraints.ConstraintNotNull,
+                        QgsFieldConstraints.Constraint.ConstraintNotNull,
                     )
                 if (
                     not bool(
                         t_ili_tid_field.constraints().constraints()
-                        & QgsFieldConstraints.ConstraintUnique
+                        & QgsFieldConstraints.Constraint.ConstraintUnique
                     )
                     and oid_setting["unique"]
                 ):
                     layer.setFieldConstraint(
                         field_idx,
-                        QgsFieldConstraints.ConstraintUnique,
-                        QgsFieldConstraints.ConstraintStrengthHard,
+                        QgsFieldConstraints.Constraint.ConstraintUnique,
+                        QgsFieldConstraints.ConstraintStrength.ConstraintStrengthHard,
                     )
                 if (
                     bool(
                         t_ili_tid_field.constraints().constraints()
-                        & QgsFieldConstraints.ConstraintUnique
+                        & QgsFieldConstraints.Constraint.ConstraintUnique
                     )
                     and not oid_setting["unique"]
                 ):
                     layer.removeFieldConstraint(
                         field_idx,
-                        QgsFieldConstraints.ConstraintUnique,
+                        QgsFieldConstraints.Constraint.ConstraintUnique,
                     )
 
     def _found_tilitid(self, container):

--- a/modelbaker/utils/qt_utils.py
+++ b/modelbaker/utils/qt_utils.py
@@ -71,7 +71,7 @@ def selectFileNameToSave(
         title,
         line_edit_widget.text(),
         file_filter,
-        options=QFileDialog.DontConfirmOverwrite
+        options=QFileDialog.Option.DontConfirmOverwrite
         if dont_confirm_overwrite
         else QFileDialog.Options(),
     )
@@ -161,9 +161,10 @@ def download_file(
     network_access_manager = QgsNetworkAccessManager.instance()
 
     req = QNetworkRequest(QUrl(url))
-    req.setAttribute(QNetworkRequest.CacheSaveControlAttribute, False)
+    req.setAttribute(QNetworkRequest.Attribute.CacheSaveControlAttribute, False)
     req.setAttribute(
-        QNetworkRequest.CacheLoadControlAttribute, QNetworkRequest.AlwaysNetwork
+        QNetworkRequest.Attribute.CacheLoadControlAttribute,
+        QNetworkRequest.CacheLoadControl.AlwaysNetwork,
     )
     req.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
     reply = network_access_manager.get(req)
@@ -173,7 +174,7 @@ def download_file(
 
     def finished(filename, reply, on_error, on_success, on_finished):
         file = QFile(filename)
-        file.open(QIODevice.WriteOnly)
+        file.open(QIODevice.OpenModeFlag.WriteOnly)
         file.write(reply.readAll())
         file.close()
         if reply.error() and on_error:
@@ -200,7 +201,7 @@ def download_file(
     if not on_finished and not on_success:
         loop = QEventLoop()
         reply.finished.connect(loop.quit)
-        loop.exec_()
+        loop.exec()
 
         if reply.error():
             raise NetworkError(reply.error(), reply.errorString())

--- a/modelbaker/utils/qt_utils.py
+++ b/modelbaker/utils/qt_utils.py
@@ -24,6 +24,7 @@ from functools import partial
 
 from qgis.core import QgsNetworkAccessManager
 from qgis.PyQt.QtCore import (
+    QT_VERSION_STR,
     QCoreApplication,
     QEventLoop,
     QFile,
@@ -166,7 +167,9 @@ def download_file(
         QNetworkRequest.Attribute.CacheLoadControlAttribute,
         QNetworkRequest.CacheLoadControl.AlwaysNetwork,
     )
-    req.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
+
+    if QT_VERSION_STR < "6.0.0":
+        req.setAttribute(QNetworkRequest.FollowRedirectsAttribute, True)
     reply = network_access_manager.get(req)
 
     def on_download_progress(bytes_received, bytes_total):

--- a/tests/test_ilicache.py
+++ b/tests/test_ilicache.py
@@ -370,18 +370,18 @@ class IliCacheTest(unittest.TestCase):
             int(IliDataItemModel.Roles.ID),
             "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0",
             1,
-            Qt.MatchExactly,
+            Qt.MatchFlag.MatchExactly,
         )
         assert bool(matches_on_id) is True
 
         if matches_on_id:
             assert (
                 "Einfaches Styling und Tree und TOML und SH Cat (OPENGIS.ch)"
-                == matches_on_id[0].data(Qt.EditRole)
+                == matches_on_id[0].data(Qt.ItemDataRole.EditRole)
             )
             assert (
                 "Einfaches Styling und Tree und TOML und SH Cat (OPENGIS.ch)"
-                == matches_on_id[0].data(Qt.DisplayRole)
+                == matches_on_id[0].data(Qt.ItemDataRole.DisplayRole)
             )
             assert "test_repo" == matches_on_id[0].data(
                 int(IliDataItemModel.Roles.ILIREPO)
@@ -450,14 +450,16 @@ class IliCacheTest(unittest.TestCase):
             int(IliDataItemModel.Roles.ID),
             "ch.opengis.ili.config.PlanerischerGewaesserschutz_config_localfile",
             1,
-            Qt.MatchExactly,
+            Qt.MatchFlag.MatchExactly,
         )
         assert bool(matches_on_id) is True
 
         if matches_on_id:
-            assert "Mit lokalem Legendenkatalog" == matches_on_id[0].data(Qt.EditRole)
             assert "Mit lokalem Legendenkatalog" == matches_on_id[0].data(
-                Qt.DisplayRole
+                Qt.ItemDataRole.EditRole
+            )
+            assert "Mit lokalem Legendenkatalog" == matches_on_id[0].data(
+                Qt.ItemDataRole.DisplayRole
             )
             assert os.path.join(
                 test_path, "testdata", "ilirepo", "usabilityhub"
@@ -631,19 +633,19 @@ class IliCacheTest(unittest.TestCase):
 
         matches_on_id = ilitoppingfilecache_model.match(
             ilitoppingfilecache_model.index(0, 0),
-            Qt.DisplayRole,
+            Qt.ItemDataRole.DisplayRole,
             "ilidata:ch.opengis.topping.opengisch_KbS_LV95_V1_4_001",
             1,
-            Qt.MatchExactly,
+            Qt.MatchFlag.MatchExactly,
         )
         assert bool(matches_on_id) is True
         if matches_on_id:
             assert (
                 "ilidata:ch.opengis.topping.opengisch_KbS_LV95_V1_4_001"
-            ), matches_on_id[0].data(Qt.EditRole)
+            ), matches_on_id[0].data(Qt.ItemDataRole.EditRole)
             assert (
                 "ilidata:ch.opengis.topping.opengisch_KbS_LV95_V1_4_001"
-            ), matches_on_id[0].data(Qt.DisplayRole)
+            ), matches_on_id[0].data(Qt.ItemDataRole.DisplayRole)
             assert "test_repo", matches_on_id[0].data(
                 int(IliToppingFileItemModel.Roles.ILIREPO)
             )

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -99,7 +99,10 @@ class TestProjectGen(unittest.TestCase):
                 belasteter_standort_punkt_layer = layer
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 fields = {field.name() for field in tabs[0].children()}
                 assert fields == {
@@ -218,7 +221,10 @@ class TestProjectGen(unittest.TestCase):
                 belasteter_standort_punkt_layer = layer
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 fields = {field.name() for field in tabs[0].children()}
                 assert fields == {
@@ -336,7 +342,10 @@ class TestProjectGen(unittest.TestCase):
             if layer.name == "belasteter_standort":  # Polygon
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 fields = {field.name() for field in tabs[0].children()}
                 assert fields == {
@@ -437,7 +446,10 @@ class TestProjectGen(unittest.TestCase):
             if layer.name == "belasteter_standort":  # Polygon
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 fields = {field.name() for field in tabs[0].children()}
                 assert fields == {
@@ -2439,42 +2451,42 @@ class TestProjectGen(unittest.TestCase):
 
         assert (
             qgis_project.relationManager().relation("agg3_agg3_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         assert (
             qgis_project.relationManager().relation("agg3_agg3_b_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc3_assoc3_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc3_assoc3_b_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         assert (
             qgis_project.relationManager().relation("classb1_agg1_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager().relation("classb1_agg2_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager().relation("classb1_assoc1_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager().relation("classb1_assoc2_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         # and that's the one with the strength 1 (composition)
         assert (
             qgis_project.relationManager().relation("classb1_comp1_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
 
     def test_relation_strength_geopackage(self):
@@ -2518,58 +2530,58 @@ class TestProjectGen(unittest.TestCase):
             qgis_project.relationManager()
             .relation("agg3_agg3_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         assert (
             qgis_project.relationManager()
             .relation("agg3_agg3_b_classb1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager()
             .relation("assoc3_assoc3_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager()
             .relation("assoc3_assoc3_b_classb1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         assert (
             qgis_project.relationManager()
             .relation("classb1_agg1_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager()
             .relation("classb1_agg2_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager()
             .relation("classb1_assoc1_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager()
             .relation("classb1_assoc2_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         # and that's the one with the strength 1 (composition)
         assert (
             qgis_project.relationManager()
             .relation("classb1_comp1_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
 
     def test_relation_strength_mssql(self):
@@ -2615,42 +2627,42 @@ class TestProjectGen(unittest.TestCase):
 
         assert (
             qgis_project.relationManager().relation("agg3_agg3_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         assert (
             qgis_project.relationManager().relation("agg3_agg3_b_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc3_assoc3_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc3_assoc3_b_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         assert (
             qgis_project.relationManager().relation("classb1_agg1_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager().relation("classb1_agg2_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager().relation("classb1_assoc1_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         assert (
             qgis_project.relationManager().relation("classb1_assoc2_a_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         # and that's the one with the strength 1 (composition)
         assert (
             qgis_project.relationManager().relation("classb1_comp1_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
 
     def test_relation_strength_fakecomposition_postgis(self):
@@ -2694,36 +2706,36 @@ class TestProjectGen(unittest.TestCase):
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc_assoc_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc_assoc_b_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to basket table should be association
         assert (
             qgis_project.relationManager().relation("assoc_t_basket_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         # real composition -<#>{0..1} should be composition
         assert (
             qgis_project.relationManager().relation("classb1_comp_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # fake composition --{0..1} should be composition
         assert (
             qgis_project.relationManager()
             .relation("classb1_fakecomp_1a_fkey")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # fake composition -<>{0..1} should be composition
         assert (
             qgis_project.relationManager()
             .relation("classb1_fakecomp_2a_fkey")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
 
     def test_relation_strength_fakecomposition_geopackage(self):
@@ -2768,42 +2780,42 @@ class TestProjectGen(unittest.TestCase):
             qgis_project.relationManager()
             .relation("assoc_assoc_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager()
             .relation("assoc_assoc_b_classb1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to basket table should be association
         assert (
             qgis_project.relationManager()
             .relation("assoc_T_basket_T_ILI2DB_BASKET_T_Id")
             .strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         # real composition -<#>{0..1} should be composition
         assert (
             qgis_project.relationManager()
             .relation("classb1_comp_a_classa1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # fake composition --{0..1} should be composition
         assert (
             qgis_project.relationManager()
             .relation("classb1_fakecomp_1a_classa1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # fake composition -<>{0..1} should be composition
         assert (
             qgis_project.relationManager()
             .relation("classb1_fakecomp_2a_classa1_T_Id")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
 
     def test_relation_strength_fakecomposition_mssql(self):
@@ -2850,36 +2862,36 @@ class TestProjectGen(unittest.TestCase):
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc_assoc_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to parent table should be composition
         assert (
             qgis_project.relationManager().relation("assoc_assoc_b_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # join table to basket table should be association
         assert (
             qgis_project.relationManager().relation("assoc_t_basket_fkey").strength()
-            == QgsRelation.Association
+            == QgsRelation.RelationStrength.Association
         )
         # real composition -<#>{0..1} should be composition
         assert (
             qgis_project.relationManager().relation("classb1_comp_a_fkey").strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # fake composition --{0..1} should be composition
         assert (
             qgis_project.relationManager()
             .relation("classb1_fakecomp_1a_fkey")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
         # fake composition -<>{0..1} should be composition
         assert (
             qgis_project.relationManager()
             .relation("classb1_fakecomp_2a_fkey")
             .strength()
-            == QgsRelation.Composition
+            == QgsRelation.RelationStrength.Composition
         )
 
     def test_relation_cardinality_postgis(self):
@@ -3597,7 +3609,7 @@ class TestProjectGen(unittest.TestCase):
             int(IliDataItemModel.Roles.ID),
             "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_localfiletest",
             1,
-            Qt.MatchExactly,
+            Qt.MatchFlag.MatchExactly,
         )
         assert bool(matches_on_id) is True
 
@@ -3856,7 +3868,7 @@ class TestProjectGen(unittest.TestCase):
                     continue
                 matches = qml_file_model.match(
                     qml_file_model.index(0, 0),
-                    Qt.DisplayRole,
+                    Qt.ItemDataRole.DisplayRole,
                     qml_section[layer_qml],
                     1,
                 )
@@ -3897,7 +3909,10 @@ class TestProjectGen(unittest.TestCase):
             ):
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 assert len(tabs) == 5
                 assert tabs[0].name() == "Allgemein"
@@ -3990,7 +4005,7 @@ class TestProjectGen(unittest.TestCase):
             int(IliDataItemModel.Roles.ID),
             "ch.opengis.ili.config.KbS_LV95_V1_4_config_V1_0_gpkg_localfiletest",
             1,
-            Qt.MatchExactly,
+            Qt.MatchFlag.MatchExactly,
         )
         assert bool(matches_on_id) is True
 
@@ -4246,7 +4261,7 @@ class TestProjectGen(unittest.TestCase):
                     continue
                 matches = qml_file_model.match(
                     qml_file_model.index(0, 0),
-                    Qt.DisplayRole,
+                    Qt.ItemDataRole.DisplayRole,
                     qml_section[layer_qml],
                     1,
                 )
@@ -4285,7 +4300,10 @@ class TestProjectGen(unittest.TestCase):
             if layer.name == "belasteter_standort":
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 assert len(tabs) == 5
                 assert tabs[0].name() == "Allgemein"
@@ -4889,7 +4907,10 @@ class TestProjectGen(unittest.TestCase):
             if layer.name == "amap":
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
 
                 if Qgis.QGIS_VERSION_INT >= 31600:
@@ -4907,7 +4928,7 @@ class TestProjectGen(unittest.TestCase):
         # when the referencing layer is a structure, it should be a composition
         for relation in relations:
             if relation.referencing_layer.name == "maphierref":
-                assert relation.strength == QgsRelation.Composition
+                assert relation.strength == QgsRelation.RelationStrength.Composition
                 count += 1
 
         assert count == 2
@@ -4937,7 +4958,7 @@ class TestProjectGen(unittest.TestCase):
 
         for file_id in id_list:
             matches = topping_file_model.match(
-                topping_file_model.index(0, 0), Qt.DisplayRole, file_id, 1
+                topping_file_model.index(0, 0), Qt.ItemDataRole.DisplayRole, file_id, 1
             )
             if matches:
                 file_path = matches[0].data(int(topping_file_model.Roles.LOCALFILEPATH))

--- a/tests/test_projectgen_oids.py
+++ b/tests/test_projectgen_oids.py
@@ -318,11 +318,11 @@ class TestProjectOIDs(unittest.TestCase):
                 # check if not null and unique constraints are set (shouldn't be)
                 assert not (
                     t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
+                    & QgsFieldConstraints.Constraint.ConstraintUnique
                 )
                 assert not (
                     t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
+                    & QgsFieldConstraints.Constraint.ConstraintNotNull
                 )
                 count += 1
             # ANYOID
@@ -595,11 +595,11 @@ class TestProjectOIDs(unittest.TestCase):
                 # check if not null and unique constraints are set (shouldn't)
                 assert not (
                     t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
+                    & QgsFieldConstraints.Constraint.ConstraintUnique
                 )
                 assert not (
                     t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
+                    & QgsFieldConstraints.Constraint.ConstraintNotNull
                 )
                 count += 1
             # ANYOID
@@ -873,11 +873,11 @@ class TestProjectOIDs(unittest.TestCase):
                 # check if not null and unique constraints are set (shouldn't)
                 assert not (
                     t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintUnique
+                    & QgsFieldConstraints.Constraint.ConstraintUnique
                 )
                 assert not (
                     t_ili_tid_field.constraints().constraints()
-                    & QgsFieldConstraints.ConstraintNotNull
+                    & QgsFieldConstraints.Constraint.ConstraintNotNull
                 )
                 count += 1
             # ANYOID
@@ -1087,23 +1087,23 @@ class TestProjectOIDs(unittest.TestCase):
     def _check_t_ili_tid_field_constraints(self, t_ili_tid_field):
         assert (
             t_ili_tid_field.constraints().constraints()
-            & QgsFieldConstraints.ConstraintUnique
+            & QgsFieldConstraints.Constraint.ConstraintUnique
         )
         assert (
             t_ili_tid_field.constraints().constraints()
-            & QgsFieldConstraints.ConstraintNotNull
+            & QgsFieldConstraints.Constraint.ConstraintNotNull
         )
         assert (
             t_ili_tid_field.constraints().constraintStrength(
-                QgsFieldConstraints.ConstraintUnique
+                QgsFieldConstraints.Constraint.ConstraintUnique
             )
-            == QgsFieldConstraints.ConstraintStrengthHard
+            == QgsFieldConstraints.ConstraintStrength.ConstraintStrengthHard
         )
         assert (
             t_ili_tid_field.constraints().constraintStrength(
-                QgsFieldConstraints.ConstraintNotNull
+                QgsFieldConstraints.Constraint.ConstraintNotNull
             )
-            == QgsFieldConstraints.ConstraintStrengthHard
+            == QgsFieldConstraints.ConstraintStrength.ConstraintStrengthHard
         )
 
     def _set_pg_naming(self, is_pg=True):

--- a/tests/test_projecttopping.py
+++ b/tests/test_projecttopping.py
@@ -365,7 +365,10 @@ class TestProjectTopping(unittest.TestCase):
             ):
                 count += 1
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 assert len(tabs) == 5
                 assert tabs[0].name() == "Allgemein"
@@ -460,7 +463,10 @@ class TestProjectTopping(unittest.TestCase):
 
                 # default style
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 assert len(tabs) == 5
                 assert tabs[0].name() == "Allgemein"
@@ -477,7 +483,10 @@ class TestProjectTopping(unittest.TestCase):
                 # robot style (in binary)
                 style_manager.setCurrentStyle("robot")
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 assert len(tabs) == 5
                 assert (
@@ -503,7 +512,10 @@ class TestProjectTopping(unittest.TestCase):
                 # french style (in french)
                 style_manager.setCurrentStyle("french")
                 edit_form_config = layer.layer.editFormConfig()
-                assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+                assert (
+                    edit_form_config.layout()
+                    == QgsEditFormConfig.EditorLayout.TabLayout
+                )
                 tabs = edit_form_config.tabs()
                 assert len(tabs) == 5
                 assert tabs[0].name() == "Général"
@@ -952,7 +964,7 @@ class TestProjectTopping(unittest.TestCase):
 
         # check qml from file at punkt_standort
         edit_form_config = punkt_standort.layer().editFormConfig()
-        assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+        assert edit_form_config.layout() == QgsEditFormConfig.EditorLayout.TabLayout
         tabs = edit_form_config.tabs()
         assert len(tabs) == 5
         assert tabs[0].name() == "Allgemein"
@@ -964,7 +976,7 @@ class TestProjectTopping(unittest.TestCase):
 
         # check qml from file at polygon_standort
         edit_form_config = polygon_standort.layer().editFormConfig()
-        assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+        assert edit_form_config.layout() == QgsEditFormConfig.EditorLayout.TabLayout
         tabs = edit_form_config.tabs()
         assert len(tabs) == 5
         assert tabs[0].name() == "Allgemein"
@@ -1064,7 +1076,7 @@ class TestProjectTopping(unittest.TestCase):
         # check qml from file
         assert belasteter_standort_geo_lage_punkt
         edit_form_config = belasteter_standort_geo_lage_punkt.layer.editFormConfig()
-        assert edit_form_config.layout() == QgsEditFormConfig.TabLayout
+        assert edit_form_config.layout() == QgsEditFormConfig.EditorLayout.TabLayout
         tabs = edit_form_config.tabs()
         assert len(tabs) == 5
         assert tabs[0].name() == "Allgemein"
@@ -1226,7 +1238,7 @@ class TestProjectTopping(unittest.TestCase):
 
         for file_id in id_list:
             matches = topping_file_model.match(
-                topping_file_model.index(0, 0), Qt.DisplayRole, file_id, 1
+                topping_file_model.index(0, 0), Qt.ItemDataRole.DisplayRole, file_id, 1
             )
             if matches:
                 file_path = matches[0].data(int(topping_file_model.Roles.LOCALFILEPATH))

--- a/tests/test_z_geom.py
+++ b/tests/test_z_geom.py
@@ -55,7 +55,7 @@ class TestGeomZ(unittest.TestCase):
             layer for layer in available_layers if "obstacle" in layer.uri
         )
         obstacle_layer.create()
-        assert obstacle_layer.layer.wkbType() == QgsWkbTypes.PointZ
+        assert obstacle_layer.layer.wkbType() == QgsWkbTypes.Type.PointZ
 
     def print_info(self, text):
         logging.info(text)


### PR DESCRIPTION
Qt6 upgrade performed by pyqgis4-checker:

```
docker run -it --rm -v /home/dave/dev/opengisch/QgisModelBaker:/home/pyqgisdev/ registry.gitlab.com/oslandia/qgis/pyqgis-4-checker/pyqgis-qt-checker:latest pyqt5_to_pyqt6.py --logfile /home/pyqgisdev/pyqt6_checker.log .
```

See https://github.com/qgis/QGIS/wiki/Plugin-migration-to-be-compatible-with-Qt5-and-Qt6
