### PR TITLE
Add dbparams file with param_map for custom specific db values

### DIFF
--- a/modelbaker/db_factory/pg_command_config_manager.py
+++ b/modelbaker/db_factory/pg_command_config_manager.py
@@ -179,6 +179,9 @@ class PgCommandConfigManager(DbCommandConfigManager):
         settings.setValue(
             self._settings_base_path + "sslmode", self.configuration.sslmode
         )
+        settings.setValue(
+            self._settings_base_path + "dbparam_map", self.configuration.dbparam_map
+        )
 
     def load_config_from_qsettings(self) -> None:
         settings = QSettings()
@@ -206,4 +209,7 @@ class PgCommandConfigManager(DbCommandConfigManager):
         )
         self.configuration.sslmode = settings.value(
             self._settings_base_path + "sslmode"
+        )
+        self.configuration.dbparam_map = settings.value(
+            self._settings_base_path + "dbparam_map", {}
         )

--- a/modelbaker/iliwrapper/ili2dbargs.py
+++ b/modelbaker/iliwrapper/ili2dbargs.py
@@ -94,14 +94,13 @@ def _get_db_args(configuration, hide_password=False):
         db_args += ["--dbdatabase", configuration.database]
         db_args += ["--dbschema", configuration.dbschema or configuration.database]
 
-        if configuration.sslmode or configuration.dbparam_map:
+        if configuration.sslmode:
+            if "sslmode" not in configuration.dbparam_map:
+                configuration.dbparam_map["sslmode"] = configuration.sslmode
+        if configuration.dbparam_map:
             temporary_filename = "{}/modelbaker-dbargs.conf".format(QDir.tempPath())
             temporary_file = QFile(temporary_filename)
             if temporary_file.open(QFile.WriteOnly):
-                if configuration.sslmode:
-                    temporary_file.write(
-                        "sslmode={}\n".format(configuration.sslmode).encode("utf-8")
-                    )
                 if configuration.dbparam_map:
                     for key in configuration.dbparam_map.keys():
                         temporary_file.write(

--- a/modelbaker/iliwrapper/ili2dbargs.py
+++ b/modelbaker/iliwrapper/ili2dbargs.py
@@ -94,13 +94,21 @@ def _get_db_args(configuration, hide_password=False):
         db_args += ["--dbdatabase", configuration.database]
         db_args += ["--dbschema", configuration.dbschema or configuration.database]
 
-        if configuration.sslmode:
+        if configuration.sslmode or configuration.dbparam_map:
             temporary_filename = "{}/modelbaker-dbargs.conf".format(QDir.tempPath())
             temporary_file = QFile(temporary_filename)
             if temporary_file.open(QFile.WriteOnly):
-                temporary_file.write(
-                    "sslmode={}".format(configuration.sslmode).encode("utf-8")
-                )
+                if configuration.sslmode:
+                    temporary_file.write(
+                        "sslmode={}".format(configuration.sslmode).encode("utf-8")
+                    )
+                if configuration.dbparam_map:
+                    for key in configuration.dbparam_map.keys():
+                        temporary_file.write(
+                            "{}={}".format(key, configuration.dbparam_map[key]).encode(
+                                "utf-8"
+                            )
+                        )
                 temporary_file.close()
                 db_args += ["--dbparams", temporary_filename]
             else:

--- a/modelbaker/iliwrapper/ili2dbargs.py
+++ b/modelbaker/iliwrapper/ili2dbargs.py
@@ -100,14 +100,14 @@ def _get_db_args(configuration, hide_password=False):
             if temporary_file.open(QFile.WriteOnly):
                 if configuration.sslmode:
                     temporary_file.write(
-                        "sslmode={}".format(configuration.sslmode).encode("utf-8")
+                        "sslmode={}\n".format(configuration.sslmode).encode("utf-8")
                     )
                 if configuration.dbparam_map:
                     for key in configuration.dbparam_map.keys():
                         temporary_file.write(
-                            "{}={}".format(key, configuration.dbparam_map[key]).encode(
-                                "utf-8"
-                            )
+                            "{}={}\n".format(
+                                key, configuration.dbparam_map[key]
+                            ).encode("utf-8")
                         )
                 temporary_file.close()
                 db_args += ["--dbparams", temporary_filename]

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -127,6 +127,7 @@ class Ili2DbCommandConfiguration:
             self.dbfile = ""
             self.dbservice = None
             self.sslmode = None
+            self.dbparam_map = {}
             self.tool = None
             self.ilifile = ""
             self.ilimodels = ""

--- a/tests/test_import_dbparams.py
+++ b/tests/test_import_dbparams.py
@@ -1,0 +1,65 @@
+"""
+/***************************************************************************
+                              -------------------
+        begin                : 06/27/2025
+        git sha              : :%H$
+        copyright            : (C) 2025 by Dave Signer @ OPENGIS.ch
+        email                : david@opengis.ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+import datetime
+import pathlib
+import tempfile
+
+from qgis.testing import start_app, unittest
+
+from modelbaker.iliwrapper import iliimporter
+from modelbaker.iliwrapper.globals import DbIliMode
+from tests.utils import iliimporter_config
+
+CATALOGUE_DATASETNAME = "Catset"
+
+start_app()
+
+test_path = pathlib.Path(__file__).parent.absolute()
+
+
+class TestDbParams(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.basetestpath = tempfile.mkdtemp()
+
+    def test_postgis_withandwithout_params(self):
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilimodels = "KbS_LV95_V1_3"
+        importer.configuration.dbschema = "kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        # now we remove the password - it should fail now
+        importer.configuration.dbpwd = None
+        assert importer.run() == iliimporter.Importer.ERROR
+
+        # now we add the password by dbparams and it should succeed again
+        importer.configuration.dbparam_map = {"password": "docker"}
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        # now we add a wrong password by dbparams and it should fail again
+        importer.configuration.dbparam_map = {"password": "ducker"}
+        assert importer.run() == iliimporter.Importer.SUCCESS

--- a/tests/test_import_dbparams.py
+++ b/tests/test_import_dbparams.py
@@ -64,7 +64,7 @@ class TestDbParams(unittest.TestCase):
         importer.configuration.dbparam_map = {"sslmode": "disable", "readOnly": "true"}
         assert importer.run() == iliimporter.Importer.ERROR
 
-        # change readonly to "false" by dbparams and it should s    ucceed again
+        # change readonly to "false" by dbparams and it should succeed again
         importer.configuration.dbparam_map = {"sslmode": "disable", "readOnly": "false"}
         assert importer.run() == iliimporter.Importer.SUCCESS
 


### PR DESCRIPTION
Specific parameters can be passed as a file to ili2db. 

This introduced a new config setting "dbparam_map" and on writing the command it writes the entry to a temporary file (like sslmode) and passes it to ili2db. More description here https://github.com/opengisch/QgisModelBaker/pull/1037
