### PR TITLE
ilicompiler integration

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -608,3 +608,57 @@ class ExportMetaConfigConfiguration(Ili2DbCommandConfiguration):
         self.append_args(args, Ili2DbCommandConfiguration.to_ili2db_args(self))
 
         return args
+
+
+class Ili2CCommandConfiguration:
+    """Manages and builds configurations for running the ili2c compiler command.
+
+    This class mirrors the architectural pattern of `Ili2DbCommandConfiguration`
+    but targets the conversion and validation flags specific to the `ili2c` tool.
+    """
+
+    def __init__(self, other=None):
+        """Initializes a new configuration instance or copies properties from another.
+
+        Args:
+            other (Ili2CCommandConfiguration, optional): Configuration object to clone.
+        """
+        if not isinstance(other, Ili2CCommandConfiguration):
+            self.base_configuration = BaseConfiguration()
+
+            self.oIMD16 = True
+            self.imdfile = ""
+            self.ilifile = ""
+        else:
+            # We got an 'other' object from which we'll get parameters
+            self.__dict__ = other.__dict__.copy()
+
+    def append_args(self, args, values):
+        """Appends a list of arguments into an existing argument accumulator list.
+
+        Args:
+            args (list): The main list of arguments being built.
+            values (list): The new elements/flags to add.
+        """
+        args += values
+
+    def to_ili2c_args(self):
+        """Generates the command-line argument list for ili2c based on the current state.
+
+        Extracts basic configurations from base settings and maps individual local
+        properties (like imdfile and ilifile) to their corresponding representations.
+
+        Returns:
+            list: A list of string arguments ready to append to the executable sequence.
+        """
+        args = self.base_configuration.to_ili2db_args(False, False)
+
+        if self.oIMD16:
+            self.append_args(args, ["-oIMD16"])
+
+        if self.imdfile:
+            self.append_args(args, ["--out", self.imdfile])
+
+        if self.ilifile:
+            self.append_args(args, [self.ilifile])
+        return args

--- a/modelbaker/iliwrapper/ili2dbtools.py
+++ b/modelbaker/iliwrapper/ili2dbtools.py
@@ -15,6 +15,11 @@ from .globals import DbIliMode
 
 
 def get_tool_version(tool, db_ili_version: int) -> str:
+    """Gets the hardcoded version string for the corresponding tool and the version 3 or bigger.
+
+    Returns:
+        str: The version string (e.g., "5.6.6").
+    """
     if tool == DbIliMode.ili2gpkg:
         if db_ili_version == 3:
             return "3.11.3"
@@ -35,6 +40,13 @@ def get_tool_version(tool, db_ili_version: int) -> str:
 
 
 def get_tool_url(tool: DbIliMode, db_ili_version: int) -> str:
+    """Constructs the absolute remote download URL for obtaining the ili2db binary archive.
+
+    Uses the version string pulled from :func:`get_tool_version`.
+
+    Returns:
+        str: Absolute download URL string.
+    """
     if tool == DbIliMode.ili2gpkg:
         return "https://downloads.interlis.ch/ili2gpkg/ili2gpkg-{version}.zip".format(
             version=get_tool_version(tool, db_ili_version)
@@ -49,3 +61,25 @@ def get_tool_url(tool: DbIliMode, db_ili_version: int) -> str:
         )
 
     return ""
+
+
+def get_ili2c_tool_version():
+    """Gets the hardcoded stable fallback or current version string for the ili2c tool.
+
+    Returns:
+        str: The version string (e.g., "5.6.6").
+    """
+    return "5.6.6"
+
+
+def get_ili2c_tool_url():
+    """Constructs the absolute remote download URL for obtaining the ili2c binary archive.
+
+    Uses the version string pulled from :func:`get_ili2c_tool_version`.
+
+    Returns:
+        str: Absolute download URL string.
+    """
+    return "https://downloads.interlis.ch/ili2c/ili2c-{version}.zip".format(
+        version=get_ili2c_tool_version()
+    )

--- a/modelbaker/iliwrapper/ili2dbutils.py
+++ b/modelbaker/iliwrapper/ili2dbutils.py
@@ -25,7 +25,12 @@ from qgis.PyQt.QtCore import QCoreApplication, pyqtSignal
 
 from ..utils.qt_utils import NetworkError, download_file
 from .globals import DbIliMode
-from .ili2dbtools import get_tool_url, get_tool_version
+from .ili2dbtools import (
+    get_ili2c_tool_url,
+    get_ili2c_tool_version,
+    get_tool_url,
+    get_tool_version,
+)
 
 if TYPE_CHECKING:
     # only needed for type checking to avoid circular imports
@@ -35,6 +40,17 @@ if TYPE_CHECKING:
 def get_ili2db_bin(
     tool: DbIliMode, db_ili_version: int, stdout: pyqtSignal, stderr: pyqtSignal
 ) -> Optional[str]:
+    """Retrieves the local file path to the `ili2pg.jar`/`ili2gpkg.jar` binary executable depending on the tool and the version.
+
+    Args:
+        tool (DbIliMode): The tool for which the binary is requested (e.g., ili2pg, ili2gpkg).
+        db_ili_version (int): The version of the Interlis database (e.g., 3 or 4).
+        stdout (pyqtSignal): Signal used to log normal execution process messages.
+        stderr (pyqtSignal): Signal used to log error execution process messages.
+
+    Returns:
+        str: Local absolute path to the functional ili2db JAR file if successful; otherwise, None.
+    """
     if tool not in DbIliMode or tool == DbIliMode.ili:
         raise RuntimeError("Tool {} not found".format(tool))
 
@@ -48,6 +64,7 @@ def get_ili2db_bin(
 
     dir_path = os.path.dirname(os.path.realpath(__file__))
     ili2db_dir = "{}-{}".format(tool_name, ili_tool_version)
+    bin_path = os.path.join(dir_path, "bin", ili2db_dir)
 
     # the structure changed since 3.12.2
     if is_version_valid(
@@ -73,59 +90,126 @@ def get_ili2db_bin(
         )
 
     if not os.path.isfile(ili2db_file):
-        try:
-            os.makedirs(os.path.join(dir_path, "bin", ili2db_dir), exist_ok=True)
-        except FileExistsError:
-            pass
-
-        tmpfile = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
-
-        stdout.emit(
-            QCoreApplication.translate(
-                "ili2dbutils",
-                "Downloading {} version {}…".format(tool_name, ili_tool_version),
-            )
+        ili2db_file = download_ili2_bin(
+            ili2db_file,
+            bin_path,
+            tool_name,
+            ili_tool_url,
+            ili_tool_version,
+            stdout,
+            stderr,
         )
 
-        try:
-            download_file(
-                ili_tool_url,
-                tmpfile.name,
-                on_progress=lambda received, total: stdout.emit("."),
-            )
-        except NetworkError as e:
-            stderr.emit(
-                QCoreApplication.translate(
-                    "ili2dbutils",
-                    'Could not download {tool_name}\n\n  Error: {error}\n\nFile "{file}" not found. Please download and extract <a href="{ili2db_url}">{tool_name}</a>'.format(
-                        tool_name=tool_name,
-                        ili2db_url=ili_tool_url,
-                        error=e.msg,
-                        file=ili2db_file,
-                    ),
-                )
-            )
-            return None
-
-        try:
-            with zipfile.ZipFile(tmpfile.name, "r") as z:
-                z.extractall(os.path.join(dir_path, "bin", ili2db_dir))
-        except zipfile.BadZipFile:
-            # We will realize soon enough that the files were not extracted
-            pass
-
-        if not os.path.isfile(ili2db_file):
-            stderr.emit(
-                QCoreApplication.translate(
-                    "ili2dbutils",
-                    'File "{file}" not found. Please download and extract <a href="{ili2db_url}">{tool_name}</a>.'.format(
-                        tool_name=tool_name, file=ili2db_file, ili2db_url=ili_tool_url
-                    ),
-                )
-            )
-            return None
-
     return ili2db_file
+
+
+def get_ili2c_bin(stdout, stderr):
+    """Retrieves the local file path to the `ili2c.jar` binary executable.
+
+    Args:
+        stdout (pyqtSignal): Signal used to log normal execution process messages.
+        stderr (pyqtSignal): Signal used to log error execution process messages.
+
+    Returns:
+        str: Local absolute path to the functional ili2c JAR file if successful; otherwise, None.
+    """
+    ili_tool_version = get_ili2c_tool_version()
+    ili_tool_url = get_ili2c_tool_url()
+
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    ili2c_dir = "ili2c-{}".format(ili_tool_version)
+
+    bin_path = os.path.join(dir_path, "bin", ili2c_dir)
+
+    ili2c_file = os.path.join(
+        bin_path,
+        "ili2c.jar".format(version=ili_tool_version),
+    )
+
+    if not os.path.isfile(ili2c_file):
+        ili2c_file = download_ili2_bin(
+            ili2c_file,
+            bin_path,
+            "ili2c",
+            ili_tool_url,
+            ili_tool_version,
+            stdout,
+            stderr,
+        )
+
+    return ili2c_file
+
+
+def download_ili2_bin(
+    bin_file, bin_path, ili_tool_name, ili_tool_url, ili_tool_version, stdout, stderr
+):
+    """Downloads java file.
+
+    Args:
+        bin_file (str): Expected destination filepath of the extracted target file.
+        bin_path (str): Extraction base directory where the archive structures belong.
+        ili_tool_name (str): String identifying the tool.
+        ili_tool_url (str): Remote address where the archive stream resides.
+        ili_tool_version (str): Identifier string of the version.
+        stdout (pyqtSignal): Signal used to log normal execution process messages.
+        stderr (pyqtSignal): Signal used to log error execution process messages.
+
+    Returns:
+        str or None: Local absolute path to the functional ili2db/ili2c JAR file if successful; otherwise, None.
+    """
+    try:
+        os.makedirs(bin_path, exist_ok=True)
+    except FileExistsError:
+        pass
+
+    tmpfile = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
+
+    stdout.emit(
+        QCoreApplication.translate(
+            "ili2dbutils",
+            "Downloading {} version {}…".format(ili_tool_name, ili_tool_version),
+        )
+    )
+
+    try:
+        download_file(
+            ili_tool_url,
+            tmpfile.name,
+            on_progress=lambda received, total: stdout.emit("."),
+        )
+    except NetworkError as e:
+        stderr.emit(
+            QCoreApplication.translate(
+                "ili2dbutils",
+                'Could not download {tool_name}\n\n  Error: {error}\n\nFile "{file}" not found. Please download and extract <a href="{ili2db_url}">{tool_name}</a>'.format(
+                    tool_name=ili_tool_name,
+                    ili2db_url=ili_tool_url,
+                    error=e.msg,
+                    file=bin_file,
+                ),
+            )
+        )
+        return None
+
+    try:
+        with zipfile.ZipFile(tmpfile.name, "r") as z:
+            z.extractall(bin_path)
+
+    except zipfile.BadZipFile:
+        # We will realize soon enough that the files were not extracted
+        pass
+
+    if not os.path.isfile(bin_file):
+        stderr.emit(
+            QCoreApplication.translate(
+                "ili2dbutils",
+                'File "{file}" not found. Please download and extract <a href="{ili_tool_url}">{tool_name}</a>.'.format(
+                    tool_name=ili_tool_name, file=bin_file, ili_tool_url=ili_tool_url
+                ),
+            )
+        )
+        return None
+    return bin_file
 
 
 def get_all_modeldir_in_path(

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -248,6 +248,12 @@ class IliCache(QObject):
                     model["version"] = self.get_element_text(
                         model_metadata.find("ili23:Version", self.ns)
                     )
+                    model["file"] = (
+                        self.get_element_text(
+                            model_metadata.find("ili23:File", self.ns)
+                        )
+                        or ""
+                    )
                     model["repository"] = netloc
                     repo_models.append(model)
 
@@ -264,6 +270,12 @@ class IliCache(QObject):
                 if model["name"]:
                     model["version"] = self.get_element_text(
                         model_metadata.find("ili23:Version", self.ns)
+                    )
+                    model["file"] = (
+                        self.get_element_text(
+                            model_metadata.find("ili23:File", self.ns)
+                        )
+                        or ""
                     )
                     model["repository"] = netloc
                     repo_models.append(model)
@@ -345,6 +357,7 @@ class IliCache(QObject):
                     model["name"] = result.group(1)
                     model["version"] = ""
                     model["repository"] = ilipath
+                    model["file"] = os.path.basename(ilipath)
                     models += [model]
 
                 result = re_model_version.search(line)
@@ -378,6 +391,7 @@ class IliModelItemModel(QStandardItemModel):
     class Roles(Enum):
         ILIREPO = Qt.ItemDataRole.UserRole + 1
         VERSION = Qt.ItemDataRole.UserRole + 2
+        FILE = Qt.ItemDataRole.UserRole + 3
 
         def __int__(self):
             return self.value
@@ -396,15 +410,22 @@ class IliModelItemModel(QStandardItemModel):
                 if any(model["name"] == s for s in names):
                     continue
 
+                name = model.get("name")
+                if not name:
+                    continue
                 item = QStandardItem()
-                item.setData(model["name"], int(Qt.ItemDataRole.DisplayRole))
+                item.setData(name, int(Qt.ItemDataRole.DisplayRole))
                 item.setData(
-                    model["name"], int(Qt.ItemDataRole.EditRole)
+                    name, int(Qt.ItemDataRole.EditRole)
                 )  # considered in completer
-                item.setData(model["repository"], int(IliModelItemModel.Roles.ILIREPO))
-                item.setData(model["version"], int(IliModelItemModel.Roles.VERSION))
-
-                names.append(model["name"])
+                item.setData(
+                    model.get("repository", ""), int(IliModelItemModel.Roles.ILIREPO)
+                )
+                item.setData(
+                    model.get("version", ""), int(IliModelItemModel.Roles.VERSION)
+                )
+                item.setData(model.get("file", ""), int(IliModelItemModel.Roles.FILE))
+                names.append(name)
                 self.appendRow(item)
 
 

--- a/modelbaker/iliwrapper/ilicompiler.py
+++ b/modelbaker/iliwrapper/ilicompiler.py
@@ -1,0 +1,29 @@
+"""
+/***************************************************************************
+        begin                : 2026-07-03
+        git sha              : :%H$
+        copyright            : (C) 2026 by Dave Signer
+        email                : david at opengis ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+from .ili2dbconfig import Ili2CCommandConfiguration
+from .iliexecutable import Ili2CExecutable
+
+
+class IliCompiler(Ili2CExecutable):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def _create_config(self) -> Ili2CCommandConfiguration:
+        """Creates the configuration that will be used by *run* method.
+        :return: ili2c configuration"""
+        return Ili2CCommandConfiguration()

--- a/modelbaker/iliwrapper/ilideleter.py
+++ b/modelbaker/iliwrapper/ilideleter.py
@@ -11,10 +11,10 @@ License:
     (at your option) any later version.
 """
 from .ili2dbconfig import DeleteConfiguration, Ili2DbCommandConfiguration
-from .iliexecutable import IliExecutable
+from .iliexecutable import Ili2DbExecutable
 
 
-class Deleter(IliExecutable):
+class Deleter(Ili2DbExecutable):
     def __init__(self, parent=None):
         super().__init__(parent)
 

--- a/modelbaker/iliwrapper/iliexecutable.py
+++ b/modelbaker/iliwrapper/iliexecutable.py
@@ -20,15 +20,14 @@ from qgis.PyQt.QtCore import QEventLoop, QObject, QProcess, pyqtSignal
 
 from ..utils.qt_utils import AbstractQObjectMeta
 from .ili2dbargs import get_ili2db_args
-from .ili2dbconfig import Ili2DbCommandConfiguration
-from .ili2dbutils import JavaNotFoundError, get_ili2db_bin, get_java_path
+from .ili2dbconfig import Ili2CCommandConfiguration, Ili2DbCommandConfiguration
+from .ili2dbutils import JavaNotFoundError, get_ili2c_bin, get_ili2db_bin, get_java_path
 
 
 class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
     SUCCESS = 0
-    # TODO: Insert more codes?
     ERROR = 1000
-    ILI2DB_NOT_FOUND = 1001
+    ILI2_NOT_FOUND = 1001
 
     stdout = pyqtSignal(str)
     stderr = pyqtSignal(str)
@@ -36,7 +35,8 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
     process_finished = pyqtSignal(int, int)
     cancel_process = pyqtSignal()
 
-    __done_pattern = re.compile(r"Info: \.\.\.([a-zA-Z]+ )?done")
+    # supertolerant done pattern
+    _done_pattern = re.compile(r"Info: \.\.\..*done")
     __result = None
 
     def __init__(self, parent=None):
@@ -56,34 +56,31 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
             self.encoding = "UTF8"
 
     @abstractmethod
-    def _create_config(self) -> Ili2DbCommandConfiguration:
+    def _create_config(self) -> Ili2DbCommandConfiguration | Ili2CCommandConfiguration:
         """Creates the configuration that will be used by *run* method.
 
         Returns:
-            Ili2DbCommandConfiguration: configuration"""
+            Ili2DbCommandConfiguration or Ili2CCommandConfiguration: ili2db/ili2c configuration
+        """
 
-    def _get_ili2db_version(self) -> int:
-        return self.configuration.db_ili_version
-
+    @abstractmethod
     def _args(self, hide_password: bool) -> list:
-        """Gets the list of ili2db arguments from configuration.
+        """Gets the list of ili2db/ili2c arguments from configuration.
 
         Args:
             hide_password (bool): *True* to mask the password, *False* otherwise.
 
         Returns:
-            list: ili2db arguments list."""
-        self.configuration.tool = self.tool
+            list: ili2db/ili2c arguments list.
+        """
 
-        return get_ili2db_args(self.configuration, hide_password)
+    @abstractmethod
+    def _ili2_jar_arg(self):
+        """Gets the list of arguments to run ili2db/ili2c jar.
 
-    def _ili2db_jar_arg(self) -> list:
-        ili2db_bin = get_ili2db_bin(
-            self.tool, self._get_ili2db_version(), self.stdout, self.stderr
-        )
-        if not ili2db_bin:
-            return self.ILI2DB_NOT_FOUND
-        return ["-jar", ili2db_bin]
+        Returns:
+            list: ili2db/ili2c jar arguments list.
+        """
 
     def _escaped_arg(self, argument=str) -> str:
         if '"' in argument:
@@ -93,15 +90,15 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
         return argument
 
     def command(self, hide_password: bool = False) -> str:
-        ili2db_jar_arg = self._ili2db_jar_arg()
-        if ili2db_jar_arg == self.ILI2DB_NOT_FOUND:
-            return "ili2db tool not found!"
+        ili2_jar_arg = self._ili2_jar_arg()
+        if ili2_jar_arg == self.ILI2_NOT_FOUND:
+            return "ili2 tool not found!"
 
         args = self._args(hide_password)
         java_path = self._escaped_arg(
             get_java_path(self.configuration.base_configuration)
         )
-        command_args = ili2db_jar_arg + args
+        command_args = ili2_jar_arg + args
         valid_args = []
         for command_arg in command_args:
             valid_args.append(self._escaped_arg(command_arg))
@@ -139,9 +136,9 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
         )
 
         if not edited_command:
-            ili2db_jar_arg = self._ili2db_jar_arg()
-            if ili2db_jar_arg == self.ILI2DB_NOT_FOUND:
-                return self.ILI2DB_NOT_FOUND
+            ili2db_jar_arg = self._ili2_jar_arg()
+            if ili2db_jar_arg == self.ILI2_NOT_FOUND:
+                return self.ILI2_NOT_FOUND
             args = self._args(False)
             java_path = get_java_path(self.configuration.base_configuration)
             proc.start(java_path, ili2db_jar_arg + args)
@@ -168,7 +165,7 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
     def stderr_ready(self, proc: QProcess) -> None:
         text = bytes(proc.readAllStandardError()).decode(self.encoding)
 
-        if self.__done_pattern.search(text):
+        if self._done_pattern.search(text):
             self.__result = self.SUCCESS
 
         self.stderr.emit(text)
@@ -176,3 +173,67 @@ class IliExecutable(QObject, metaclass=AbstractQObjectMeta):
     def stdout_ready(self, proc: QProcess) -> None:
         text = bytes(proc.readAllStandardOutput()).decode(self.encoding)
         self.stdout.emit(text)
+
+
+class Ili2DbExecutable(IliExecutable):
+    """Executes operation on ili2db."""
+
+    _done_pattern = re.compile(r"Info: \.\.\.([a-zA-Z]+ )?done")
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def _args(self, hide_password):
+        """Gets the list of ili2db arguments from configuration.
+
+        Args:
+            hide_password (bool): *True* to mask the password, *False* otherwise.
+
+        Returns:
+            list: ili2db arguments list.
+        """
+        self.configuration.tool = self.tool
+
+        return get_ili2db_args(self.configuration, hide_password)
+
+    def _ili2_jar_arg(self):
+        """Locates and creates the Java entrypoint arguments array targeting the ili2db jar.
+
+        Returns:
+            list or int: Executable jar target arguments list, or a missing constant code.
+        """
+        ili2db_bin = get_ili2db_bin(
+            self.tool, self._get_ili2db_version(), self.stdout, self.stderr
+        )
+        if not ili2db_bin:
+            return self.ILI2_NOT_FOUND
+        return ["-jar", ili2db_bin]
+
+    def _get_ili2db_version(self):
+        return self.configuration.db_ili_version
+
+
+class Ili2CExecutable(IliExecutable):
+    """Executes operation on ili2c."""
+
+    _done_pattern = re.compile(r"Info: \.\.\.compiler run done.*$")
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+    def _args(self, _param):
+        """Gets the list of ili2db arguments from configuration.
+
+        Args:
+            _param (bool): Unused parameter, kept for interface compatibility.
+
+        Returns:
+            list: ili2c arguments list.
+        """
+        return self.configuration.to_ili2c_args()
+
+    def _ili2_jar_arg(self):
+        ili2c_bin = get_ili2c_bin(self.stdout, self.stderr)
+        if not ili2c_bin:
+            return self.ILI2_NOT_FOUND
+        return ["-jar", ili2c_bin]

--- a/modelbaker/iliwrapper/iliexporter.py
+++ b/modelbaker/iliwrapper/iliexporter.py
@@ -11,10 +11,10 @@ License:
     (at your option) any later version.
 """
 from .ili2dbconfig import ExportConfiguration, Ili2DbCommandConfiguration
-from .iliexecutable import IliExecutable
+from .iliexecutable import Ili2DbExecutable
 
 
-class Exporter(IliExecutable):
+class Exporter(Ili2DbExecutable):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.version = 4

--- a/modelbaker/iliwrapper/iliimporter.py
+++ b/modelbaker/iliwrapper/iliimporter.py
@@ -15,10 +15,10 @@ from .ili2dbconfig import (
     ImportDataConfiguration,
     SchemaImportConfiguration,
 )
-from .iliexecutable import IliExecutable
+from .iliexecutable import Ili2DbExecutable
 
 
-class Importer(IliExecutable):
+class Importer(Ili2DbExecutable):
     def __init__(self, dataImport=False, parent=None):
         self.__data_import = dataImport
         super().__init__(parent)

--- a/modelbaker/iliwrapper/ilimetaconfigexporter.py
+++ b/modelbaker/iliwrapper/ilimetaconfigexporter.py
@@ -11,10 +11,10 @@ License:
     (at your option) any later version.
 """
 from .ili2dbconfig import ExportMetaConfigConfiguration, Ili2DbCommandConfiguration
-from .iliexecutable import IliExecutable
+from .iliexecutable import Ili2DbExecutable
 
 
-class MetaConfigExporter(IliExecutable):
+class MetaConfigExporter(Ili2DbExecutable):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.version = 4

--- a/modelbaker/iliwrapper/iliupdater.py
+++ b/modelbaker/iliwrapper/iliupdater.py
@@ -13,10 +13,10 @@ License:
 
 
 from .ili2dbconfig import UpdateDataConfiguration
-from .iliexecutable import IliExecutable
+from .iliexecutable import Ili2DbExecutable
 
 
-class Updater(IliExecutable):
+class Updater(Ili2DbExecutable):
     """Executes an update operation on ili2db."""
 
     def __init__(self, parent=None):

--- a/modelbaker/iliwrapper/ilivalidator.py
+++ b/modelbaker/iliwrapper/ilivalidator.py
@@ -18,10 +18,10 @@ from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtGui import QStandardItem, QStandardItemModel
 
 from .ili2dbconfig import ValidateConfiguration
-from .iliexecutable import IliExecutable
+from .iliexecutable import Ili2DbExecutable
 
 
-class Validator(IliExecutable):
+class Validator(Ili2DbExecutable):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.version = 4

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,0 +1,99 @@
+"""
+/***************************************************************************
+        begin                : 2026-07-03
+        git sha              : :%H$
+        copyright            : (C) 2026 by Dave Signer
+        email                : david at opengis ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+"""
+
+import datetime
+import logging
+import os
+import shutil
+import tempfile
+import xml.etree.ElementTree as ET
+
+from qgis.testing import start_app, unittest
+
+from modelbaker.iliwrapper import ilicompiler
+from tests.utils import ilicompiler_config, testdata_path
+
+start_app()
+
+
+class TestCompile(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.basetestpath = tempfile.mkdtemp()
+
+    def test_compile_simplemodel_1(self):
+        # Schema Import
+        compiler = ilicompiler.IliCompiler()
+        compiler.configuration = ilicompiler_config()
+        compiler.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        compiler.configuration.imdfile = os.path.join(
+            self.basetestpath,
+            "metamodel_{:%Y%m%d%H%M%S%f}.imd".format(datetime.datetime.now()),
+        )
+        compiler.stdout.connect(self.print_info)
+        compiler.stderr.connect(self.print_error)
+        assert compiler.run() == ilicompiler.IliCompiler.SUCCESS
+
+        assert os.path.exists(compiler.configuration.imdfile)
+
+        namespaces = {
+            "ili": "http://www.interlis.ch/xtf/2.4/INTERLIS",
+            "IlisMeta16": "http://www.interlis.ch/xtf/2.4/IlisMeta16",
+        }
+
+        tree = ET.parse(compiler.configuration.imdfile)
+        root = tree.getroot()
+
+        # Check some random items
+
+        # Class Street
+        street_class = root.find(
+            ".//IlisMeta16:Class[@ili:tid='RoadsSimple.Roads.Street']", namespaces
+        )
+        assert street_class is not None
+        assert street_class.find("IlisMeta16:Name", namespaces).text == "Street"
+        assert street_class.find("IlisMeta16:Kind", namespaces).text == "Class"
+
+        # Association StreetAxisAssoc
+        assoc_class = root.find(
+            ".//IlisMeta16:Class[@ili:tid='RoadsSimple.Roads.StreetAxisAssoc']",
+            namespaces,
+        )
+        assert assoc_class is not None
+        assert assoc_class.find("IlisMeta16:Name", namespaces).text == "StreetAxisAssoc"
+        assert assoc_class.find("IlisMeta16:Kind", namespaces).text == "Association"
+
+        # Enum Water
+        water_enum = root.find(
+            ".//IlisMeta16:EnumNode[@ili:tid='RoadsSimple.Roads.LandCover.Type.TYPE.TOP.water']",
+            namespaces,
+        )
+        assert water_enum is not None
+        assert water_enum.find("IlisMeta16:Name", namespaces).text == "water"
+
+    def print_info(self, text):
+        logging.info(text)
+
+    def print_error(self, text):
+        logging.error(text)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests."""
+        shutil.rmtree(cls.basetestpath, True)

--- a/tests/test_dataset_handling.py
+++ b/tests/test_dataset_handling.py
@@ -38,7 +38,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -55,7 +55,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -81,7 +81,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_seuzach.xtf"
@@ -105,7 +105,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -122,7 +122,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -148,7 +148,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_seuzach.xtf"
@@ -173,7 +173,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -191,7 +191,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2mssql
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -217,7 +217,7 @@ class TestDatasetHandling(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2mssql
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_seuzach.xtf"

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -43,7 +43,7 @@ class TestDelete(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -60,7 +60,7 @@ class TestDelete(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -86,7 +86,7 @@ class TestDelete(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_seuzach.xtf"
@@ -126,7 +126,7 @@ class TestDelete(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -143,7 +143,7 @@ class TestDelete(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -169,7 +169,7 @@ class TestDelete(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_seuzach.xtf"
@@ -210,7 +210,7 @@ class TestDelete(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -228,7 +228,7 @@ class TestDelete(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2mssql
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -254,7 +254,7 @@ class TestDelete(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2mssql
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_seuzach.xtf"

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -1006,7 +1006,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Abfallsammelstellen_ZEBA_V1.ili"
         )
@@ -1133,7 +1133,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Abfallsammelstellen_ZEBA_V1.ili"
         )
@@ -1257,7 +1257,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Abfallsammelstellen_ZEBA_V1.ili"
         )
@@ -1385,7 +1385,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Abfallsammelstellen_ZEBA_V1.ili"
         )
@@ -1511,7 +1511,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Naturschutz_und_Erholungsinfrastruktur_V1.ili"
         )
@@ -1743,7 +1743,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Naturschutz_und_Erholungsinfrastruktur_V1.ili"
         )
@@ -1971,7 +1971,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Naturschutz_und_Erholungsinfrastruktur_V1.ili"
         )
@@ -2206,7 +2206,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Naturschutz_und_Erholungsinfrastruktur_V1.ili"
         )
@@ -2436,9 +2436,9 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3.ili")
-        importer.configuration.ilimodels = "KbS_LV95_V1_3"
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3_metas.ili")
+        importer.configuration.ilimodels = "KbS_LV95_V1_3_metas"
         importer.configuration.dbschema = "any_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
@@ -2577,9 +2577,9 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3.ili")
-        importer.configuration.ilimodels = "KbS_LV95_V1_3"
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3_metas.ili")
+        importer.configuration.ilimodels = "KbS_LV95_V1_3_metas"
         importer.configuration.dbschema = "any_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
@@ -2699,9 +2699,9 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3.ili")
-        importer.configuration.ilimodels = "KbS_LV95_V1_3"
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3_metas.ili")
+        importer.configuration.ilimodels = "KbS_LV95_V1_3_metas"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
             "tmp_import_bags_of_enum_kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}.gpkg".format(
@@ -2827,9 +2827,9 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
-        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3.ili")
-        importer.configuration.ilimodels = "KbS_LV95_V1_3"
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_3_metas.ili")
+        importer.configuration.ilimodels = "KbS_LV95_V1_3_metas"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
             "tmp_import_bags_of_enum_kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}.gpkg".format(
@@ -2939,7 +2939,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Hazard_Mapping_V1_2.ili"
         )
@@ -3359,7 +3359,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Hazard_Mapping_V1_2.ili"
         )
@@ -3777,7 +3777,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Naturschutz_und_Erholungsinfrastruktur_V1.ili"
         )
@@ -3882,7 +3882,7 @@ class TestDomainClassRelation(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ZG_Naturschutz_und_Erholungsinfrastruktur_V1.ili"
         )

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -243,7 +243,7 @@ class TestExport(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(
@@ -289,7 +289,7 @@ class TestExport(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(

--- a/tests/test_exportmetaconfig.py
+++ b/tests/test_exportmetaconfig.py
@@ -38,7 +38,7 @@ class TestExportMetaConfig(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -55,7 +55,9 @@ class TestExportMetaConfig(unittest.TestCase):
         # ExportMetaConfig
         exportMetaConfig = ilimetaconfigexporter.MetaConfigExporter()
         exportMetaConfig.tool = DbIliMode.ili2pg
-        exportMetaConfig.configuration = ilimetaconfigexporter_config(importer.tool)
+        exportMetaConfig.configuration = ilimetaconfigexporter_config(
+            importer.tool, "ilimodels"
+        )
         metaconfig_file = os.path.join(
             self.basetestpath, "tmp_exported_metaconfig_pg.ini"
         )
@@ -126,7 +128,7 @@ class TestExportMetaConfig(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -143,7 +145,9 @@ class TestExportMetaConfig(unittest.TestCase):
         # ExportMetaConfig
         exportMetaConfig = ilimetaconfigexporter.MetaConfigExporter()
         exportMetaConfig.tool = DbIliMode.ili2gpkg
-        exportMetaConfig.configuration = ilimetaconfigexporter_config(importer.tool)
+        exportMetaConfig.configuration = ilimetaconfigexporter_config(
+            importer.tool, "ilimodels"
+        )
         exportMetaConfig.configuration.dbfile = importer.configuration.dbfile
         metaconfig_file = os.path.join(
             self.basetestpath, "tmp_exported_metaconfig_gpkg.ini"

--- a/tests/test_ilitoppingmaker.py
+++ b/tests/test_ilitoppingmaker.py
@@ -33,7 +33,7 @@ from modelbaker.ilitoppingmaker import (
 from modelbaker.iliwrapper import iliimporter
 from modelbaker.iliwrapper.globals import DbIliMode
 from modelbaker.iliwrapper.ili2dbconfig import Ili2DbCommandConfiguration
-from tests.utils import testdata_path
+from tests.utils import iliimporter_config, testdata_path
 
 start_app()
 
@@ -207,6 +207,7 @@ class IliToppingMakerTest(unittest.TestCase):
         # import schema with modelbaker library
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/KbS_V1_5.ili")
         importer.configuration.ilimodels = "KbS_V1_5"
         dbfile = os.path.join(

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -287,7 +287,7 @@ class TestImport(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -308,7 +308,7 @@ class TestImport(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -341,7 +341,7 @@ class TestImport(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -362,7 +362,7 @@ class TestImport(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -393,7 +393,7 @@ class TestImport(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -415,7 +415,7 @@ class TestImport(unittest.TestCase):
         # Import data
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2mssql
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_pipebaskettest_v1_winti.xtf"
@@ -452,7 +452,7 @@ class TestImport(unittest.TestCase):
         # Schema Import normal
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(
@@ -467,7 +467,7 @@ class TestImport(unittest.TestCase):
         # Import valid data succeeds
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_valid_street.xtf"
@@ -480,7 +480,7 @@ class TestImport(unittest.TestCase):
         # Import invalid data fails because validation is not disabled
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"
@@ -493,7 +493,7 @@ class TestImport(unittest.TestCase):
         # Import invalid data with disabled validation still fails because of the not null constraint in the DB
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"
@@ -506,7 +506,7 @@ class TestImport(unittest.TestCase):
         # Schema Import allowing NOT NULL values for mandatory attributes (disable_mandatory)
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(
@@ -522,7 +522,7 @@ class TestImport(unittest.TestCase):
         # Import valid data succeeds
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_valid_street.xtf"
@@ -535,7 +535,7 @@ class TestImport(unittest.TestCase):
         # Import invalid data fails because validation is not disabled
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"
@@ -547,7 +547,7 @@ class TestImport(unittest.TestCase):
 
         # Import invalid data with disabled validation finally succeeds because of the disabled mandatory constraint in the DB
         dataImporter.tool = DbIliMode.ili2pg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbschema = importer.configuration.dbschema
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"
@@ -561,7 +561,7 @@ class TestImport(unittest.TestCase):
         # Schema Import normal
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbfile = os.path.join(
@@ -577,7 +577,7 @@ class TestImport(unittest.TestCase):
         # Import valid data succeeds
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_valid_street.xtf"
@@ -590,7 +590,7 @@ class TestImport(unittest.TestCase):
         # Import invalid data fails because validation is not disabled
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"
@@ -603,7 +603,7 @@ class TestImport(unittest.TestCase):
         # Import invalid data with disabled validation still fails because of the not null constraint in the DB
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"
@@ -616,7 +616,7 @@ class TestImport(unittest.TestCase):
         # Schema Import allowing NOT NULL values for mandatory attributes (disable_mandatory)
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbfile = os.path.join(
@@ -633,7 +633,7 @@ class TestImport(unittest.TestCase):
         # Import valid data succeeds
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_valid_street.xtf"
@@ -646,7 +646,7 @@ class TestImport(unittest.TestCase):
         # Import invalid data fails because validation is not disabled
         dataImporter = iliimporter.Importer(dataImport=True)
         dataImporter.tool = DbIliMode.gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"
@@ -658,7 +658,7 @@ class TestImport(unittest.TestCase):
 
         # Import invalid data with disabled validation finally succeeds because of the disabled mandatory constraint in the DB
         dataImporter.tool = DbIliMode.gpkg
-        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration = ilidataimporter_config(importer.tool, "ilimodels")
         dataImporter.configuration.dbfile = importer.configuration.dbfile
         dataImporter.configuration.xtffile = testdata_path(
             "xtf/test_roads_simple_invalid_street.xtf"

--- a/tests/test_import_dbparams.py
+++ b/tests/test_import_dbparams.py
@@ -37,7 +37,7 @@ class TestDbParams(unittest.TestCase):
     def test_postgis_withandwithout_params(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.dbschema = "kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()

--- a/tests/test_multiple_geom_gpkg.py
+++ b/tests/test_multiple_geom_gpkg.py
@@ -49,7 +49,7 @@ class TestMultipleGeometriesPerTable(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/MultipleGeom.ili")
         importer.configuration.ilimodels = "MultipleGeom"
         importer.configuration.dbfile = os.path.join(

--- a/tests/test_pgservice.py
+++ b/tests/test_pgservice.py
@@ -66,7 +66,7 @@ class TestPgservice(unittest.TestCase):
         """
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_pure{:%Y%m%d%H%M%S%f}".format(
@@ -173,7 +173,7 @@ class TestPgservice(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_pure{:%Y%m%d%H%M%S%f}".format(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -75,7 +75,7 @@ class TestProcessingAlgorithms(unittest.TestCase):
     def pg_schema(self, basket_col):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -56,7 +56,7 @@ class TestProjectGen(unittest.TestCase):
     def test_ili2db3_kbs_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.dbschema = "ciaf_ladm_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
@@ -179,7 +179,7 @@ class TestProjectGen(unittest.TestCase):
     def test_kbs_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.dbschema = "kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
@@ -301,7 +301,7 @@ class TestProjectGen(unittest.TestCase):
     def test_ili2db3_kbs_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -406,7 +406,7 @@ class TestProjectGen(unittest.TestCase):
     def test_kbs_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -1051,7 +1051,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/RoadsSimpleIndividualExtents.ili"
         )
@@ -1132,7 +1132,7 @@ class TestProjectGen(unittest.TestCase):
     def test_precision_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/RoadsSimpleIndividualExtents.ili"
         )
@@ -1214,7 +1214,7 @@ class TestProjectGen(unittest.TestCase):
     def test_precision_mssql(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/RoadsSimpleIndividualExtents.ili"
         )
@@ -1416,7 +1416,7 @@ class TestProjectGen(unittest.TestCase):
     def test_nmrel_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "CoordSys"
         importer.configuration.dbschema = "ciaf_ladm_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
@@ -1460,7 +1460,7 @@ class TestProjectGen(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "CoordSys"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -2121,7 +2121,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/CardinalityBag.ili")
         importer.configuration.ilimodels = "CardinalityBag"
         importer.configuration.dbschema = "any_{:%Y%m%d%H%M%S%f}".format(
@@ -2397,7 +2397,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/CardinalityBag.ili")
         importer.configuration.ilimodels = "CardinalityBag"
         importer.configuration.dbfile = os.path.join(
@@ -2675,7 +2675,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//BagOfEnumBase.ili")
         importer.configuration.ilimodels = "BagOfEnumBase"
         importer.configuration.tomlfile = testdata_path("toml//BagOfEnumExt.ini")
@@ -2729,7 +2729,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//BagOfEnumBase.ili")
         importer.configuration.ilimodels = "BagOfEnumBase"
         importer.configuration.tomlfile = testdata_path("toml//BagOfEnumExt.ini")
@@ -2786,7 +2786,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//BagOfEnumExt.ili")
         importer.configuration.ilimodels = "BagOfEnumExt"
         importer.configuration.tomlfile = testdata_path("toml//BagOfEnumExt.ini")
@@ -2841,7 +2841,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//BagOfEnumExt.ili")
         importer.configuration.ilimodels = "BagOfEnumExt"
         importer.configuration.tomlfile = testdata_path("toml//BagOfEnumExt.ini")
@@ -2899,7 +2899,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//Assoc23.ili")
         importer.configuration.ilimodels = "Assoc3"
         importer.configuration.dbschema = "assoc23_{:%Y%m%d%H%M%S%f}".format(
@@ -2975,7 +2975,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//Assoc23.ili")
         importer.configuration.ilimodels = "Assoc3"
         importer.configuration.dbfile = os.path.join(
@@ -3070,7 +3070,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//Assoc23.ili")
         importer.configuration.ilimodels = "Assoc3"
         importer.configuration.dbschema = "assoc23_{:%Y%m%d%H%M%S%f}".format(
@@ -3153,7 +3153,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//CompAssoc23.ili")
         importer.configuration.ilimodels = "CompAssoc"
         importer.configuration.dbschema = "compassoc_{:%Y%m%d%H%M%S%f}".format(
@@ -3224,7 +3224,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//CompAssoc23.ili")
         importer.configuration.ilimodels = "CompAssoc"
         importer.configuration.dbfile = os.path.join(
@@ -3304,7 +3304,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels//CompAssoc23.ili")
         importer.configuration.ilimodels = "CompAssoc"
         importer.configuration.dbschema = "compassoc{:%Y%m%d%H%M%S%f}".format(
@@ -3380,7 +3380,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels//OneToOneRelations.ili"
         )
@@ -3466,7 +3466,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels//OneToOneRelations.ili"
         )
@@ -3555,7 +3555,7 @@ class TestProjectGen(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels//OneToOneRelations.ili"
         )
@@ -3649,7 +3649,7 @@ class TestProjectGen(unittest.TestCase):
         """
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -3718,7 +3718,7 @@ class TestProjectGen(unittest.TestCase):
         """
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -3789,7 +3789,7 @@ class TestProjectGen(unittest.TestCase):
         """
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/PipeBasketTest_V1.ili"
         )
@@ -3863,7 +3863,7 @@ class TestProjectGen(unittest.TestCase):
     def test_kbs_postgis_basket_handling(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.dbschema = "kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
@@ -3952,7 +3952,7 @@ class TestProjectGen(unittest.TestCase):
     def test_kbs_geopackage_basket_handling(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -4829,7 +4829,7 @@ class TestProjectGen(unittest.TestCase):
     def test_kbs_postgis_multisurface(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.tomlfile = testdata_path("toml/multisurface.toml")
         importer.configuration.dbschema = "kbs_lv95_v1_3_{:%Y%m%d%H%M%S%f}".format(
@@ -4869,7 +4869,7 @@ class TestProjectGen(unittest.TestCase):
     def test_kbs_geopackage_multisurface(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "KbS_LV95_V1_3"
         importer.configuration.tomlfile = testdata_path("toml/multisurface.toml")
         importer.configuration.dbfile = os.path.join(
@@ -4948,7 +4948,7 @@ class TestProjectGen(unittest.TestCase):
     def test_array_mapping_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/ArrayMapping.ili")
         importer.configuration.ilimodels = "ArrayMapping"
         importer.configuration.dbschema = "array_mapping_{:%Y%m%d%H%M%S%f}".format(
@@ -5002,7 +5002,7 @@ class TestProjectGen(unittest.TestCase):
     def test_array_mapping_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/ArrayMapping.ili")
         importer.configuration.ilimodels = "ArrayMapping"
         importer.configuration.dbfile = os.path.join(
@@ -5055,7 +5055,7 @@ class TestProjectGen(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/ArrayMapping.ili")
         importer.configuration.ilimodels = "ArrayMapping"
         importer.configuration.dbschema = "array_mapping_{:%Y%m%d%H%M%S%f}".format(
@@ -5109,7 +5109,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_bag_of_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/gebaeude_bag_of_V1_6.ili"
         )
@@ -5153,7 +5153,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_bag_of_mapping_array_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/ArrayMappingCatalogue.ili"
         )
@@ -5199,7 +5199,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_bag_of_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/gebaeude_bag_of_V1_6.ili"
         )
@@ -5242,7 +5242,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_bag_of_no_mapping_2_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/gebaeude_bag_of_no_mapping_V1_6.ili"
         )
@@ -5286,7 +5286,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_list_of_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/gebaeude_list_of_V1_6.ili"
         )
@@ -5330,7 +5330,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_list_of_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/gebaeude_list_of_V1_6.ili"
         )
@@ -5373,7 +5373,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_bag_of_no_mapping_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/BagOfNoMappingMetaAttr.ili"
         )
@@ -5419,7 +5419,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_bag_of_no_mapping_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/BagOfNoMappingMetaAttr.ili"
         )
@@ -5462,7 +5462,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_no_bag_of_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/gebaeude_V1_6.ili")
         importer.configuration.ilimodels = "Gebaeudeinventar_V1_6"
         importer.configuration.dbschema = (
@@ -5504,7 +5504,7 @@ class TestProjectGen(unittest.TestCase):
     def test_catalogue_reference_layer_no_bag_of_geopackage(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/gebaeude_V1_6.ili")
         importer.configuration.ilimodels = "Gebaeudeinventar_V1_6"
         importer.configuration.dbfile = os.path.join(
@@ -5544,7 +5544,7 @@ class TestProjectGen(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/Maps_V1.ili")
         importer.configuration.ilimodels = "Maps_V1"
         importer.configuration.dbfile = os.path.join(

--- a/tests/test_projectgen_extension_optimization_smart1.py
+++ b/tests/test_projectgen_extension_optimization_smart1.py
@@ -65,7 +65,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
         )
@@ -114,7 +114,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
         )
@@ -166,7 +166,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
         )
@@ -471,7 +471,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
         )
@@ -520,7 +520,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
         )
@@ -572,7 +572,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
         )
@@ -907,7 +907,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Kantonale_Bauplanung_V1_1.ili"
         )
@@ -955,7 +955,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Kantonale_Bauplanung_V1_1.ili"
         )
@@ -1007,7 +1007,7 @@ class TestProjectExtOptimizationSmart1(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Kantonale_Bauplanung_V1_1.ili"
         )

--- a/tests/test_projectgen_extension_optimization_smart2.py
+++ b/tests/test_projectgen_extension_optimization_smart2.py
@@ -66,7 +66,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
         )
@@ -129,7 +129,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
         )
@@ -194,7 +194,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Staedtische_Ortsplanung_V1_1.ili"
         )
@@ -911,7 +911,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
         )
@@ -974,7 +974,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
         )
@@ -1039,7 +1039,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Polymorphic_Ortsplanung_V1_1.ili"
         )
@@ -1886,7 +1886,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Kantonale_Bauplanung_V1_1.ili"
         )
@@ -1948,7 +1948,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Kantonale_Bauplanung_V1_1.ili"
         )
@@ -2013,7 +2013,7 @@ class TestProjectExtOptimizationSmart2(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path(
             "ilimodels/Kantonale_Bauplanung_V1_1.ili"
         )

--- a/tests/test_projectgen_oids.py
+++ b/tests/test_projectgen_oids.py
@@ -61,7 +61,7 @@ class TestProjectOIDs(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/OIDMadness_V1.ili")
         importer.configuration.ilimodels = "OIDMadness_V1"
         importer.configuration.dbschema = "oid_madness{:%Y%m%d%H%M%S%f}".format(
@@ -122,7 +122,7 @@ class TestProjectOIDs(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/OIDMadness_V1.ili")
         importer.configuration.ilimodels = "OIDMadness_V1"
         importer.configuration.dbfile = os.path.join(
@@ -185,7 +185,7 @@ class TestProjectOIDs(unittest.TestCase):
 
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/OIDMadness_V1.ili")
         importer.configuration.ilimodels = "OIDMadness_V1"
         importer.configuration.dbschema = (

--- a/tests/test_sequence_reset.py
+++ b/tests/test_sequence_reset.py
@@ -36,7 +36,7 @@ class TestSequenceReset(unittest.TestCase):
     def test_reset_seq_postgis(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "road_simple{:%Y%m%d%H%M%S%f}".format(
@@ -80,7 +80,7 @@ class TestSequenceReset(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbfile = os.path.join(
@@ -126,7 +126,7 @@ class TestSequenceReset(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -44,7 +44,7 @@ class TestTranslations(unittest.TestCase):
     def test_translated_db_objects_gpkg(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "PlansDAffectation_V1_2"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -140,7 +140,7 @@ class TestTranslations(unittest.TestCase):
     def test_translated_db_objects_pg(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "PlansDAffectation_V1_2"
         importer.configuration.dbschema = "tid_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
@@ -230,7 +230,7 @@ class TestTranslations(unittest.TestCase):
     def test_translated_available_langs_gpkg(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "PlansDAffectation_V1_2"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -280,7 +280,7 @@ class TestTranslations(unittest.TestCase):
     def test_translated_available_langs_pg(self):
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "PlansDAffectation_V1_2"
         importer.configuration.dbschema = "tid_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
@@ -330,7 +330,7 @@ class TestTranslations(unittest.TestCase):
         # same as translated_db_objects but this time is the schema in French (namelang) and the preferred language German.
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "PlansDAffectation_V1_2"
         importer.configuration.dbfile = os.path.join(
             self.basetestpath,
@@ -427,7 +427,7 @@ class TestTranslations(unittest.TestCase):
         # same as translated_db_objects but this time is the schema in French (namelang) and the preferred language German.
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "PlansDAffectation_V1_2"
         importer.configuration.dbschema = "tid_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -123,7 +123,7 @@ class TestExport(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(
@@ -201,7 +201,7 @@ class TestExport(unittest.TestCase):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2mssql
-        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
         importer.configuration.ilimodels = "RoadsSimple"
         importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(

--- a/tests/testdata/ilimodels/KbS_V1_3_metas.ili
+++ b/tests/testdata/ilimodels/KbS_V1_3_metas.ili
@@ -140,7 +140,7 @@ END KbS_LV03_V1_3.
 !!@ furtherInformation=http://www.bafu.admin.ch/geodatenmodelle
 !!@ technicalContact=mailto:gis@bafu.admin.ch
 !!@ IDGeoIV="114.2, 116.1, 117.1, 118.1, 119.1"
-MODEL KbS_LV95_V1_3 (de)
+MODEL KbS_LV95_V1_3_metas (de)
 AT "https://models.geo.admin.ch/BAFU"
 VERSION "2016-11-28"  =
   IMPORTS LocalisationCH_V1,GeometryCHLV95_V1,KbS_Basis_V1_3;
@@ -168,8 +168,10 @@ VERSION "2016-11-28"  =
       EGRID : BAG {0..*} OF KbS_Basis_V1_3.EGRID_;
       Standorttyp : MANDATORY KbS_Basis_V1_3.Standorttyp;
       InBetrieb : BOOLEAN;
+      !!@ili2db.mapping=ARRAY
       Deponietyp : BAG {0..*} OF KbS_Basis_V1_3.Deponietyp_;
       Nachsorge : BOOLEAN;
+      !!@ili2db.mapping=ARRAY
       Untersuchungsmassnahmen : BAG {1..*} OF KbS_Basis_V1_3.UntersMassn_;
       StatusAltlV : MANDATORY KbS_Basis_V1_3.StatusAltlV;
       Ersteintrag : MANDATORY INTERLIS.XMLDate;
@@ -189,4 +191,4 @@ VERSION "2016-11-28"  =
 
   END Belastete_Standorte;
 
-END KbS_LV95_V1_3.
+END KbS_LV95_V1_3_metas.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,6 +24,7 @@ from modelbaker.iliwrapper.ili2dbconfig import (
     DeleteConfiguration,
     ExportConfiguration,
     ExportMetaConfigConfiguration,
+    Ili2CCommandConfiguration,
     ImportDataConfiguration,
     SchemaImportConfiguration,
     UpdateDataConfiguration,
@@ -210,6 +211,13 @@ def ilimetaconfigexporter_config(tool=DbIliMode.ili2pg, modeldir=None):
 
     configuration.base_configuration = base_config
 
+    return configuration
+
+
+def ilicompiler_config():
+    base_config = BaseConfiguration()
+    configuration = Ili2CCommandConfiguration()
+    configuration.base_configuration = base_config
     return configuration
 
 


### PR DESCRIPTION
# ilicompiler integration

Integrate IliCompiler functionality in the iliwrapper module.

Some restructuring on the ili2db functions where it made sense.

Keeping backwards compatibility for:
- Modules ili2dbutils and ili2dbconfig and ili2dbutils keep the db in the name (althoug they also contain ili2c stuff, because they use common functions classes)

Breaking backwards compatibility for:
- IliExecutable has now abstract functions, but should not be a problem, because it's usually derived (by IliImporter/IliExporter etc.) for the library usage
