### PR TITLE
BAG OF enumeration support on enum tabs

### DIFF
--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -294,16 +294,20 @@ class Project(QObject):
                     current_layer = layer_obj.create()
 
                 field_widget = "ValueRelation"
+                domain_layer = domain_table.create()
                 field_widget_config = {
                     "AllowMulti": True,
                     "UseCompleter": False,
                     "Value": value_field,
                     "OrderByValue": False,
                     "AllowNull": True,
-                    "Layer": domain_table.create().id(),
+                    "Layer": domain_layer.id(),
+                    # Filter only if domain layer uses 'thisClass' containing multiple inherited layer targets
                     "FilterExpression": "\"{}\" = '{}'".format(
-                        ENUM_THIS_CLASS_COLUMN, layer.ili_name
-                    ),
+                        ENUM_THIS_CLASS_COLUMN, domain_table.ili_name
+                    )
+                    if domain_layer.fields().lookupField(ENUM_THIS_CLASS_COLUMN) >= 0
+                    else "",
                     "Key": key_field,
                     "NofColumns": 1,
                 }

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -407,11 +407,21 @@ class DBConnector(QObject):
         """
         return False
 
-    def get_ili2db_settings(self) -> dict:
+    def get_ili2db_settings(self) -> list:
         """
         Returns the settings like they are without any name mapping etc.
         """
-        return {}
+        return []
+
+    def get_ili2db_settings_as_dict(self) -> dict:
+        """
+        Returns the settings as a simple dict with key (tag) and value (setting)
+        """
+        settings_dict = {}
+        setting_records = self.get_ili2db_settings()
+        for setting_record in setting_records:
+            settings_dict[setting_record["tag"]] = setting_record["setting"]
+        return settings_dict
 
     def get_ili2db_sequence_value(self) -> str:
         """

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -659,7 +659,7 @@ class GPKGConnector(DBConnector):
                 # When we use fks for the relations, we get it by the property ch.ehi.ili2db.foreignKey
                 cursor.execute(
                     """SELECT
-                            cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max, meta_attrs_array.attr_value as mapping_type, '{}' as fk_key
+                            cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max, meta_attrs_array.attr_value as mapping_type, '{}' as target_layer_key
                             FROM T_ILI2DB_COLUMN_PROP as cprop
                             LEFT JOIN T_ILI2DB_ATTRNAME aname
                             ON aname.sqlname = cprop.columnname AND aname.colowner = cprop.tablename
@@ -678,7 +678,7 @@ class GPKGConnector(DBConnector):
                 # When we don't have fks we get it by property ch.ehi.ili2db.enumDomain
                 cursor.execute(
                     """SELECT
-                            aname.colowner as current_layer_name, aname.sqlname as attribute, classn.sqlname as target_layer_name, meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max, meta_attrs_array.attr_value as mapping_type, '{}' as fk_key
+                            aname.colowner as current_layer_name, aname.sqlname as attribute, classn.sqlname as target_layer_name, meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max, meta_attrs_array.attr_value as mapping_type, '{}' as target_layer_key
                             FROM T_ILI2DB_ATTRNAME aname
                             LEFT JOIN T_ILI2DB_COLUMN_PROP as cprop
                             ON aname.sqlname = cprop.columnname and cprop.tag = 'ch.ehi.ili2db.enumDomain' AND aname.colowner = cprop.tablename

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -649,21 +649,51 @@ class GPKGConnector(DBConnector):
         bags_of_info = {}
         if self.metadata_exists():
             cursor = self.conn.cursor()
-            cursor.execute(
-                """SELECT
-                        cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max, meta_attrs_array.attr_value as mapping_type
-                        FROM T_ILI2DB_COLUMN_PROP as cprop
-                        LEFT JOIN T_ILI2DB_ATTRNAME aname
-                        ON aname.sqlname = cprop.columnname AND aname.colowner = cprop.tablename
-                        LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_array
-                        ON meta_attrs_array.ilielement = aname.iliname AND meta_attrs_array.attr_name = 'ili2db.mapping'
-                        LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_cardinality_min
-                        ON meta_attrs_cardinality_min.ilielement = aname.iliname AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
-                        LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_cardinality_max
-                        ON meta_attrs_cardinality_max.ilielement = aname.iliname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
-                        WHERE cprop.tag = 'ch.ehi.ili2db.foreignKey'
-                    """
-            )
+
+            if (
+                self.get_ili2db_settings_as_dict().get(
+                    "ch.ehi.ili2db.createEnumDefs", None
+                )
+                == "multiTableWithId"
+            ):
+                # When we use fks for the relations, we get it by the property ch.ehi.ili2db.foreignKey
+                cursor.execute(
+                    """SELECT
+                            cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name, meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max, meta_attrs_array.attr_value as mapping_type, '{}' as fk_key
+                            FROM T_ILI2DB_COLUMN_PROP as cprop
+                            LEFT JOIN T_ILI2DB_ATTRNAME aname
+                            ON aname.sqlname = cprop.columnname AND aname.colowner = cprop.tablename
+                            LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_array
+                            ON meta_attrs_array.ilielement = aname.iliname AND meta_attrs_array.attr_name = 'ili2db.mapping'
+                            LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_cardinality_min
+                            ON meta_attrs_cardinality_min.ilielement = aname.iliname AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
+                            LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_cardinality_max
+                            ON meta_attrs_cardinality_max.ilielement = aname.iliname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
+                            WHERE cprop.tag = 'ch.ehi.ili2db.foreignKey'
+                            """.format(
+                        self.tid
+                    )
+                )
+            else:
+                # When we don't have fks we get it by property ch.ehi.ili2db.enumDomain
+                cursor.execute(
+                    """SELECT
+                            aname.colowner as current_layer_name, aname.sqlname as attribute, classn.sqlname as target_layer_name, meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max, meta_attrs_array.attr_value as mapping_type, '{}' as fk_key
+                            FROM T_ILI2DB_ATTRNAME aname
+                            LEFT JOIN T_ILI2DB_COLUMN_PROP as cprop
+                            ON aname.sqlname = cprop.columnname and cprop.tag = 'ch.ehi.ili2db.enumDomain' AND aname.colowner = cprop.tablename
+                            LEFT JOIN T_ILI2DB_CLASSNAME as classn
+                            ON classn.iliname = cprop.setting
+                            LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_array
+                            ON meta_attrs_array.ilielement = aname.iliname AND meta_attrs_array.attr_name = 'ili2db.mapping'
+                            LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_cardinality_min
+                            ON meta_attrs_cardinality_min.ilielement = aname.iliname AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
+                            LEFT JOIN T_ILI2DB_META_ATTRS as meta_attrs_cardinality_max
+                            ON meta_attrs_cardinality_max.ilielement = aname.iliname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
+                    """.format(
+                        "iliCode"
+                    )
+                )
             bags_of_info = cursor.fetchall()
             cursor.close()
         return bags_of_info

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -822,27 +822,62 @@ class PGConnector(DBConnector):
     def get_bags_of_info(self) -> list[dict]:
         if self.schema and self.metadata_exists():
             cur = self.conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
-            cur.execute(
-                sql.SQL(
-                    """SELECT cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name,
-                        meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max,
-                        meta_attrs_array.attr_value as mapping_type
-                    FROM {schema}.t_ili2db_column_prop as cprop
-                    LEFT JOIN {schema}.t_ili2db_attrname aname
-                    ON aname.sqlname = cprop.columnname AND aname.colowner = cprop.tablename
-                    LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_array
-                    ON meta_attrs_array.ilielement ILIKE aname.iliname AND meta_attrs_array.attr_name = 'ili2db.mapping'
-                    LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_cardinality_min
-                    ON meta_attrs_cardinality_min.ilielement ILIKE aname.iliname AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
-                    LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_cardinality_max
-                    ON meta_attrs_cardinality_max.ilielement ILIKE aname.iliname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
-                    WHERE cprop.tag = 'ch.ehi.ili2db.foreignKey'
-                    """
-                ).format(
-                    schema=sql.Identifier(self.schema),
-                    t_ili2db_meta_attrs=sql.Identifier(PG_METAATTRS_TABLE),
+
+            if (
+                self.get_ili2db_settings_as_dict().get(
+                    "ch.ehi.ili2db.createEnumDefs", None
                 )
-            )
+                == "multiTableWithId"
+            ):
+                # When we use fks for the relations, we get it by the property ch.ehi.ili2db.foreignKey
+                cur.execute(
+                    sql.SQL(
+                        """SELECT cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name,
+                            meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max,
+                            meta_attrs_array.attr_value as mapping_type,  %s as fk_key
+                        FROM {schema}.t_ili2db_column_prop as cprop
+                        LEFT JOIN {schema}.t_ili2db_attrname aname
+                        ON aname.sqlname = cprop.columnname AND aname.colowner = cprop.tablename
+                        LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_array
+                        ON meta_attrs_array.ilielement ILIKE aname.iliname AND meta_attrs_array.attr_name = 'ili2db.mapping'
+                        LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_cardinality_min
+                        ON meta_attrs_cardinality_min.ilielement ILIKE aname.iliname AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
+                        LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_cardinality_max
+                        ON meta_attrs_cardinality_max.ilielement ILIKE aname.iliname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
+                        WHERE cprop.tag = 'ch.ehi.ili2db.foreignKey'
+                        """
+                    ).format(
+                        schema=sql.Identifier(self.schema),
+                        t_ili2db_meta_attrs=sql.Identifier(PG_METAATTRS_TABLE),
+                    ),
+                    (self.tid,),
+                )
+            else:
+                # When we don't have fks we get it by property ch.ehi.ili2db.enumDomain
+                cur.execute(
+                    sql.SQL(
+                        """SELECT aname.colowner as current_layer_name, aname.sqlname as attribute, classn.sqlname as target_layer_name,
+                            meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max,
+                            meta_attrs_array.attr_value as mapping_type, %s as fk_key
+                        FROM {schema}.t_ili2db_attrname aname
+                        LEFT JOIN {schema}.t_ili2db_column_prop as cprop
+                        ON aname.sqlname = cprop.columnname and cprop.tag = 'ch.ehi.ili2db.enumDomain' AND aname.colowner = cprop.tablename
+                        LEFT JOIN {schema}.t_ili2db_classname as classn
+                        ON classn.iliname = cprop.setting
+                        LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_array
+                        ON meta_attrs_array.ilielement = aname.iliname AND meta_attrs_array.attr_name = 'ili2db.mapping'
+                        LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_cardinality_min
+                        ON meta_attrs_cardinality_min.ilielement = aname.iliname AND meta_attrs_cardinality_min.attr_name = 'ili2db.ili.attrCardinalityMin'
+                        LEFT JOIN {schema}.{t_ili2db_meta_attrs} as meta_attrs_cardinality_max
+                        ON meta_attrs_cardinality_max.ilielement = aname.iliname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
+                        """
+                    ).format(
+                        fk_key="ilicode",
+                        schema=sql.Identifier(self.schema),
+                        t_ili2db_meta_attrs=sql.Identifier(PG_METAATTRS_TABLE),
+                    ),
+                    ("ilicode",),
+                )
             return cur
         return []
 

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -834,7 +834,7 @@ class PGConnector(DBConnector):
                     sql.SQL(
                         """SELECT cprop.tablename as current_layer_name, cprop.columnname as attribute, cprop.setting as target_layer_name,
                             meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max,
-                            meta_attrs_array.attr_value as mapping_type,  %s as fk_key
+                            meta_attrs_array.attr_value as mapping_type,  %s as target_layer_key
                         FROM {schema}.t_ili2db_column_prop as cprop
                         LEFT JOIN {schema}.t_ili2db_attrname aname
                         ON aname.sqlname = cprop.columnname AND aname.colowner = cprop.tablename
@@ -858,7 +858,7 @@ class PGConnector(DBConnector):
                     sql.SQL(
                         """SELECT aname.colowner as current_layer_name, aname.sqlname as attribute, classn.sqlname as target_layer_name,
                             meta_attrs_cardinality_min.attr_value as cardinality_min, meta_attrs_cardinality_max.attr_value as cardinality_max,
-                            meta_attrs_array.attr_value as mapping_type, %s as fk_key
+                            meta_attrs_array.attr_value as mapping_type, %s as target_layer_key
                         FROM {schema}.t_ili2db_attrname aname
                         LEFT JOIN {schema}.t_ili2db_column_prop as cprop
                         ON aname.sqlname = cprop.columnname and cprop.tag = 'ch.ehi.ili2db.enumDomain' AND aname.colowner = cprop.tablename
@@ -872,7 +872,6 @@ class PGConnector(DBConnector):
                         ON meta_attrs_cardinality_max.ilielement = aname.iliname AND meta_attrs_cardinality_max.attr_name = 'ili2db.ili.attrCardinalityMax'
                         """
                     ).format(
-                        fk_key="ilicode",
                         schema=sql.Identifier(self.schema),
                         t_ili2db_meta_attrs=sql.Identifier(PG_METAATTRS_TABLE),
                     ),

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -653,7 +653,7 @@ class Generator(QObject):
                             if record["cardinality_min"] and record["cardinality_max"]
                             else "",
                             layer_map[record["target_layer_name"]][0],
-                            record["fk_key"],
+                            record["target_layer_key"],
                             self._db_connector.dispName,
                             record["mapping_type"],
                         ]

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -653,7 +653,7 @@ class Generator(QObject):
                             if record["cardinality_min"] and record["cardinality_max"]
                             else "",
                             layer_map[record["target_layer_name"]][0],
-                            self._db_connector.tid,
+                            record["fk_key"],
                             self._db_connector.dispName,
                             record["mapping_type"],
                         ]

--- a/modelbaker/iliwrapper/ili2dbargs.py
+++ b/modelbaker/iliwrapper/ili2dbargs.py
@@ -44,9 +44,9 @@ def _get_db_args(
     su = configuration.db_use_super_login  # Boolean
     db_args = list()
 
-    if configuration.tool in DbIliMode.ili2gpkg:
+    if configuration.tool in [DbIliMode.ili2gpkg, DbIliMode.gpkg]:
         db_args = ["--dbfile", configuration.dbfile]
-    elif configuration.tool in DbIliMode.ili2pg:
+    elif configuration.tool in [DbIliMode.ili2pg, DbIliMode.pg]:
         db_args += ["--dbhost", configuration.dbhost]
         if configuration.dbport:
             db_args += ["--dbport", configuration.dbport]
@@ -119,7 +119,7 @@ def _get_db_args(
                     )
                 )
 
-    elif configuration.tool in DbIliMode.ili2mssql:
+    elif configuration.tool in [DbIliMode.ili2mssql, DbIliMode.mssql]:
         db_args += ["--dbhost", configuration.dbhost]
         if configuration.dbport:
             db_args += ["--dbport", configuration.dbport]

--- a/modelbaker/iliwrapper/ili2dbconfig.py
+++ b/modelbaker/iliwrapper/ili2dbconfig.py
@@ -338,7 +338,7 @@ class SchemaImportConfiguration(Ili2DbCommandConfiguration):
         elif self.db_ili_version is None or self.db_ili_version > 3:
             self.append_args(args, ["--strokeArcs=False"])
 
-        if self.tool and (self.tool & DbIliMode.gpkg):
+        if self.tool and (self.tool in [DbIliMode.gpkg, DbIliMode.ili2gpkg]):
             if self.create_gpkg_multigeom:
                 self.append_args(args, ["--gpkgMultiGeomPerTable"])
             elif self.db_ili_version is None or self.db_ili_version > 3:

--- a/modelbaker/iliwrapper/ili2dbtools.py
+++ b/modelbaker/iliwrapper/ili2dbtools.py
@@ -19,17 +19,17 @@ def get_tool_version(tool, db_ili_version: int) -> str:
         if db_ili_version == 3:
             return "3.11.3"
         else:
-            return "5.5.0"
+            return "5.5.2"
     elif tool == DbIliMode.ili2pg:
         if db_ili_version == 3:
             return "3.11.2"
         else:
-            return "5.5.0"
+            return "5.5.2"
     elif tool == DbIliMode.ili2mssql:
         if db_ili_version == 3:
             return "3.12.2"
         else:
-            return "5.5.0"
+            return "5.5.2"
 
     return "0"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -55,3 +55,324 @@ These are dirty notes for the quickest way to test mssql queries manually in the
     sa
     '<YourStrong!Passw0rd>'
     ```
+
+### Testing in python console
+
+Another dirty script as helper.
+
+To test in python console in QGIS you need
+- to get the modelbaker library from the plugin
+- copy paste the test utils functions and apply local db settings
+- use your local paths for model dir and target gpkg etc.
+
+```
+import datetime
+import logging
+import os
+import shutil
+import tempfile
+
+import pytest
+from qgis.core import Qgis, QgsProject
+from qgis.testing import start_app, unittest
+
+from QgisModelBaker.libs.modelbaker.dataobjects.project import Project
+from QgisModelBaker.libs.modelbaker.db_factory.gpkg_command_config_manager import GpkgCommandConfigManager
+from QgisModelBaker.libs.modelbaker.generator.generator import Generator
+from QgisModelBaker.libs.modelbaker.iliwrapper import iliimporter
+from QgisModelBaker.libs.modelbaker.iliwrapper.globals import DbIliMode
+
+import os
+from subprocess import call
+
+import pytest
+
+from modelbaker.iliwrapper import ili2dbconfig
+from modelbaker.iliwrapper.globals import DbIliMode
+from modelbaker.iliwrapper.ili2dbconfig import (
+    BaseConfiguration,
+    DeleteConfiguration,
+    ExportConfiguration,
+    ExportMetaConfigConfiguration,
+    ImportDataConfiguration,
+    SchemaImportConfiguration,
+    UpdateDataConfiguration,
+    ValidateConfiguration,
+)
+
+
+def iliimporter_config(tool=DbIliMode.ili2pg, modeldir=None):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = SchemaImportConfiguration()
+    configuration.tool = tool
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = "localhost"
+        configuration.dbport = 54322
+        configuration.dbusr = "docker"
+        configuration.dbpwd = "docker"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = "mssql"
+        configuration.dbusr = "sa"
+        configuration.dbpwd = "<YourStrong!Passw0rd>"
+        configuration.database = "gis"
+    configuration.base_configuration = base_config
+
+    return configuration
+
+
+def iliexporter_config(
+    tool=DbIliMode.ili2pg, modeldir=None, gpkg_path="geopackage/test_export.gpkg"
+):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = ExportConfiguration()
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = "localhost"
+        configuration.dbport = 54322
+        configuration.dbusr = "docker"
+        configuration.dbpwd = "docker"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = "mssql"
+        configuration.dbusr = "sa"
+        configuration.dbpwd = "<YourStrong!Passw0rd>"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2gpkg:
+        configuration.dbfile = testdata_path(gpkg_path)
+    configuration.base_configuration = base_config
+
+    return configuration
+
+
+def ilidataimporter_config(tool=DbIliMode.ili2pg, modeldir=None):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = ImportDataConfiguration()
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = "localhost"
+        configuration.dbport = 54322
+        configuration.dbusr = "docker"
+        configuration.dbpwd = "docker"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = "mssql"
+        configuration.dbusr = "sa"
+        configuration.dbpwd = "<YourStrong!Passw0rd>"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2gpkg:
+        configuration.dbfile = testdata_path("geopackage/test_export.gpkg")
+    configuration.base_configuration = base_config
+
+    return configuration
+
+
+def iliupdater_config(tool=DbIliMode.ili2pg, modeldir=None):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = UpdateDataConfiguration()
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = "localhost"
+        configuration.dbport = 54322
+        configuration.dbusr = "docker"
+        configuration.dbpwd = "docker"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = "mssql"
+        configuration.dbusr = "sa"
+        configuration.dbpwd = "<YourStrong!Passw0rd>"
+        configuration.database = "gis"
+
+    configuration.base_configuration = base_config
+
+    return configuration
+
+
+def ilivalidator_config(
+    tool=DbIliMode.ili2pg, modeldir=None, gpkg_path="geopackage/test_validate.gpkg"
+):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = ValidateConfiguration()
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = "localhost"
+        configuration.dbport = 54322
+        configuration.dbusr = "docker"
+        configuration.dbpwd = "docker"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = "mssql"
+        configuration.dbusr = "sa"
+        configuration.dbpwd = "<YourStrong!Passw0rd>"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2gpkg:
+        configuration.dbfile = testdata_path(gpkg_path)
+    configuration.base_configuration = base_config
+
+    return configuration
+
+
+def ilideleter_config(tool=DbIliMode.ili2pg, modeldir=None):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = DeleteConfiguration()
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = "localhost"
+        configuration.dbport = 54322
+        configuration.dbusr = "docker"
+        configuration.dbpwd = "docker"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = "mssql"
+        configuration.dbusr = "sa"
+        configuration.dbpwd = "<YourStrong!Passw0rd>"
+        configuration.database = "gis"
+
+    configuration.base_configuration = base_config
+
+    return configuration
+
+
+def ilimetaconfigexporter_config(tool=DbIliMode.ili2pg, modeldir=None):
+    base_config = BaseConfiguration()
+    if modeldir is None:
+        base_config.custom_model_directories_enabled = False
+    else:
+        base_config.custom_model_directories = testdata_path(modeldir)
+        base_config.custom_model_directories_enabled = True
+
+    configuration = ExportMetaConfigConfiguration()
+    if tool == DbIliMode.ili2pg:
+        configuration.dbhost = "localhost"
+        configuration.dbport = 54322
+        configuration.dbusr = "docker"
+        configuration.dbpwd = "docker"
+        configuration.database = "gis"
+    elif tool == DbIliMode.ili2mssql:
+        configuration.dbhost = "mssql"
+        configuration.dbusr = "sa"
+        configuration.dbpwd = "<YourStrong!Passw0rd>"
+        configuration.database = "gis"
+
+    configuration.base_configuration = base_config
+
+    return configuration
+
+
+@pytest.mark.skip("This is a utility function, not a test function")
+def testdata_path(path):
+    basepath = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(basepath, "testdata", path)
+
+
+def get_pg_conn(schema):
+    myenv = os.environ.copy()
+    myenv["PGPASSWORD"] = "docker"
+
+    call(
+        [
+            "pg_restore",
+            "-Fc",
+            "-h" + "localhost"
+            "-p54322"
+            "-Udocker",
+            "-dgis",
+            testdata_path("dumps/{}_dump".format(schema)),
+        ],
+        env=myenv,
+    )
+    db_factory = DbSimpleFactory().create_factory(DbIliMode.pg)
+    configuration = ili2dbconfig.ExportConfiguration()
+
+    configuration.database = "gis"
+    configuration.dbhost = "localhost"
+    configuration.dbport = 54322
+    configuration.dbusr = "docker"
+    configuration.dbpwd = "docker"
+    configuration.dbport = "5432"
+
+    config_manager = db_factory.get_db_command_config_manager(configuration)
+    db_connector = db_factory.get_db_connector(config_manager.get_uri(), schema)
+    return db_connector
+
+
+def get_gpkg_conn(gpkg):
+    db_factory = DbSimpleFactory().create_factory(DbIliMode.gpkg)
+    db_connector = db_factory.get_db_connector(
+        testdata_path("geopackage/{}.gpkg".format(gpkg)), None
+    )
+    return db_connector
+
+
+def get_pg_connection_string():
+    pg_host = "localhost"
+    dbport = 54322
+    return "dbname=gis user=docker password=docker host=localhost port=54322"
+
+
+# Schema Import
+importer = iliimporter.Importer()
+importer.tool = DbIliMode.ili2gpkg
+importer.configuration = iliimporter_config(importer.tool, "/home/dave/dev/opengisch/QgisModelBakerLibrary/tests/testdata/ilimodels")
+importer.configuration.ilimodels = "Colors_V2"
+importer.configuration.dbfile = f"/home/dave/qgis-projects/test_{datetime.datetime.now()}.gpkg"
+importer.configuration.inheritance = "smart2"
+importer.configuration.create_basket_col = False
+# createEnumTabs
+importer.configuration.enum_tabs = "tabs"
+print(importer.run())
+
+config_manager = GpkgCommandConfigManager(importer.configuration)
+uri = config_manager.get_uri()
+
+generator = Generator(
+    DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
+)
+
+available_layers = generator.layers()
+relations, bagof = generator.relations(available_layers)
+
+legend = generator.legend(available_layers)
+
+project = Project()
+project.layers = available_layers
+project.relations = relations
+print(bagof)
+print(available_layers)
+project.legend = legend
+project.post_generate()
+
+qgis_project = QgsProject.instance()
+project.create(None, qgis_project)
+```

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4139,6 +4139,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 count += 1
 
             if layer.alias == "UninheritedCMYColor":
+                # colortype
                 field = layer.layer.fields().field("colortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4148,10 +4149,28 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
                 )
+
+                # bagofcolortype
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert config["AllowMulti"]
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+
                 count += 1
         assert count == 2
 
@@ -4219,10 +4238,28 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
                 )
+
+                # bagofcolortype
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert config["AllowMulti"]
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+
                 count += 1
         assert count == 2
 
@@ -4315,10 +4352,28 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
                 )
+
+                # bagofcolortype
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert config["AllowMulti"]
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+
                 count += 1
         assert count == 4
 
@@ -4410,11 +4465,29 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert not (config["AllowMulti"])
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                )
+
+                # bagofcolortype
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
                 )
                 count += 1
+
         assert count == 4
 
     def test_enumtabs_smart1_postgis(self):
@@ -4466,10 +4539,28 @@ class TestDomainClassRelation(unittest.TestCase):
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
+                assert not (config["AllowMulti"])
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert config["FilterExpression"] == ""
+                assert not (config["AllowMulti"])
+
+                # bagofcolortype
+                """
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert config["FilterExpression"] == ""
+                assert (config["AllowMulti"])
+                """
                 count += 1
         assert count == 2
 
@@ -4527,6 +4618,23 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert not (config["AllowMulti"])
+                assert config["FilterExpression"] == ""
+
+                # bagofcolortype
+                """
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (config["AllowMulti"])
+                assert config["FilterExpression"] == ""
+                """
                 count += 1
         assert count == 2
 
@@ -4616,7 +4724,23 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert not (config["AllowMulti"])
                 assert config["FilterExpression"] == ""
+
+                # bagofcolortype
+                """
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (config["AllowMulti"])
+                assert config["FilterExpression"] == ""
+                """
                 count += 1
         assert count == 4
 
@@ -4707,7 +4831,23 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
+                assert not (config["AllowMulti"])
                 assert config["FilterExpression"] == ""
+
+                # bagofcolortype
+                """
+                field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert (
+                    qgis_project.mapLayer(config["Layer"]).name()
+                    == "UninheritedCMYColorType"
+                )
+                assert (config["AllowMulti"])
+                assert config["FilterExpression"] == ""
+                """
                 count += 1
         assert count == 4
 

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4108,13 +4108,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4198,13 +4199,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4286,13 +4288,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4401,13 +4404,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4515,13 +4519,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4548,7 +4553,6 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert not (config["AllowMulti"])
 
                 # bagofcolortype
-                """
                 field = layer.layer.fields().field("bagofcolortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4559,8 +4563,7 @@ class TestDomainClassRelation(unittest.TestCase):
                     == "UninheritedCMYColorType"
                 )
                 assert config["FilterExpression"] == ""
-                assert (config["AllowMulti"])
-                """
+                assert config["AllowMulti"]
                 count += 1
         assert count == 2
 
@@ -4590,13 +4593,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4622,7 +4626,6 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["FilterExpression"] == ""
 
                 # bagofcolortype
-                """
                 field = layer.layer.fields().field("bagofcolortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4632,9 +4635,8 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
-                assert (config["AllowMulti"])
+                assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
-                """
                 count += 1
         assert count == 2
 
@@ -4663,13 +4665,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4728,7 +4731,6 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["FilterExpression"] == ""
 
                 # bagofcolortype
-                """
                 field = layer.layer.fields().field("bagofcolortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4738,9 +4740,8 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
-                assert (config["AllowMulti"])
+                assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
-                """
                 count += 1
         assert count == 4
 
@@ -4770,13 +4771,14 @@ class TestDomainClassRelation(unittest.TestCase):
         )
 
         available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
+        relations, bags_of_enum = generator.relations(available_layers)
 
         legend = generator.legend(available_layers)
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
+        project.bags_of_enum = bags_of_enum
         project.legend = legend
         project.post_generate()
 
@@ -4835,7 +4837,6 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["FilterExpression"] == ""
 
                 # bagofcolortype
-                """
                 field = layer.layer.fields().field("bagofcolortype")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
@@ -4845,9 +4846,9 @@ class TestDomainClassRelation(unittest.TestCase):
                     qgis_project.mapLayer(config["Layer"]).name()
                     == "UninheritedCMYColorType"
                 )
-                assert (config["AllowMulti"])
+                assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
-                """
+
                 count += 1
         assert count == 4
 
@@ -4868,27 +4869,6 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
 
-        generator = Generator(
-            DbIliMode.ili2pg,
-            get_pg_connection_string(),
-            importer.configuration.inheritance,
-            importer.configuration.dbschema,
-        )
-
-        available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
-
-        legend = generator.legend(available_layers)
-
-        project = Project()
-        project.layers = available_layers
-        project.relations = relations
-        project.legend = legend
-        project.post_generate()
-
-        qgis_project = QgsProject.instance()
-        project.create(None, qgis_project)
-
     def test_enumsingletab_smart1_geopackage(self):
         # Schema Import
         importer = iliimporter.Importer()
@@ -4907,27 +4887,6 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
 
-        config_manager = GpkgCommandConfigManager(importer.configuration)
-        uri = config_manager.get_uri()
-
-        generator = Generator(
-            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
-        )
-
-        available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
-
-        legend = generator.legend(available_layers)
-
-        project = Project()
-        project.layers = available_layers
-        project.relations = relations
-        project.legend = legend
-        project.post_generate()
-
-        qgis_project = QgsProject.instance()
-        project.create(None, qgis_project)
-
     def test_enumsingletab_smart2_postgis(self):
         # Schema Import
         importer = iliimporter.Importer()
@@ -4944,27 +4903,6 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
-
-        generator = Generator(
-            DbIliMode.ili2pg,
-            get_pg_connection_string(),
-            importer.configuration.inheritance,
-            importer.configuration.dbschema,
-        )
-
-        available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
-
-        legend = generator.legend(available_layers)
-
-        project = Project()
-        project.layers = available_layers
-        project.relations = relations
-        project.legend = legend
-        project.post_generate()
-
-        qgis_project = QgsProject.instance()
-        project.create(None, qgis_project)
 
     def test_enumsingletab_smart2_geopackage(self):
         # Schema Import
@@ -4983,27 +4921,6 @@ class TestDomainClassRelation(unittest.TestCase):
         importer.stdout.connect(self.print_info)
         importer.stderr.connect(self.print_error)
         assert importer.run() == iliimporter.Importer.SUCCESS
-
-        config_manager = GpkgCommandConfigManager(importer.configuration)
-        uri = config_manager.get_uri()
-
-        generator = Generator(
-            DbIliMode.ili2gpkg, uri, importer.configuration.inheritance
-        )
-
-        available_layers = generator.layers()
-        relations, _ = generator.relations(available_layers)
-
-        legend = generator.legend(available_layers)
-
-        project = Project()
-        project.layers = available_layers
-        project.relations = relations
-        project.legend = legend
-        project.post_generate()
-
-        qgis_project = QgsProject.instance()
-        project.create(None, qgis_project)
 
     def print_info(self, text):
         logging.info(text)

--- a/tests/test_projectgen.py
+++ b/tests/test_projectgen.py
@@ -534,7 +534,19 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 15
         assert len(available_layers) == 23
-        assert len(relations) == 13
+        assert len(relations) == 22  # 21 of them are enum-relations
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.post_generate()
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # in the end we only have one connection (Datenbestand -> ZustaendigeStelle)
+        # the enums are value relations
+        qgis_relations = qgis_project.relationManager().relations()
+        assert len(qgis_relations) == 1
 
     def test_naturschutz_geopackage(self):
         importer = iliimporter.Importer()
@@ -566,7 +578,19 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 65
         assert len(available_layers) == 23
-        assert len(relations) == 13
+        assert len(relations) == 22  # 21 of them are enum-relations
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.post_generate()
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # in the end we only have one connection (Datenbestand -> ZustaendigeStelle)
+        # the enums are value relations
+        qgis_relations = qgis_project.relationManager().relations()
+        assert len(qgis_relations) == 1
 
     def test_naturschutz_mssql(self):
         importer = iliimporter.Importer()
@@ -602,7 +626,19 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 20
         assert len(available_layers) == 23
-        assert len(relations) == 22
+        assert len(relations) == 22  # 21 of them are enum-relations
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.post_generate()
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # in the end we only have one connection (Datenbestand -> ZustaendigeStelle)
+        # the enums are value relations
+        qgis_relations = qgis_project.relationManager().relations()
+        assert len(qgis_relations) == 1
 
     def test_naturschutz_set_ignored_layers_postgis(self):
         importer = iliimporter.Importer()
@@ -633,7 +669,19 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 17
         assert len(available_layers) == 21
-        assert len(relations) == 12
+        assert len(relations) == 21  # 21 of them are enum-relations
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.post_generate()
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # in the end we have no connections
+        # the enums are value relations
+        qgis_relations = qgis_project.relationManager().relations()
+        assert len(qgis_relations) == 0
 
     def test_naturschutz_set_ignored_layers_geopackage(self):
         importer = iliimporter.Importer()
@@ -662,21 +710,25 @@ class TestProjectGen(unittest.TestCase):
         generator.set_additional_ignored_layers(["einzelbaum", "datenbestand"])
         ignored_layers = generator.get_ignored_layers()
         available_layers = generator.layers([])
-        legend = generator.legend(available_layers)
+        generator.legend(available_layers)
         relations, _ = generator.relations(available_layers)
 
         assert len(ignored_layers) == 67
         assert len(available_layers) == 21
-        assert len(relations) == 12
+        assert len(relations) == 21  # 21 of them are enum-relations
 
         project = Project()
         project.layers = available_layers
         project.relations = relations
-        project.legend = legend
         project.post_generate()
 
         qgis_project = QgsProject.instance()
         project.create(None, qgis_project)
+
+        # in the end we have no connections
+        # the enums are value relations
+        qgis_relations = qgis_project.relationManager().relations()
+        assert len(qgis_relations) == 0
 
         layer_names = [l.name().lower() for l in qgis_project.mapLayers().values()]
         assert "einzelbaum" not in layer_names
@@ -718,7 +770,20 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 22
         assert len(available_layers) == 21
-        assert len(relations) == 21
+        assert len(relations) == 21  # 21 of them are enum-relations
+
+        project = Project()
+        project.layers = available_layers
+        project.relations = relations
+        project.post_generate()
+
+        qgis_project = QgsProject.instance()
+        project.create(None, qgis_project)
+
+        # in the end we have no connections
+        # the enums are value relations
+        qgis_relations = qgis_project.relationManager().relations()
+        assert len(qgis_relations) == 0
 
     def test_naturschutz_nometa_postgis(self):
         # model with missing meta attributes for multigeometry - no layers should be ignored
@@ -749,7 +814,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 9
         assert len(available_layers) == 29
-        assert len(relations) == 23
+        assert len(relations) == 32
 
     def test_naturschutz_nometa_geopackage(self):
         # model with missing meta attributes for multigeometry - no layers should be ignored
@@ -782,7 +847,7 @@ class TestProjectGen(unittest.TestCase):
 
         assert len(ignored_layers) == 31
         assert len(available_layers) == 29
-        assert len(relations) == 23
+        assert len(relations) == 32
 
     def test_ranges_postgis(self):
         importer = iliimporter.Importer()


### PR DESCRIPTION
Detecting the BAG OF enumeration structures in the meta tables. With `createEnumTabsWithIds`, we have the foreign keys there and detected them with this. But when we have no `tids`, we don't have any "hard" foreign keys, so we have to detect the relations via `enumDomain` property.

This requires ili2db 5.5.2 and fixes https://github.com/opengisch/QgisModelBaker/issues/1121


### Financed 
by the Canton of Solothurn and the QGIS Model Baker Group
