### PR TITLE
Store dbparam map in baseconfig instead of the importconfig,

### DIFF
--- a/modelbaker/db_factory/pg_command_config_manager.py
+++ b/modelbaker/db_factory/pg_command_config_manager.py
@@ -188,9 +188,6 @@ class PgCommandConfigManager(DbCommandConfigManager):
         settings.setValue(
             self._settings_base_path + "sslmode", self.configuration.sslmode
         )
-        settings.setValue(
-            self._settings_base_path + "dbparam_map", self.configuration.dbparam_map
-        )
 
     def load_config_from_qsettings(self) -> None:
         settings = QSettings()
@@ -218,7 +215,4 @@ class PgCommandConfigManager(DbCommandConfigManager):
         )
         self.configuration.sslmode = settings.value(
             self._settings_base_path + "sslmode"
-        )
-        self.configuration.dbparam_map = settings.value(
-            self._settings_base_path + "dbparam_map", {}
         )

--- a/modelbaker/iliwrapper/ili2dbargs.py
+++ b/modelbaker/iliwrapper/ili2dbargs.py
@@ -95,17 +95,19 @@ def _get_db_args(configuration, hide_password=False):
         db_args += ["--dbschema", configuration.dbschema or configuration.database]
 
         if configuration.sslmode:
-            if "sslmode" not in configuration.dbparam_map:
-                configuration.dbparam_map["sslmode"] = configuration.sslmode
-        if configuration.dbparam_map:
+            if "sslmode" not in configuration.base_configuration.dbparam_map:
+                configuration.base_configuration.dbparam_map[
+                    "sslmode"
+                ] = configuration.sslmode
+        if configuration.base_configuration.dbparam_map:
             temporary_filename = "{}/modelbaker-dbargs.conf".format(QDir.tempPath())
             temporary_file = QFile(temporary_filename)
             if temporary_file.open(QFile.OpenModeFlag.WriteOnly):
-                if configuration.dbparam_map:
-                    for key in configuration.dbparam_map.keys():
+                if configuration.base_configuration.dbparam_map:
+                    for key in configuration.base_configuration.dbparam_map.keys():
                         temporary_file.write(
                             "{}={}\n".format(
-                                key, configuration.dbparam_map[key]
+                                key, configuration.base_configuration.dbparam_map[key]
                             ).encode("utf-8")
                         )
                 temporary_file.close()

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -28,6 +28,7 @@ class BaseConfiguration:
     def __init__(self):
         self.super_pg_user = "postgres"
         self.super_pg_password = "postgres"
+        self.dbparam_map = {}
 
         self.custom_model_directories_enabled = False
         self.custom_model_directories = ""
@@ -39,6 +40,7 @@ class BaseConfiguration:
     def save(self, settings):
         settings.setValue("SuperUser", self.super_pg_user)
         settings.setValue("SuperPassword", self.super_pg_password)
+        settings.setValue("CustomDbParameters", self.dbparam_map)
         settings.setValue(
             "CustomModelDirectoriesEnabled", self.custom_model_directories_enabled
         )
@@ -50,6 +52,7 @@ class BaseConfiguration:
     def restore(self, settings):
         self.super_pg_user = settings.value("SuperUser", "postgres", str)
         self.super_pg_password = settings.value("SuperPassword", "postgres", str)
+        self.dbparam_map = settings.value("CustomDbParameters", {}, dict)
         self.custom_model_directories_enabled = settings.value(
             "CustomModelDirectoriesEnabled", False, bool
         )
@@ -127,7 +130,6 @@ class Ili2DbCommandConfiguration:
             self.dbfile = ""
             self.dbservice = None
             self.sslmode = None
-            self.dbparam_map = {}
             self.tool = None
             self.ilifile = ""
             self.ilimodels = ""


### PR DESCRIPTION
Since it's used on every ili2db command usually.

And often (validate / export) we read the needed connection parameters from the QGIS layer. But general settings (like gsslib) are not used in QGIS and with it not stored in the layer at all.