### PR TITLE
New ili2db schemaimport option disable_mandatory to disable NOT NULL constraints

### DIFF
--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -268,6 +268,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         self.pre_script = ""
         self.post_script = ""
         self.name_lang = ""
+        self.disable_mandatory = False
 
     def to_ili2db_args(
         self, extra_args: list[str] = [], with_action: bool = True
@@ -293,6 +294,8 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
             self.append_args(args, ["--sqlEnableNull"], force_append=True)
             self.append_args(args, ["--sqlColsAsText"], force_append=True)
         else:
+            if self.disable_mandatory:
+                self.append_args(args, ["--sqlEnableNull"], True)
             self.append_args(args, ["--createNumChecks"], True)
             self.append_args(args, ["--createUnique"], True)
             self.append_args(args, ["--createFk"], True)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -448,6 +448,226 @@ class TestImport(unittest.TestCase):
         assert record is not None
         assert record[0].lower() == "59ba6620-6cbc-452f-91c2-ea2574b47330"
 
+    def test_import_nonmandatory_import_postgis(self):
+        # Schema Import normal
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.srs_code = 3116
+        importer.configuration.inheritance = "smart2"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        # Import valid data succeeds
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2pg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_valid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+        # Import invalid data fails because validation is not disabled
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2pg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() != iliimporter.Importer.SUCCESS
+
+        # Import invalid data with disabled validation still fails because of the not null constraint in the DB
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2pg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = True
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() != iliimporter.Importer.SUCCESS
+
+        # Schema Import allowing NOT NULL values for mandatory attributes (disable_mandatory)
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.ili2pg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbschema = "roads_simple_{:%Y%m%d%H%M%S%f}".format(
+            datetime.datetime.now()
+        )
+        importer.configuration.srs_code = 3116
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.disable_mandatory = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        # Import valid data succeeds
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2pg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_valid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+        # Import invalid data fails because validation is not disabled
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.ili2pg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() != iliimporter.Importer.SUCCESS
+
+        # Import invalid data with disabled validation finally succeeds because of the disabled mandatory constraint in the DB
+        dataImporter.tool = DbIliMode.ili2pg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbschema = importer.configuration.dbschema
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = True
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+    def test_import_nonmandatory_import_geopackage(self):
+        # Schema Import normal
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.gpkg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "tmp_roads_simple_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.srs_code = 3116
+        importer.configuration.inheritance = "smart2"
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        # Import valid data succeeds
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.gpkg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbfile = importer.configuration.dbfile
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_valid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+        # Import invalid data fails because validation is not disabled
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.gpkg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbfile = importer.configuration.dbfile
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() != iliimporter.Importer.SUCCESS
+
+        # Import invalid data with disabled validation still fails because of the not null constraint in the DB
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.gpkg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbfile = importer.configuration.dbfile
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = True
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() != iliimporter.Importer.SUCCESS
+
+        # Schema Import allowing NOT NULL values for mandatory attributes (disable_mandatory)
+        importer = iliimporter.Importer()
+        importer.tool = DbIliMode.gpkg
+        importer.configuration = iliimporter_config(importer.tool)
+        importer.configuration.ilifile = testdata_path("ilimodels/RoadsSimple.ili")
+        importer.configuration.ilimodels = "RoadsSimple"
+        importer.configuration.dbfile = os.path.join(
+            self.basetestpath,
+            "tmp_roads_simple_{:%Y%m%d%H%M%S%f}.gpkg".format(datetime.datetime.now()),
+        )
+        importer.configuration.srs_code = 3116
+        importer.configuration.inheritance = "smart2"
+        importer.configuration.disable_mandatory = True
+        importer.stdout.connect(self.print_info)
+        importer.stderr.connect(self.print_error)
+        assert importer.run() == iliimporter.Importer.SUCCESS
+
+        # Import valid data succeeds
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.gpkg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbfile = importer.configuration.dbfile
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_valid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
+        # Import invalid data fails because validation is not disabled
+        dataImporter = iliimporter.Importer(dataImport=True)
+        dataImporter.tool = DbIliMode.gpkg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbfile = importer.configuration.dbfile
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = False
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() != iliimporter.Importer.SUCCESS
+
+        # Import invalid data with disabled validation finally succeeds because of the disabled mandatory constraint in the DB
+        dataImporter.tool = DbIliMode.gpkg
+        dataImporter.configuration = ilidataimporter_config(importer.tool)
+        dataImporter.configuration.dbfile = importer.configuration.dbfile
+        dataImporter.configuration.xtffile = testdata_path(
+            "xtf/test_roads_simple_invalid_street.xtf"
+        )
+        dataImporter.configuration.disable_validation = True
+        dataImporter.stdout.connect(self.print_info)
+        dataImporter.stderr.connect(self.print_error)
+        assert dataImporter.run() == iliimporter.Importer.SUCCESS
+
     def print_info(self, text):
         logging.info(text)
 

--- a/tests/testdata/xtf/test_roads_simple_invalid_street.xtf
+++ b/tests/testdata/xtf/test_roads_simple_invalid_street.xtf
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?><TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
+<HEADERSECTION SENDER="ili2gpkg-5.5.0-a63de657a43b4ef80b3400f35d088f91ea36fe98" VERSION="2.3"><MODELS><MODEL NAME="RoadsSimple" VERSION="2016-08-11" URI="http://www.interlis.ch/models"></MODEL></MODELS></HEADERSECTION>
+<DATASECTION>
+<RoadsSimple.Roads BID="RoadsSimple.Roads">
+<RoadsSimple.Roads.Street TID="_8f5d05f5-7290-45ce-8103-6d660be68352"><Name>Schoorenstrasse</Name></RoadsSimple.Roads.Street>
+<RoadsSimple.Roads.Street TID="_93dacbc6-2a15-448a-8dbb-722193d96e98"></RoadsSimple.Roads.Street>
+</RoadsSimple.Roads>
+</DATASECTION>
+</TRANSFER>

--- a/tests/testdata/xtf/test_roads_simple_valid_street.xtf
+++ b/tests/testdata/xtf/test_roads_simple_valid_street.xtf
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?><TRANSFER xmlns="http://www.interlis.ch/INTERLIS2.3">
+<HEADERSECTION SENDER="ili2gpkg-5.5.0-a63de657a43b4ef80b3400f35d088f91ea36fe98" VERSION="2.3"><MODELS><MODEL NAME="RoadsSimple" VERSION="2016-08-11" URI="http://www.interlis.ch/models"></MODEL></MODELS></HEADERSECTION>
+<DATASECTION>
+<RoadsSimple.Roads BID="RoadsSimple.Roads">
+<RoadsSimple.Roads.Street TID="_8f5d05f5-7290-45ce-8103-6d660be68352"><Name>Schoorenstrasse</Name></RoadsSimple.Roads.Street>
+</RoadsSimple.Roads>
+</DATASECTION>
+</TRANSFER>


### PR DESCRIPTION
... on mandatory attribute constraints. This appends `--sqlEnableNull` but keeps the other constraints, fks and column types...