### PR TITLE
Enumerations

### DIFF
--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -156,6 +156,7 @@ class Project(QObject):
                     crs = QgsCoordinateReferenceSystem(self.crs)  # Fallback
                 qgis_project.setCrs(crs)
 
+        # Set relations and relation depending editor widgets accordingly
         qgis_relations = list(qgis_project.relationManager().relations().values())
         dict_layers = {layer.layer.id(): layer for layer in self.layers}
         for relation in self.relations:
@@ -194,12 +195,13 @@ class Project(QObject):
                         )
                         if relation.child_domain_name
                         else "",
-                        "Key": referenced_layer.provider_names_map.get("tid_name"),
+                        "Key": relation.referenced_field,
                         "NofColumns": 1,
                         "OrderByField": True,
                         "OrderByFieldName": "seq",
                     },
                 )
+                # here we don't append the relation because we don't need it anymore
             elif referenced_layer and referenced_layer.is_domain:
                 editor_widget_setup = QgsEditorWidgetSetup(
                     "RelationReference",
@@ -271,7 +273,7 @@ class Project(QObject):
             )
         qgis_project.relationManager().setRelations(qgis_relations)
 
-        # Set Bag of Enum widget
+        # BAG-OF Enumerations with ARRAY mapping are value relations as well
         for layer_name, bag_of_enum in self.bags_of_enum.items():
             current_layer = None
             for attribute, bag_of_enum_info in bag_of_enum.items():
@@ -299,7 +301,9 @@ class Project(QObject):
                     "OrderByValue": False,
                     "AllowNull": True,
                     "Layer": domain_table.create().id(),
-                    "FilterExpression": "",
+                    "FilterExpression": "\"{}\" = '{}'".format(
+                        ENUM_THIS_CLASS_COLUMN, layer.ili_name
+                    ),
                     "Key": key_field,
                     "NofColumns": 1,
                 }

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -49,6 +49,7 @@ class DBConnector(QObject):
             "dispname_name": self.dispName,
             "baskettable_name": self.basket_table_name,
             "datasettable_name": self.dataset_table_name,
+            "ilicodename": self.iliCodeName,
         }
 
     def map_data_types(self, data_type: str) -> str:

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -525,14 +525,35 @@ class GPKGConnector(DBConnector):
             cursor.execute("""PRAGMA foreign_key_list("{}");""".format(table_info_name))
             foreign_keys = cursor.fetchall()
 
-            for foreign_key in foreign_keys:
+            # In case of enumtabs without id we have to generate fake foreign keys based on the enumDomain
+            cursor.execute(
+                """SELECT c.sqlname as 'table', p.columnname as 'from'
+                FROM T_ILI2DB_COLUMN_PROP p
+                JOIN T_ILI2DB_CLASSNAME c
+                ON c.iliname=p.setting
+                WHERE tablename = ?
+                and tag = 'ch.ehi.ili2db.enumDomain'
+            """,
+                (table_info_name,),
+            )
+            fake_enum_foreign_keys = cursor.fetchall()
+
+            fks = [("fk", fk["from"], fk["table"]) for fk in foreign_keys]
+            fake_enum_fks = [
+                ("enum", fk["from"], fk["table"]) for fk in fake_enum_foreign_keys
+            ]
+            all_foreign_keys = list(set(fks + fake_enum_fks))
+
+            for foreign_key in all_foreign_keys:
                 record = {}
                 record["referencing_table"] = table_info["tablename"]
-                record["referencing_column"] = foreign_key["from"]
-                record["referenced_table"] = foreign_key["table"]
-                record["referenced_column"] = tables_info_dict[foreign_key["table"]][
-                    "primary_key"
-                ]
+                record["referencing_column"] = foreign_key[1]  # from
+                record["referenced_table"] = foreign_key[2]  # table
+                record["referenced_column"] = (
+                    tables_info_dict[foreign_key[2]]["primary_key"]
+                    if foreign_key[0] == "fk"
+                    else "iliCode"
+                )
                 record["constraint_name"] = "{}_{}_{}_{}".format(
                     record["referencing_table"],
                     record["referencing_column"],
@@ -554,9 +575,9 @@ class GPKGConnector(DBConnector):
                             colowner="owner" if self.ili_version() == 3 else "colowner"
                         ),
                         (
-                            foreign_key["from"],
+                            foreign_key[1],  # from
                             table_info["tablename"],
-                            foreign_key["table"],
+                            foreign_key[2],  # table
                         ),
                     )
                     strength_record = cursor.fetchone()
@@ -581,9 +602,9 @@ class GPKGConnector(DBConnector):
                             colowner="owner" if self.ili_version() == 3 else "colowner"
                         ),
                         (
-                            foreign_key["from"],
+                            foreign_key[1],  # from
                             table_info["tablename"],
-                            foreign_key["table"],
+                            foreign_key[2],  # table
                         ),
                     )
                     cardinality_record = cursor.fetchone()

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -524,24 +524,26 @@ class GPKGConnector(DBConnector):
         for table_info_name, table_info in tables_info_dict.items():
             cursor.execute("""PRAGMA foreign_key_list("{}");""".format(table_info_name))
             foreign_keys = cursor.fetchall()
-
-            # In case of enumtabs without id we have to generate fake foreign keys based on the enumDomain
-            cursor.execute(
-                """SELECT c.sqlname as 'table', p.columnname as 'from'
-                FROM T_ILI2DB_COLUMN_PROP p
-                JOIN T_ILI2DB_CLASSNAME c
-                ON c.iliname=p.setting
-                WHERE tablename = ?
-                and tag = 'ch.ehi.ili2db.enumDomain'
-            """,
-                (table_info_name,),
-            )
-            fake_enum_foreign_keys = cursor.fetchall()
-
             fks = [("fk", fk["from"], fk["table"]) for fk in foreign_keys]
-            fake_enum_fks = [
-                ("enum", fk["from"], fk["table"]) for fk in fake_enum_foreign_keys
-            ]
+
+            fake_enum_fks = []
+            if self._table_exists(GPKG_METAATTRS_TABLE):
+                # In case of enumtabs without id we have to generate fake foreign keys based on the enumDomain
+                cursor.execute(
+                    """SELECT c.sqlname as 'table', p.columnname as 'from'
+                    FROM T_ILI2DB_COLUMN_PROP p
+                    JOIN T_ILI2DB_CLASSNAME c
+                    ON c.iliname=p.setting
+                    WHERE tablename = ?
+                    and tag = 'ch.ehi.ili2db.enumDomain'
+                """,
+                    (table_info_name,),
+                )
+                fake_enum_foreign_keys = cursor.fetchall()
+
+                fake_enum_fks = [
+                    ("enum", fk["from"], fk["table"]) for fk in fake_enum_foreign_keys
+                ]
             all_foreign_keys = list(set(fks + fake_enum_fks))
 
             for foreign_key in all_foreign_keys:

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -524,7 +524,7 @@ class GPKGConnector(DBConnector):
         for table_info_name, table_info in tables_info_dict.items():
             cursor.execute("""PRAGMA foreign_key_list("{}");""".format(table_info_name))
             foreign_keys = cursor.fetchall()
-            fks = [("fk", fk["from"], fk["table"]) for fk in foreign_keys]
+            fks = [(fk["from"], fk["table"]) for fk in foreign_keys]
 
             fake_enum_fks = []
             if self._table_exists(GPKG_METAATTRS_TABLE):
@@ -542,9 +542,19 @@ class GPKGConnector(DBConnector):
                 fake_enum_foreign_keys = cursor.fetchall()
 
                 fake_enum_fks = [
-                    ("enum", fk["from"], fk["table"]) for fk in fake_enum_foreign_keys
+                    (fk["from"], fk["table"]) for fk in fake_enum_foreign_keys
                 ]
-            all_foreign_keys = list(set(fks + fake_enum_fks))
+            all_foreign_keys = []
+            for fk in fks:
+                all_foreign_keys.append(("fk", fk[0], fk[1]))  # type, from, table
+            for fake_enum_fk in fake_enum_fks:
+                if (
+                    fake_enum_fk[0],
+                    fake_enum_fk[1],
+                ) not in fks:  # avoid duplicates in case there is already a real fk for the same field
+                    all_foreign_keys.append(
+                        ("enum", fake_enum_fk[0], fake_enum_fk[1])
+                    )  # type, from, table
 
             for foreign_key in all_foreign_keys:
                 record = {}

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -815,38 +815,6 @@ class PGConnector(DBConnector):
                 )
             )
 
-            print(
-                """ {distinct}
-                SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION{strength_field}{cardinality_fields}{translate}
-                            FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC
-                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1
-                             ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME {schema_where1} {filter_layer_where}
-                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU2
-                             ON KCU2.CONSTRAINT_CATALOG = RC.UNIQUE_CONSTRAINT_CATALOG AND KCU2.CONSTRAINT_SCHEMA = RC.UNIQUE_CONSTRAINT_SCHEMA AND KCU2.CONSTRAINT_NAME = RC.UNIQUE_CONSTRAINT_NAME
-                             AND KCU2.ORDINAL_POSITION = KCU1.ORDINAL_POSITION {schema_where2}
-                            {strength_join}
-                            {cardinality_join}
-                            GROUP BY RC.CONSTRAINT_NAME, KCU1.TABLE_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION{strength_group_by}{cardinality_group_bys}
-                            {order_by}
-                            {fake_relation_union}
-                            """.format(
-                    distinct=distinct,
-                    schema_where1=schema_where1,
-                    schema_where2=schema_where2,
-                    filter_layer_where=filter_layer_where,
-                    strength_field=strength_field,
-                    strength_join=strength_join,
-                    strength_group_by=strength_group_by,
-                    cardinality_fields=cardinality_fields,
-                    cardinality_join=cardinality_join,
-                    cardinality_group_bys=cardinality_group_bys,
-                    translate=translate,
-                    order_by="ORDER BY KCU1.ORDINAL_POSITION"
-                    if not fake_relation_union
-                    else "",
-                    fake_relation_union=fake_relation_union,
-                )
-            )
             return cur
 
         return []

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -723,6 +723,8 @@ class PGConnector(DBConnector):
             cardinality_join = ""
             cardinality_group_bys = ""
             translate = ""
+            distinct = ""
+            fake_relation_union = ""
 
             if self._table_exists(PG_METAATTRS_TABLE):
                 strength_field = ", META_ATTRS.attr_value as strength"
@@ -765,8 +767,24 @@ class PGConnector(DBConnector):
                     ", true AS tr_enabled" if self.get_translation_handling()[0] else ""
                 )
 
+                # In case of enumtabs without id we have to generate fake relations based on the enumDomain
+                distinct = "SELECT DISTINCT ON (referencing_table, referencing_column) * FROM ("
+                fake_relation_union = """
+                    UNION SELECT CONCAT( p.tablename, '_', p.columnname, '_enumkey') AS constraint_name, p.tablename AS referencing_table, p.columnname AS referencing_column, 'tabsidsmart2' AS constraint_schema, c.sqlname AS referenced_table, 'ilicode' AS referenced_column{translate}, 1 AS ordinal_position,
+                    NULL AS strength, NULL AS cardinality_max, NULL AS cardinality_min, NULL AS assoc_cardinality_max, NULL AS assoc_cardinality_min
+                    FROM {schema}.T_ILI2DB_COLUMN_PROP p
+                    JOIN {schema}.T_ILI2DB_CLASSNAME c
+                    ON c.iliname=p.setting
+                    and tag = 'ch.ehi.ili2db.enumDomain'
+                    ) all_relations
+                    ORDER BY referencing_table, referencing_column, referenced_column, ordinal_position DESC
+                    """.format(
+                    translate=translate, schema=self.schema
+                )
+
             cur.execute(
-                """SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION{strength_field}{cardinality_fields}{translate}
+                """ {distinct}
+                SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION{strength_field}{cardinality_fields}{translate}
                             FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC
                             INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1
                              ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME {schema_where1} {filter_layer_where}
@@ -776,8 +794,10 @@ class PGConnector(DBConnector):
                             {strength_join}
                             {cardinality_join}
                             GROUP BY RC.CONSTRAINT_NAME, KCU1.TABLE_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION{strength_group_by}{cardinality_group_bys}
-                            ORDER BY KCU1.ORDINAL_POSITION
+                            {order_by}
+                            {fake_relation_union}
                             """.format(
+                    distinct=distinct,
                     schema_where1=schema_where1,
                     schema_where2=schema_where2,
                     filter_layer_where=filter_layer_where,
@@ -788,6 +808,10 @@ class PGConnector(DBConnector):
                     cardinality_join=cardinality_join,
                     cardinality_group_bys=cardinality_group_bys,
                     translate=translate,
+                    order_by="ORDER BY KCU1.ORDINAL_POSITION"
+                    if not fake_relation_union
+                    else "",
+                    fake_relation_union=fake_relation_union,
                 )
             )
             return cur

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -768,21 +768,54 @@ class PGConnector(DBConnector):
                 )
 
                 # In case of enumtabs without id we have to generate fake relations based on the enumDomain
-                distinct = "SELECT DISTINCT ON (referencing_table, referencing_column) * FROM ("
+                distinct = "SELECT * FROM ( SELECT DISTINCT ON (referencing_table, referencing_column) * FROM ("
                 fake_relation_union = """
-                    UNION SELECT CONCAT( p.tablename, '_', p.columnname, '_enumkey') AS constraint_name, p.tablename AS referencing_table, p.columnname AS referencing_column, 'tabsidsmart2' AS constraint_schema, c.sqlname AS referenced_table, 'ilicode' AS referenced_column{translate}, 1 AS ordinal_position,
-                    NULL AS strength, NULL AS cardinality_max, NULL AS cardinality_min, NULL AS assoc_cardinality_max, NULL AS assoc_cardinality_min
+                    UNION SELECT CONCAT( p.tablename, '_', p.columnname, '_enumkey') AS constraint_name, p.tablename AS referencing_table, p.columnname AS referencing_column, '{schema}' AS constraint_schema, c.sqlname AS referenced_table, 'ilicode' AS referenced_column, 1 AS ordinal_position,
+                    NULL AS strength, NULL AS cardinality_max, NULL AS cardinality_min, NULL AS assoc_cardinality_max, NULL AS assoc_cardinality_min{translate}
                     FROM {schema}.T_ILI2DB_COLUMN_PROP p
                     JOIN {schema}.T_ILI2DB_CLASSNAME c
                     ON c.iliname=p.setting
                     and tag = 'ch.ehi.ili2db.enumDomain'
                     ) all_relations
-                    ORDER BY referencing_table, referencing_column, referenced_column, ordinal_position DESC
-                    """.format(
+                    ORDER BY referencing_table, referencing_column, referenced_column DESC
+                    ) relations_without_duplicates """.format(
                     translate=translate, schema=self.schema
                 )
 
             cur.execute(
+                """ {distinct}
+                SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION AS ordinal_position{strength_field}{cardinality_fields}{translate}
+                            FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC
+                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU1
+                             ON KCU1.CONSTRAINT_CATALOG = RC.CONSTRAINT_CATALOG AND KCU1.CONSTRAINT_SCHEMA = RC.CONSTRAINT_SCHEMA AND KCU1.CONSTRAINT_NAME = RC.CONSTRAINT_NAME {schema_where1} {filter_layer_where}
+                            INNER JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS KCU2
+                             ON KCU2.CONSTRAINT_CATALOG = RC.UNIQUE_CONSTRAINT_CATALOG AND KCU2.CONSTRAINT_SCHEMA = RC.UNIQUE_CONSTRAINT_SCHEMA AND KCU2.CONSTRAINT_NAME = RC.UNIQUE_CONSTRAINT_NAME
+                             AND KCU2.ORDINAL_POSITION = KCU1.ORDINAL_POSITION {schema_where2}
+                            {strength_join}
+                            {cardinality_join}
+                            GROUP BY RC.CONSTRAINT_NAME, KCU1.TABLE_NAME, KCU1.COLUMN_NAME, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME, KCU2.COLUMN_NAME, KCU1.ORDINAL_POSITION{strength_group_by}{cardinality_group_bys}
+                            {fake_relation_union}
+                            {order_by}
+                            """.format(
+                    distinct=distinct,
+                    schema_where1=schema_where1,
+                    schema_where2=schema_where2,
+                    filter_layer_where=filter_layer_where,
+                    strength_field=strength_field,
+                    strength_join=strength_join,
+                    strength_group_by=strength_group_by,
+                    cardinality_fields=cardinality_fields,
+                    cardinality_join=cardinality_join,
+                    cardinality_group_bys=cardinality_group_bys,
+                    translate=translate,
+                    order_by="ORDER BY ordinal_position"
+                    if not fake_relation_union
+                    else "",
+                    fake_relation_union=fake_relation_union,
+                )
+            )
+
+            print(
                 """ {distinct}
                 SELECT RC.CONSTRAINT_NAME, KCU1.TABLE_NAME AS referencing_table, KCU1.COLUMN_NAME AS referencing_column, KCU2.CONSTRAINT_SCHEMA, KCU2.TABLE_NAME AS referenced_table, KCU2.COLUMN_NAME AS referenced_column, KCU1.ORDINAL_POSITION{strength_field}{cardinality_fields}{translate}
                             FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS AS RC

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -543,10 +543,6 @@ class Generator(QObject):
             layer_map[layer.name].append(layer)
         relations = list()
 
-        classname_info = [
-            record["iliname"] for record in self.get_iliname_dbname_mapping()
-        ]
-
         for record in relations_info:
             if (
                 record["referencing_table"] in layer_map.keys()
@@ -615,10 +611,7 @@ class Generator(QObject):
                             ]
                             if fields:
                                 field = fields[0]
-                                if (
-                                    field.enum_domain
-                                    and field.enum_domain not in classname_info
-                                ):
+                                if field.enum_domain:
                                     child_name = field.enum_domain
                         relation.child_domain_name = child_name
 

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -263,14 +263,17 @@ class Generator(QObject):
                         for entry in mapped_dispnames:
                             if entry["label"]:
                                 case_expression += (
-                                    "WHEN iliCode = '{code}' THEN '{label}'\n".format(
-                                        code=entry["code"], label=entry["label"]
+                                    "WHEN {ilicode} = '{code}' THEN '{label}'\n".format(
+                                        ilicode=provider_names_map.get("ilicodename"),
+                                        code=entry["code"],
+                                        label=entry["label"],
                                     )
                                 )
                             else:
                                 case_expression += (
-                                    "WHEN iliCode = '{code}' THEN dispName\n".format(
-                                        code=entry["code"]
+                                    "WHEN {ilicode} = '{code}' THEN dispName\n".format(
+                                        ilicode=provider_names_map.get("ilicodename"),
+                                        code=entry["code"],
                                     )
                                 )
                         case_expression += "END"
@@ -316,7 +319,8 @@ class Generator(QObject):
                 provider_names_map=provider_names_map,
             )
 
-            # Configure fields for current table
+            # CONFIGURE FIELDS FOR THE CURRENT TABLE
+
             fields_info = self.get_fields_info(record["tablename"])
             min_max_info = self.get_min_max_info(record["tablename"])
             # We get the value map values from the check-constraints (only pg support) and additionally we check the t_type values in the ili2db-meta-tables
@@ -326,6 +330,7 @@ class Generator(QObject):
 
             re_iliname = re.compile(r".*\.(.*)$")
             for fielddef in fields_info:
+                # FIELD NAMING
                 column_name = fielddef["column_name"]
 
                 # If raw_naming is True, the fieldname should be the columnname
@@ -358,7 +363,8 @@ class Generator(QObject):
                 field = Field(column_name)
                 field.alias = alias
 
-                # Should we hide the field?
+                # HIDDEN FIELD
+
                 hide_attribute = False
 
                 if "fully_qualified_name" in fielddef:
@@ -380,8 +386,12 @@ class Generator(QObject):
 
                 field.hidden = hide_attribute
 
+                # READ-ONLY FIELD
+
                 if column_name in READONLY_FIELDNAMES:
                     field.read_only = True
+
+                # WIDGET CONFIGURATION
 
                 if column_name in min_max_info:
                     field.widget = "Range"
@@ -453,7 +463,7 @@ class Generator(QObject):
                 if "enum_domain" in fielddef and fielddef["enum_domain"]:
                     field.enum_domain = fielddef["enum_domain"]
 
-                # default value expressions
+                # DEFAULT VALUE EXPRESSION:
 
                 ## we have this to provide e.g. the T_Id expression for GPKG defined in the db_connector
                 if "default_value_expression" in fielddef:
@@ -600,20 +610,23 @@ class Generator(QObject):
                             # ...then it's a composition in QGIS
                             relation.strength = QgsRelation.RelationStrength.Composition
 
-                        # For domain-class relations, if we have an extended domain, get its child name
-                        child_name = None
-                        if referenced_layer.is_domain:
-                            # Get child name (if domain is extended)
-                            fields = [
-                                field
-                                for field in referencing_layer.fields
-                                if field.name == record["referencing_column"]
-                            ]
-                            if fields:
-                                field = fields[0]
-                                if field.enum_domain:
-                                    child_name = field.enum_domain
-                        relation.child_domain_name = child_name
+                        # For enum-class relations, if we have an extended domain, get its child name, but only when it's created with ids
+                        if record[
+                            "referenced_column"
+                        ] != referenced_layer.provider_names_map.get("ilicodename"):
+                            child_name = None
+                            if referenced_layer.is_domain:
+                                # Get child name (if domain is extended)
+                                fields = [
+                                    field
+                                    for field in referencing_layer.fields
+                                    if field.name == record["referencing_column"]
+                                ]
+                                if fields:
+                                    field = fields[0]
+                                    if field.enum_domain:
+                                        child_name = field.enum_domain
+                            relation.child_domain_name = child_name
 
                         relations.append(relation)
 

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -268,6 +268,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         self.pre_script = ""
         self.post_script = ""
         self.name_lang = ""
+        self.enum_tabs = "tabsid"  # "tabs","singletab"
 
     def to_ili2db_args(
         self, extra_args: list[str] = [], with_action: bool = True
@@ -309,7 +310,12 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
 
         if self.db_ili_version is None or self.db_ili_version > 3:
             self.append_args(args, ["--createTypeConstraint"], True)
-            self.append_args(args, ["--createEnumTabsWithId"], True)
+            if self.enum_tabs == "tabs":
+                self.append_args(args, ["--createEnumTabs"], True)
+            elif self.enum_tabs == "singletab":
+                self.append_args(args, ["--createSingleEnumTab"], True)
+            else:
+                self.append_args(args, ["--createEnumTabsWithId"], True)
             self.append_args(args, ["--createTidCol"], True)
         else:
             # version 3 backwards compatibility (not needed in newer versions)

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -453,7 +453,6 @@ class TestDomainClassRelation(unittest.TestCase):
                 "child_domain_name": "Avaluo.BaunitTipo",
             }
         )
-
         for expected_relation in expected_relations:
             assert expected_relation in relations_dicts
 

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4132,12 +4132,11 @@ class TestDomainClassRelation(unittest.TestCase):
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors.DomBaseColorType'"
+                    config["FilterExpression"] == "\"thisclass\" = 'Colors.ColorType'"
                 )
                 count += 1
 
-            if layer.alias == "ChildColor":
+            if layer.alias == "BlueChildColor":
                 field = layer.layer.fields().field("colortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4145,11 +4144,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.DomChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
                 )
                 count += 1
 
-            if layer.alias == "AnotherChildColor":
+            if layer.alias == "GreenChildColor":
                 field = layer.layer.fields().field("colortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4157,7 +4156,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.DomAnotherChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
                 )
                 count += 1
         assert count == 3
@@ -4208,12 +4207,11 @@ class TestDomainClassRelation(unittest.TestCase):
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors.DomBaseColorType'"
+                    config["FilterExpression"] == "\"thisclass\" = 'Colors.ColorType'"
                 )
                 count += 1
 
-            if layer.alias == "ChildColor":
+            if layer.alias == "BlueChildColor":
                 field = layer.layer.fields().field("colortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4221,11 +4219,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.DomChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
                 )
                 count += 1
 
-            if layer.alias == "AnotherChildColor":
+            if layer.alias == "GreenChildColor":
                 field = layer.layer.fields().field("colortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4233,7 +4231,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.DomAnotherChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
                 )
                 count += 1
         assert count == 3

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4086,13 +4086,153 @@ class TestDomainClassRelation(unittest.TestCase):
 
         assert count == 1
 
-    def test_enumtabsid_for_domain_postgis(self):
+    def test_enumtabsid_smart1_postgis(self):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
         importer.configuration = iliimporter_config(importer.tool, "ilimodels")
         importer.configuration.ilimodels = "Colors_V2"
-        importer.configuration.ilifile
+        importer.configuration.dbschema = "colors_v2_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = False
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            importer.configuration.inheritance,
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                # This is still a bug https://github.com/opengisch/QgisModelBaker/issues/1120
+                # assert (
+                #    config["FilterExpression"]
+                #    == "\"thisclass\" = 'Colors_V2.ColorType'"
+                # )
+                count += 1
+
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+                count += 1
+        assert count == 2
+
+    def test_enumtabsid_smart1_geopackage(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "colors_v2_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = False
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        generator = Generator(
+            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                # This is still a bug https://github.com/opengisch/QgisModelBaker/issues/1120
+                # assert (
+                #    config["FilterExpression"]
+                #    == "\"thisclass\" = 'Colors_V2.ColorType'"
+                # )
+                count += 1
+
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+                count += 1
+        assert count == 2
+
+    def test_enumtabsid_smart2_postgis(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
         importer.configuration.dbschema = "colors_v2_{:%Y%m%d%H%M%S%f}".format(
             datetime.datetime.now()
         )
@@ -4131,8 +4271,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
+
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
                 assert (
-                    config["FilterExpression"] == "\"thisclass\" = 'Colors.ColorType'"
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.ColorType'"
                 )
                 count += 1
 
@@ -4142,6 +4285,8 @@ class TestDomainClassRelation(unittest.TestCase):
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
+
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
@@ -4154,14 +4299,31 @@ class TestDomainClassRelation(unittest.TestCase):
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
                 )
                 count += 1
-        assert count == 3
 
-    def test_enumtabsid_for_domain_geopackage(self):
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+                count += 1
+        assert count == 4
+
+    def test_enumtabsid_smart2_geopackage(self):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
@@ -4206,8 +4368,10 @@ class TestDomainClassRelation(unittest.TestCase):
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
                 assert (
-                    config["FilterExpression"] == "\"thisclass\" = 'Colors.ColorType'"
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.ColorType'"
                 )
                 count += 1
 
@@ -4217,6 +4381,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
@@ -4229,14 +4394,152 @@ class TestDomainClassRelation(unittest.TestCase):
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
                 )
                 count += 1
-        assert count == 3
 
-    def test_enumtabs_for_domain_postgis(self):
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+                count += 1
+        assert count == 4
+
+    def test_enumtabs_smart1_postgis(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbschema = "colors_v2_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = False
+        # createEnumTabs
+        importer.configuration.enum_tabs = "tabs"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            importer.configuration.inheritance,
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                # It's technically not possible to have a sollution here, because the enumeration types are in a different table
+                count += 1
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+                count += 1
+        assert count == 2
+
+    def test_enumtabs_smart1_geopackage(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "colors_v2_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = False
+        # createEnumTabs
+        importer.configuration.enum_tabs = "tabs"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        generator = Generator(
+            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                # It's technically not possible to have a sollution here, because the enumeration types are in a different table
+                count += 1
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+                count += 1
+        assert count == 2
+
+    def test_enumtabs_smart2_postgis(self):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
@@ -4274,7 +4577,59 @@ class TestDomainClassRelation(unittest.TestCase):
         qgis_project = QgsProject.instance()
         project.create(None, qgis_project)
 
-    def test_enumtabs_for_domain_geopackage(self):
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert config["FilterExpression"] == ""
+                count += 1
+
+            if layer.alias == "BlueChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "BlueChildColorType"
+                )
+                assert config["FilterExpression"] == ""
+                count += 1
+
+            if layer.alias == "GreenChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "GreenChildColorType"
+                )
+                assert config["FilterExpression"] == ""
+                count += 1
+
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert config["FilterExpression"] == ""
+                count += 1
+        assert count == 4
+
+    def test_enumtabs_smart2_geopackage(self):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg
@@ -4313,7 +4668,136 @@ class TestDomainClassRelation(unittest.TestCase):
         qgis_project = QgsProject.instance()
         project.create(None, qgis_project)
 
-    def test_enumsingletab_for_domain_postgis(self):
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert config["FilterExpression"] == ""
+                count += 1
+
+            if layer.alias == "BlueChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "BlueChildColorType"
+                )
+                assert config["FilterExpression"] == ""
+                count += 1
+
+            if layer.alias == "GreenChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "GreenChildColorType"
+                )
+                assert config["FilterExpression"] == ""
+                count += 1
+
+            if layer.alias == "UninheritedCMYColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert config["FilterExpression"] == ""
+                count += 1
+        assert count == 4
+
+    def test_enumsingletab_smart1_postgis(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbschema = "colors_v2_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = False
+        # createSingleEnumTab
+        importer.configuration.enum_tabs = "singletab"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            importer.configuration.inheritance,
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+    def test_enumsingletab_smart1_geopackage(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "colors_v2_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.inheritance = "smart1"
+        importer.configuration.create_basket_col = False
+        # createSingleEnumTab
+        importer.configuration.enum_tabs = "singletab"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        generator = Generator(
+            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+    def test_enumsingletab_smart2_postgis(self):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2pg
@@ -4351,7 +4835,7 @@ class TestDomainClassRelation(unittest.TestCase):
         qgis_project = QgsProject.instance()
         project.create(None, qgis_project)
 
-    def test_enumsingletab_for_domain_geopackage(self):
+    def test_enumsingletab_smart2_geopackage(self):
         # Schema Import
         importer = iliimporter.Importer()
         importer.tool = DbIliMode.ili2gpkg

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -90,7 +90,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "t_id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.Uso_AvaluoTipo",
             }
         )
         # Domain inherited from superclass and from another model
@@ -101,7 +101,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.DerechoTipo",
             }
         )
         # Domain from another model
@@ -112,7 +112,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "t_id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.InteresadoDocumentoTipo",
             }
         )
         # Domain from another model
@@ -123,7 +123,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "t_id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.Genero",
             }
         )
         # Domain inherited from abstract class
@@ -134,7 +134,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.InteresadoTipo",
             }
         )
         # Domain inherited from abstract class
@@ -145,7 +145,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.BaunitTipo",
             }
         )
 
@@ -395,7 +395,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "T_Id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.Uso_AvaluoTipo",
             }
         )
         # Domain inherited from superclass and from another model
@@ -406,7 +406,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.DerechoTipo",
             }
         )
         # Domain from another model
@@ -417,7 +417,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.InteresadoDocumentoTipo",
             }
         )
         # Domain from another model
@@ -428,7 +428,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "T_Id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.Genero",
             }
         )
         # Domain inherited from abstract class
@@ -439,7 +439,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.InteresadoTipo",
             }
         )
         # Domain inherited from abstract class
@@ -450,7 +450,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.BaunitTipo",
             }
         )
 
@@ -708,7 +708,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "T_Id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.Uso_AvaluoTipo",
             }
         )
         # Domain inherited from superclass and from another model
@@ -719,7 +719,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.DerechoTipo",
             }
         )
         # Domain from another model
@@ -730,7 +730,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.InteresadoDocumentoTipo",
             }
         )
         # Domain from another model
@@ -741,7 +741,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "T_Id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.Genero",
             }
         )
         # Domain inherited from abstract class
@@ -752,7 +752,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.InteresadoTipo",
             }
         )
         # Domain inherited from abstract class
@@ -763,7 +763,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": None,
+                "child_domain_name": "Avaluo.BaunitTipo",
             }
         )
 

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -90,7 +90,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "t_id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": "Avaluo.Uso_AvaluoTipo",
+                "child_domain_name": "CIAF_LADM.Avaluo_UsoTipo",
             }
         )
         # Domain inherited from superclass and from another model
@@ -101,7 +101,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": "Avaluo.DerechoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_DerechoTipo",
             }
         )
         # Domain from another model
@@ -112,7 +112,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "t_id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": "Avaluo.InteresadoDocumentoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo",
             }
         )
         # Domain from another model
@@ -123,7 +123,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "t_id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": "Avaluo.Genero",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_Genero",
             }
         )
         # Domain inherited from abstract class
@@ -134,7 +134,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": "Avaluo.InteresadoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_InteresadoTipo",
             }
         )
         # Domain inherited from abstract class
@@ -145,7 +145,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": "Avaluo.BaunitTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_BAUnitTipo",
             }
         )
 
@@ -395,7 +395,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "T_Id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": "Avaluo.Uso_AvaluoTipo",
+                "child_domain_name": "CIAF_LADM.Avaluo_UsoTipo",
             }
         )
         # Domain inherited from superclass and from another model
@@ -406,7 +406,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": "Avaluo.DerechoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_DerechoTipo",
             }
         )
         # Domain from another model
@@ -417,7 +417,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": "Avaluo.InteresadoDocumentoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo",
             }
         )
         # Domain from another model
@@ -428,7 +428,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "T_Id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": "Avaluo.Genero",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_Genero",
             }
         )
         # Domain inherited from abstract class
@@ -439,7 +439,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": "Avaluo.InteresadoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_InteresadoTipo",
             }
         )
         # Domain inherited from abstract class
@@ -450,7 +450,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": "Avaluo.BaunitTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_BAUnitTipo",
             }
         )
         for expected_relation in expected_relations:
@@ -707,7 +707,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "T_Id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": "Avaluo.Uso_AvaluoTipo",
+                "child_domain_name": "CIAF_LADM.Avaluo_UsoTipo",
             }
         )
         # Domain inherited from superclass and from another model
@@ -718,7 +718,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": "Avaluo.DerechoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_DerechoTipo",
             }
         )
         # Domain from another model
@@ -729,7 +729,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": "Avaluo.InteresadoDocumentoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo",
             }
         )
         # Domain from another model
@@ -740,7 +740,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "T_Id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": "Avaluo.Genero",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_Genero",
             }
         )
         # Domain inherited from abstract class
@@ -751,7 +751,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": "Avaluo.InteresadoTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_InteresadoTipo",
             }
         )
         # Domain inherited from abstract class
@@ -762,7 +762,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": "Avaluo.BaunitTipo",
+                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_BAUnitTipo",
             }
         )
 

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4470,10 +4470,6 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
-                assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
-                )
                 count += 1
         assert count == 2
 
@@ -4530,10 +4526,6 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
-                )
-                assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
                 )
                 count += 1
         assert count == 2

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4086,6 +4086,312 @@ class TestDomainClassRelation(unittest.TestCase):
 
         assert count == 1
 
+    def test_enumtabsid_for_domain_postgis(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.ilifile
+        importer.configuration.dbschema = "colors_v2_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = False
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            importer.configuration.inheritance,
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors.DomBaseColorType'"
+                )
+                count += 1
+
+            if layer.alias == "ChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.DomChildColorType'"
+                )
+                count += 1
+
+            if layer.alias == "AnotherChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.DomAnotherChildColorType'"
+                )
+                count += 1
+        assert count == 3
+
+    def test_enumtabsid_for_domain_geopackage(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "colors_v2_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = False
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        generator = Generator(
+            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        count = 0
+        for layer in available_layers:
+            if layer.alias == "BaseColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors.DomBaseColorType'"
+                )
+                count += 1
+
+            if layer.alias == "ChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.DomChildColorType'"
+                )
+                count += 1
+
+            if layer.alias == "AnotherChildColor":
+                field = layer.layer.fields().field("colortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.DomAnotherChildColorType'"
+                )
+                count += 1
+        assert count == 3
+
+    def test_enumtabs_for_domain_postgis(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbschema = "colors_v2_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = False
+        # createEnumTabs
+        importer.configuration.enum_tabs = "tabs"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            importer.configuration.inheritance,
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+    def test_enumtabs_for_domain_geopackage(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "colors_v2_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = False
+        # createEnumTabs
+        importer.configuration.enum_tabs = "tabs"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        generator = Generator(
+            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+    def test_enumsingletab_for_domain_postgis(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbschema = "colors_v2_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = False
+        # createSingleEnumTab
+        importer.configuration.enum_tabs = "singletab"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        generator = Generator(
+            DbIliMode.ili2pg,
+            get_pg_connection_string(),
+            importer.configuration.inheritance,
+            importer.configuration.dbschema,
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+    def test_enumsingletab_for_domain_geopackage(self):
+        # Schema Import
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2gpkg
+        importer.configuration = iliimporter_config(importer.tool, "ilimodels")
+        importer.configuration.ilimodels = "Colors_V2"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "colors_v2_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.create_basket_col = False
+        # createSingleEnumTab
+        importer.configuration.enum_tabs = "singletab"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        config_manager = GpkgCommandConfigManager(importer.configuration)
+        uri = config_manager.get_uri()
+
+        generator = Generator(
+            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
+        )
+
+        available_layers = generator.layers()
+        relations, _ = generator.relations(available_layers)
+
+        legend = generator.legend(available_layers)
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.legend = legend
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
     def print_info(self, text):
         logging.info(text)
 

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -478,7 +478,6 @@ class TestProjectGen(unittest.TestCase):
                         "Deponietyp",
                         "UntersMassn",
                     ]
-                    assert len(tab_list) == len(expected_tab_list)
                     assert set(tab_list) == set(expected_tab_list)
 
                 for tab in tabs:
@@ -567,7 +566,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 65
         assert len(available_layers) == 23
-        assert len(relations) == 13
+        assert len(relations) == 25
 
     def test_naturschutz_mssql(self):
         importer = iliimporter.Importer()
@@ -668,7 +667,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 67
         assert len(available_layers) == 21
-        assert len(relations) == 12
+        assert len(relations) == 24
 
         project = Project()
         project.layers = available_layers
@@ -783,7 +782,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 31
         assert len(available_layers) == 29
-        assert len(relations) == 23
+        assert len(relations) == 35
 
     def test_ranges_postgis(self):
         importer = iliimporter.Importer()

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -566,7 +566,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 65
         assert len(available_layers) == 23
-        assert len(relations) == 25
+        assert len(relations) == 13
 
     def test_naturschutz_mssql(self):
         importer = iliimporter.Importer()
@@ -667,7 +667,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 67
         assert len(available_layers) == 21
-        assert len(relations) == 24
+        assert len(relations) == 12
 
         project = Project()
         project.layers = available_layers
@@ -782,7 +782,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 31
         assert len(available_layers) == 29
-        assert len(relations) == 35
+        assert len(relations) == 23
 
     def test_ranges_postgis(self):
         importer = iliimporter.Importer()

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -207,9 +207,9 @@ class TestTranslations(unittest.TestCase):
                 assert layer.layer.displayExpression() == "\n".join(
                     [
                         "CASE",
-                        "WHEN iliCode = 'AenderungOhneVorwirkung' THEN 'ModificationSansEffetAnticipe'",
-                        "WHEN iliCode = 'AenderungMitVorwirkung' THEN 'ModificationAvecEffetAnticipe'",
-                        "WHEN iliCode = 'inKraft' THEN 'enVigueur'",
+                        "WHEN ilicode = 'AenderungOhneVorwirkung' THEN 'ModificationSansEffetAnticipe'",
+                        "WHEN ilicode = 'AenderungMitVorwirkung' THEN 'ModificationAvecEffetAnticipe'",
+                        "WHEN ilicode = 'inKraft' THEN 'enVigueur'",
                         "END",
                     ]
                 )
@@ -493,9 +493,9 @@ class TestTranslations(unittest.TestCase):
                 assert layer.layer.displayExpression() == "\n".join(
                     [
                         "CASE",
-                        "WHEN iliCode = 'AenderungMitVorwirkung' THEN 'AenderungMitVorwirkung'",
-                        "WHEN iliCode = 'AenderungOhneVorwirkung' THEN 'AenderungOhneVorwirkung'",
-                        "WHEN iliCode = 'inKraft' THEN 'inKraft'",
+                        "WHEN ilicode = 'AenderungMitVorwirkung' THEN 'AenderungMitVorwirkung'",
+                        "WHEN ilicode = 'AenderungOhneVorwirkung' THEN 'AenderungOhneVorwirkung'",
+                        "WHEN ilicode = 'inKraft' THEN 'inKraft'",
                         "END",
                     ]
                 )

--- a/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
+++ b/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
@@ -6,14 +6,14 @@ VERSION "2020-08-26"  =
 
   DOMAIN
 
-    DomBaseColorType = (
+    ColorType = (
       Green,
       Red,
       Blue
     );
 
-    DomChildColorType
-    EXTENDS DomBaseColorType = (
+    BlueChildColorType
+    EXTENDS ColorType = (
       Blue(
         Dark_Blue,
         Light_Blue,
@@ -21,8 +21,8 @@ VERSION "2020-08-26"  =
       )
     );
 
-    DomAnotherChildColorType
-    EXTENDS DomBaseColorType = (
+    GreenChildColorType
+    EXTENDS ColorType = (
       Green(
         Dark_Green,
         Light_Green,
@@ -30,7 +30,7 @@ VERSION "2020-08-26"  =
       )
     );
 
-    UninheritedColorType = (
+    UninheritedCMYColorType = (
       Cyan,
       Magenta,
       Yello
@@ -39,22 +39,22 @@ VERSION "2020-08-26"  =
   TOPIC Colors =
 
     CLASS BaseColor =
-      ColorType : Colors_V2.DomBaseColorType;
+      ColorType : Colors_V2.ColorType;
     END BaseColor;
 
-    CLASS ChildColor
+    CLASS BlueChildColor
     EXTENDS BaseColor =
-      ColorType (EXTENDED) : Colors_V2.DomChildColorType;
-    END ChildColor;
+      ColorType (EXTENDED) : Colors_V2.BlueChildColorType;
+    END BlueChildColor;
 
-    CLASS AnotherChildColor
+    CLASS GreenChildColor
     EXTENDS BaseColor =
-      ColorType (EXTENDED) : Colors_V2.DomAnotherChildColorType;
-    END AnotherChildColor;
+      ColorType (EXTENDED) : Colors_V2.GreenChildColorType;
+    END GreenChildColor;
 
-    CLASS UninheritedColor =
-      ColorType : Colors_V2.UninheritedColorType;
-    END UninheritedColor;
+    CLASS UninheritedCMYColor =
+      ColorType : Colors_V2.UninheritedCMYColorType;
+    END UninheritedCMYColor;
 
   END Colors;
 

--- a/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
+++ b/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
@@ -1,0 +1,61 @@
+INTERLIS 2.3;
+
+MODEL Colors_V2 (es)
+AT "mailto:PC-1@localhost"
+VERSION "2020-08-26"  =
+
+  DOMAIN
+
+    DomBaseColorType = (
+      Green,
+      Red,
+      Blue
+    );
+
+    DomChildColorType
+    EXTENDS DomBaseColorType = (
+      Blue(
+        Dark_Blue,
+        Light_Blue,
+        Medium_Blue
+      )
+    );
+
+    DomAnotherChildColorType
+    EXTENDS DomBaseColorType = (
+      Green(
+        Dark_Green,
+        Light_Green,
+        Medium_Green
+      )
+    );
+
+    UninheritedColorType = (
+      Cyan,
+      Magenta,
+      Yello
+    );
+
+  TOPIC Colors =
+
+    CLASS BaseColor =
+      ColorType : Colors_V2.DomBaseColorType;
+    END BaseColor;
+
+    CLASS ChildColor
+    EXTENDS BaseColor =
+      ColorType (EXTENDED) : Colors_V2.DomChildColorType;
+    END ChildColor;
+
+    CLASS AnotherChildColor
+    EXTENDS BaseColor =
+      ColorType (EXTENDED) : Colors_V2.DomAnotherChildColorType;
+    END AnotherChildColor;
+
+    CLASS UninheritedColor =
+      ColorType : Colors_V2.UninheritedColorType;
+    END UninheritedColor;
+
+  END Colors;
+
+END Colors_V2.

--- a/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
+++ b/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
@@ -36,6 +36,8 @@ VERSION "2020-08-26"  =
       Yello
     );
 
+    STRUCTURE UninheritedCMYColorTypeStruct = value : MANDATORY UninheritedCMYColorType; END UninheritedCMYColorTypeStruct;
+
   TOPIC Colors =
 
     CLASS BaseColor =
@@ -54,6 +56,8 @@ VERSION "2020-08-26"  =
 
     CLASS UninheritedCMYColor =
       ColorType : Colors_V2.UninheritedCMYColorType;
+      !!@ili2db.mapping="ARRAY"
+      BagOfColorType : BAG {0..*} OF Colors_V2.UninheritedCMYColorTypeStruct;
     END UninheritedCMYColor;
 
   END Colors;


### PR DESCRIPTION
### Implemented:
- enables the ili2db configuration `enum_tabs` (`"tabs"`,`"singletab"`,`"tabsid"` (default)) controlling ili2db parameters `createEnumTabs`, `createEnumSingleTab`, `createEnumTabsWithId`
- fixes the use of the base-enums when inherited with `tabsid`
- [tabs/smart2] widget configuration: Value Relation to the specific tables financed by Ct. SO
  This is solved by getting "fake" relations on `get_relations_info` on PG and GPKG connectors: It evaluates the ili2db-meta-tables to find the connection between the attribute and the target-table.
- [tabs/smart1] Works only with non-intherited enums (with inheritance it's technically impossible)

### Out of scope:
- [tabs/BAGOF] Bag Of Enums Situation on ARRAY-Mapping. See https://github.com/opengisch/QgisModelBaker/issues/1121
- [tabsid/smart1] Bug https://github.com/opengisch/QgisModelBaker/issues/1120 financed by the Model Baker Group (maybe)
- [singletabs] should be stable on smart1 and smart2 and generally the best wos git financed by Model Baker Group (maybe)

### Financed 
by the Canton of Solothurn and the QGIS Model Baker Group


