### PR TITLE
Fix how to check the group 

### DIFF
--- a/modelbaker/dataobjects/legend.py
+++ b/modelbaker/dataobjects/legend.py
@@ -74,7 +74,7 @@ class LegendGroup:
     def create(
         self, qgis_project: QgsProject, group: Optional[QgsLayerTreeGroup] = None
     ) -> None:
-        if not group:
+        if group is None:
             group = qgis_project.layerTreeRoot()
 
         existing_layer_source_uris = [


### PR DESCRIPTION
because bool(group) returns False if the group exists but is empty. This changed with QGIS 4). 

This fixes https://github.com/opengisch/QgisModelBaker/issues/1134

QGIS 3.44.9:
<img width="843" height="69" alt="image" src="https://github.com/user-attachments/assets/d8c7de93-3ce3-4e40-b5a4-cf6cfd129fb1" />

QGIS master:
<img width="610" height="69" alt="image" src="https://github.com/user-attachments/assets/361d6702-86ad-4766-9af7-2065e4745a9e" />



