### PR TITLE
`--skipGeometryErrors` and `--skipReferenceErrors`

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -357,6 +357,7 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         self.baskets = list()
         self.with_schemaimport = False
         self.with_importbid = False
+        # requires sqlEnableNull on schema:
         self.skip_reference_errors = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
@@ -417,6 +418,7 @@ class UpdateDataConfiguration(Ili2DbCommandConfiguration):
         self.delete_data = False
         self.with_importtid = False
         self.with_importbid = False
+        # requires sqlEnableNull on schema:
         self.skip_reference_errors = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -357,6 +357,7 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         self.baskets = list()
         self.with_schemaimport = False
         self.with_importbid = False
+        self.skip_reference_errors = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
         args = list()
@@ -370,6 +371,9 @@ class ImportDataConfiguration(SchemaImportConfiguration):
         if self.disable_validation:
             self.append_args(args, ["--disableValidation"])
             self.append_args(args, ["--skipGeometryErrors"])
+
+        if self.skip_reference_errors:
+            self.append_args(args, ["--skipReferenceErrors"])
 
         if self.delete_data:
             self.append_args(args, ["--deleteData"])
@@ -413,6 +417,7 @@ class UpdateDataConfiguration(Ili2DbCommandConfiguration):
         self.delete_data = False
         self.with_importtid = False
         self.with_importbid = False
+        self.skip_reference_errors = False
 
     def to_ili2db_args(self, extra_args=[], with_action=True):
         args = list()
@@ -428,6 +433,9 @@ class UpdateDataConfiguration(Ili2DbCommandConfiguration):
         if self.disable_validation:
             self.append_args(args, ["--disableValidation"])
             self.append_args(args, ["--skipGeometryErrors"])
+
+        if self.skip_reference_errors:
+            self.append_args(args, ["--skipReferenceErrors"])
 
         if self.with_importtid:
             self.append_args(args, ["--importTid"])

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -214,6 +214,7 @@ class ExportConfiguration(Ili2DbCommandConfiguration):
 
         if self.disable_validation:
             self.append_args(args, ["--disableValidation"])
+            self.append_args(args, ["--skipGeometryErrors"])
 
         if self.with_exporttid:
             self.append_args(args, ["--exportTid"])
@@ -368,6 +369,7 @@ class ImportDataConfiguration(SchemaImportConfiguration):
 
         if self.disable_validation:
             self.append_args(args, ["--disableValidation"])
+            self.append_args(args, ["--skipGeometryErrors"])
 
         if self.delete_data:
             self.append_args(args, ["--deleteData"])
@@ -425,6 +427,7 @@ class UpdateDataConfiguration(Ili2DbCommandConfiguration):
 
         if self.disable_validation:
             self.append_args(args, ["--disableValidation"])
+            self.append_args(args, ["--skipGeometryErrors"])
 
         if self.with_importtid:
             self.append_args(args, ["--importTid"])


### PR DESCRIPTION
`--skipGeometryErrors` appended on export / import / update when disable_validation is activated.

`--skipReferenceErrors` is a seperate config parameter because it requires the schema-import with sqlEnableNull. It's used by the Model Baker Quick Viewer