### PR TITLE
Ignore (usually) all the system schema in the list 

### DIFF
--- a/modelbaker/dbconnector/config.py
+++ b/modelbaker/dbconnector/config.py
@@ -1,4 +1,4 @@
-IGNORED_SCHEMAS = ["pg_catalog", "information_schema"]
+IGNORED_SCHEMAS = ["pg_catalog", "information_schema", "pg_*"]
 
 IGNORED_TABLES = [
     "spatial_ref_sys",

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -15,6 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 """
+import fnmatch
+
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 
 from .config import BASKET_TABLES, IGNORED_ILI_ELEMENTS, IGNORED_SCHEMAS, IGNORED_TABLES
@@ -234,7 +236,12 @@ class DBConnector(QObject):
                     detected_tables.append(record["tablename"])
                     continue
             if "schemaname" in record:
-                if record["schemaname"] in IGNORED_SCHEMAS:
+                ignored = False
+                for ignored_schema_pattern in IGNORED_SCHEMAS:
+                    if fnmatch.fnmatch(record["schemaname"], ignored_schema_pattern):
+                        ignored = True
+                        break
+                if ignored:
                     static_tables.append(record["tablename"])
                     continue
             if "tablename" in record:
@@ -451,6 +458,30 @@ class DBConnector(QObject):
     def get_domain_dispnames(self, tablename):
         """
         Get the domain display names with consideration of the translation
+        """
+        return []
+
+    def get_schemas(self, ignore_system_schemas=True):
+        result = []
+        all_schemas = self.get_all_schemas()
+
+        if not ignore_system_schemas:
+            result = all_schemas
+        else:
+            # filter ignored schemas
+            for schema in all_schemas:
+                ignored = False
+                for ignored_schema_pattern in IGNORED_SCHEMAS:
+                    if fnmatch.fnmatch(schema, ignored_schema_pattern):
+                        ignored = True
+                if ignored:
+                    continue
+                result.append(schema)
+        return result
+
+    def get_all_schemas(self):
+        """
+        Get the schemas from PostgreSQL. Otherwise empty.
         """
         return []
 

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -1374,7 +1374,7 @@ class PGConnector(DBConnector):
 
         return False, self.tr("Could not reset sequence")
 
-    def get_schemas(self):
+    def get_all_schemas(self):
         cursor = self.conn.cursor()
         try:
             cursor.execute(


### PR DESCRIPTION
(e.g used as dropdown in the gui to create ili-schema). 

pg_catalog is still in the list for backwards compatibility. 

This fixes https://github.com/opengisch/QgisModelBaker/issues/1049