### PR TITLE
Filter on Enumeration-ValueRelations according the `T_Type` on `smart1`

### DIFF
--- a/modelbaker/dataobjects/fields.py
+++ b/modelbaker/dataobjects/fields.py
@@ -29,7 +29,7 @@ class Field:
         self.widget = None
         self.widget_config = dict()
         self.default_value_expression = None
-        self.enum_domain = None
+        self.enum_domain = []
         self.oid_domain = None
 
     def dump(self) -> dict:

--- a/modelbaker/dataobjects/project.py
+++ b/modelbaker/dataobjects/project.py
@@ -190,11 +190,10 @@ class Project(QObject):
                         else True,  # order by value if order by field is not available yet
                         "AllowNull": True,
                         "Layer": rel.referencedLayerId(),
-                        "FilterExpression": "\"{}\" = '{}'".format(
-                            ENUM_THIS_CLASS_COLUMN, relation.child_domain_name
-                        )
-                        if relation.child_domain_name
-                        else "",
+                        "FilterExpression": self._enum_filter_expression(
+                            relation.child_domain_name,
+                            referenced_layer.provider_names_map.get("ttype_name"),
+                        ),
                         "Key": relation.referenced_field,
                         "NofColumns": 1,
                         "OrderByField": True,
@@ -211,11 +210,10 @@ class Project(QObject):
                         "OrderByValue": True,
                         "ShowOpenFormButton": False,
                         "AllowNULL": True,
-                        "FilterExpression": "\"{}\" = '{}'".format(
-                            ENUM_THIS_CLASS_COLUMN, relation.child_domain_name
-                        )
-                        if relation.child_domain_name
-                        else "",
+                        "FilterExpression": self._enum_filter_expression(
+                            relation.child_domain_name,
+                            referenced_layer.provider_names_map.get("ttype_name"),
+                        ),
                         "FilterFields": list(),
                     },
                 )
@@ -303,11 +301,10 @@ class Project(QObject):
                     "AllowNull": True,
                     "Layer": domain_layer.id(),
                     # Filter only if domain layer uses 'thisClass' containing multiple inherited layer targets
-                    "FilterExpression": "\"{}\" = '{}'".format(
-                        ENUM_THIS_CLASS_COLUMN, child_domain_name
-                    )
-                    if domain_layer.fields().lookupField(ENUM_THIS_CLASS_COLUMN) >= 0
-                    else "",
+                    "FilterExpression": self._enum_filter_expression(
+                        child_domain_name,
+                        layer_obj.provider_names_map.get("ttype_name"),
+                    ),
                     "Key": key_field,
                     "NofColumns": 1,
                 }
@@ -344,6 +341,24 @@ class Project(QObject):
 
         if path:
             qgis_project.write(path)
+
+    def _enum_filter_expression(self, child_domain_names, t_type_name):
+        expression = ""
+        if len(child_domain_names) == 1:
+            # usual case with one type per domain
+            expression = "\"{}\" = '{}'".format(
+                ENUM_THIS_CLASS_COLUMN, list(child_domain_names[0].keys())[0]
+            )
+        if len(child_domain_names) > 1:
+            # this must be a multiple inherited types on smart1
+            when_blocks = [
+                f"    WHEN current_value('{t_type_name}') = '{t_type_value}' THEN\n        \"thisclass\" = '{child_domain}'"
+                for child_domain_item in child_domain_names
+                for child_domain, t_type_value in child_domain_item.items()
+            ]
+            return "CASE\n" + "\n".join(when_blocks) + "\nEND"
+
+        return expression
 
     def load_custom_layer_order(self, qgis_project: QgsProject) -> None:
         custom_layer_order = list()

--- a/modelbaker/dataobjects/relations.py
+++ b/modelbaker/dataobjects/relations.py
@@ -13,7 +13,7 @@ class Relation:
         self.strength = QgsRelation.RelationStrength.Association
         self.cardinality_max = None
         self.cardinality_min = None
-        self.child_domain_name = None
+        self.child_domain_name = []
         self.qgis_relation = None
         self._id = None
         self.translate_name = False

--- a/modelbaker/dbconnector/db_connector.py
+++ b/modelbaker/dbconnector/db_connector.py
@@ -39,6 +39,7 @@ class DBConnector(QObject):
         self.enum_table_name = (
             ""  # When there is a technical table holding all the enum values
         )
+        self.ttype_name = ""  # On smart1 the type of inherited object (t_type)
         self._lang = ""  # Preferred tr language for table/column info (2 characters)
 
     def get_provider_specific_names(self) -> dict:
@@ -54,6 +55,7 @@ class DBConnector(QObject):
             "datasettable_name": self.dataset_table_name,
             "ilicodename": self.iliCodeName,
             "enumtable_name": self.enum_table_name,
+            "ttype_name": self.ttype_name,
         }
 
     def map_data_types(self, data_type: str) -> str:

--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -54,6 +54,7 @@ class GPKGConnector(DBConnector):
         self.tilitid = "T_Ili_Tid"
         self.dispName = "dispName"
         self.attachmentKey = "attachmentKey"
+        self.ttype_name = "T_Type"
         self.basket_table_name = GPKG_BASKET_TABLE
         self.dataset_table_name = GPKG_DATASET_TABLE
         self.enum_table_name = GPKG_ENUM_TABLE
@@ -403,7 +404,7 @@ class GPKGConnector(DBConnector):
             record["unit"] = None
             record["texttype"] = None
             record["column_alias"] = None
-            record["enum_domain"] = None
+            record["enum_domain"] = []
             record["oid_domain"] = None
 
             if record["column_name"] == "T_Id" and Qgis.QGIS_VERSION_INT >= 30500:
@@ -431,7 +432,13 @@ class GPKGConnector(DBConnector):
                     elif column_prop["tag"] == "ch.ehi.ili2db.dispName":
                         record["column_alias"] = column_prop["setting"]
                     elif column_prop["tag"] == "ch.ehi.ili2db.enumDomain":
-                        record["enum_domain"] = column_prop["setting"]
+                        # In Smart1, a field can have multiple types (enum_domains) due to inherited enumerations.
+                        # To handle this, we create a dict containing:
+                        #   - 'type': The specific type
+                        #   - 't_type': The targetable type used for filtering
+                        record["enum_domain"].append(
+                            {column_prop["setting"]: column_prop["subtype"]}
+                        )
                     elif column_prop["tag"] == "ch.ehi.ili2db.oidDomain":
                         record["oid_domain"] = column_prop["setting"]
 

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -48,6 +48,7 @@ class MssqlConnector(DBConnector):
         self.iliCodeName = "iliCode"
         self.tid = "T_Id"
         self.tilitid = "T_Ili_Tid"
+        self.ttype_name = "T_Type"
         self.attachmentKey = "attachmentkey"
         self.dispName = "dispName"
         self.basket_table_name = BASKET_TABLE
@@ -505,7 +506,14 @@ class MssqlConnector(DBConnector):
                 stmt += ln + "    , txttype.setting AS texttype"
                 stmt += ln + "    , alias.setting AS column_alias"
                 stmt += ln + "    , full_name.iliname AS fully_qualified_name"
-                stmt += ln + "    , enum_domain.setting AS enum_domain"
+                stmt += (
+                    ln
+                    + "    , CASE"
+                    + "        WHEN enum_domain.setting IS NOT NULL"
+                    + "        THEN CAST('[{{\"+ enum_domain.setting + \":null}}]' AS NVARCHAR(MAX))"
+                    + "        ELSE CAST('[]' AS NVARCHAR(MAX))"
+                    + "    END AS enum_domain"
+                )
                 stmt += ln + "    , oid_domain.setting AS oid_domain"
                 if metaattrs_exists:
                     stmt += (

--- a/modelbaker/dbconnector/mssql_connector.py
+++ b/modelbaker/dbconnector/mssql_connector.py
@@ -11,6 +11,7 @@ License:
     (at your option) any later version.
 """
 
+import json
 import numbers
 import re
 from typing import Optional
@@ -510,7 +511,7 @@ class MssqlConnector(DBConnector):
                     ln
                     + "    , CASE"
                     + "        WHEN enum_domain.setting IS NOT NULL"
-                    + "        THEN CAST('[{{\"+ enum_domain.setting + \":null}}]' AS NVARCHAR(MAX))"
+                    + "        THEN CAST(CONCAT('[{{\"', enum_domain.setting, '\":null}}]') AS NVARCHAR(MAX))"
                     + "        ELSE CAST('[]' AS NVARCHAR(MAX))"
                     + "    END AS enum_domain"
                 )
@@ -877,6 +878,8 @@ class MssqlConnector(DBConnector):
         res = []
         for row in cur.fetchall():
             my_rec = dict(zip(columns, row))
+            if "enum_domain" in my_rec and isinstance(my_rec["enum_domain"], str):
+                my_rec["enum_domain"] = json.loads(my_rec["enum_domain"])
             res.append(my_rec)
 
         return res

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -49,6 +49,7 @@ class PGConnector(DBConnector):
         self.tilitid = "t_ili_tid"
         self.attachmentKey = "attachmentkey"
         self.dispName = "dispname"
+        self.ttype_name = "t_type"
         self.basket_table_name = PG_BASKET_TABLE
         self.dataset_table_name = PG_DATASET_TABLE
         self.enum_table_name = PG_ENUM_TABLE
@@ -460,7 +461,7 @@ class PGConnector(DBConnector):
             unit_field = ""
             text_kind_field = ""
             full_name_field = ""
-            enum_domain_field = ""
+            enum_domain_structure = ""
             oid_domain_field = ""
             attr_order_field = ""
             attr_mapping_field = ""
@@ -484,7 +485,16 @@ class PGConnector(DBConnector):
                 text_kind_field = "txttype.setting AS texttype,"
                 column_alias = "alias.setting AS column_alias,"
                 full_name_field = "full_name.iliname as fully_qualified_name,"
-                enum_domain_field = "enum_domain.setting as enum_domain,"
+                # In Smart1, a field can have multiple types (enum_domains) due to inherited enumerations.
+                # To handle this, we create a JSON dict containing:
+                #   - 'type': The specific type
+                #   - 't_type': The targetable type used for filtering
+                enum_domain_structure = """COALESCE(
+                    json_agg(
+                    json_build_object(enum_domain.setting, enum_domain.subtype)
+                    ) FILTER (WHERE enum_domain.setting IS NOT NULL),
+                    '[]'::json
+                ) AS enum_domain,"""
                 oid_domain_field = "oid_domain.setting as oid_domain,"
                 translations = """nls.label AS column_tr,""" if tr_enabled else ""
                 unit_join = """LEFT JOIN {}.t_ili2db_column_prop unit
@@ -525,6 +535,24 @@ class PGConnector(DBConnector):
                                                     oid_domain.tag = 'ch.ehi.ili2db.oidDomain'""".format(
                     self.schema
                 )
+                # group by because of coalesce in the enum domain
+                group_by = """GROUP BY
+                    c.column_name,
+                    c.data_type,
+                    c.numeric_scale,
+                    unit.setting,
+                    txttype.setting,
+                    alias.setting,
+                    full_name.iliname,
+                    oid_domain.setting,
+                    form_order.attr_value,
+                    meta_attr_mapping_value.attr_value,
+                    pgd.description,
+                    {translation_label}
+                    c.ordinal_position
+                """.format(
+                    translation_label="nls.label" if tr_enabled else ""
+                )
 
                 if self._table_exists(PG_METAATTRS_TABLE):
                     attr_order_field = "COALESCE(to_number(form_order.attr_value, '999'), 999) as attr_order,"
@@ -537,7 +565,7 @@ class PGConnector(DBConnector):
                                                             """.format(
                         schema=self.schema, t_ili2db_meta_attrs=PG_METAATTRS_TABLE
                     )
-                    order_by_attr_order = """ORDER BY attr_order"""
+                    order_by_attr_order = """ORDER BY attr_order, ordinal_position --to keep the sort of the occurence"""
 
                     attr_mapping_field = (
                         "meta_attr_mapping_value.attr_value as attr_mapping,"
@@ -570,7 +598,7 @@ class PGConnector(DBConnector):
                       {text_kind_field}
                       {column_alias}
                       {full_name_field}
-                      {enum_domain_field}
+                      {enum_domain_structure}
                       {oid_domain_field}
                       {attr_order_field}
                       {attr_mapping_field}
@@ -589,6 +617,7 @@ class PGConnector(DBConnector):
                     {attr_mapping_join}
                     {translations_left_join}
                     WHERE st.relid = '{schema}."{table}"'::regclass
+                    {group_by}
                     {order_by_attr_order};
                     """.format(
                         schema=self.schema,
@@ -597,7 +626,7 @@ class PGConnector(DBConnector):
                         text_kind_field=text_kind_field,
                         column_alias=column_alias,
                         full_name_field=full_name_field,
-                        enum_domain_field=enum_domain_field,
+                        enum_domain_structure=enum_domain_structure,
                         oid_domain_field=oid_domain_field,
                         attr_order_field=attr_order_field,
                         attr_mapping_field=attr_mapping_field,
@@ -611,10 +640,10 @@ class PGConnector(DBConnector):
                         attr_order_join=attr_order_join,
                         attr_mapping_join=attr_mapping_join,
                         translations_left_join=translations_left_join,
+                        group_by=group_by,
                         order_by_attr_order=order_by_attr_order,
                     )
                 )
-
                 return fields_cur
 
         return []

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -535,25 +535,8 @@ class PGConnector(DBConnector):
                                                     oid_domain.tag = 'ch.ehi.ili2db.oidDomain'""".format(
                     self.schema
                 )
-                # group by because of coalesce in the enum domain
-                group_by = """GROUP BY
-                    c.column_name,
-                    c.data_type,
-                    c.numeric_scale,
-                    unit.setting,
-                    txttype.setting,
-                    alias.setting,
-                    full_name.iliname,
-                    oid_domain.setting,
-                    form_order.attr_value,
-                    meta_attr_mapping_value.attr_value,
-                    pgd.description,
-                    {translation_label}
-                    c.ordinal_position
-                """.format(
-                    translation_label="nls.label" if tr_enabled else ""
-                )
 
+                metaattr_groupby_part = ""
                 if self._table_exists(PG_METAATTRS_TABLE):
                     attr_order_field = "COALESCE(to_number(form_order.attr_value, '999'), 999) as attr_order,"
                     attr_order_join = """LEFT JOIN {schema}.{t_ili2db_meta_attrs} form_order
@@ -587,6 +570,28 @@ class PGConnector(DBConnector):
                         if tr_enabled
                         else ""
                     )
+
+                    metaattr_groupby_part = """form_order.attr_value,
+                        meta_attr_mapping_value.attr_value,"""
+
+                # group by because of coalesce in the enum domain
+                group_by = """GROUP BY
+                    c.column_name,
+                    c.data_type,
+                    c.numeric_scale,
+                    unit.setting,
+                    txttype.setting,
+                    alias.setting,
+                    full_name.iliname,
+                    oid_domain.setting,
+                    {metaattr_part}
+                    pgd.description,
+                    {translation_label}
+                    c.ordinal_position
+                """.format(
+                    metaattr_part=metaattr_groupby_part,
+                    translation_label="nls.label," if tr_enabled else "",
+                )
 
                 fields_cur.execute(
                     """

--- a/modelbaker/generator/generator.py
+++ b/modelbaker/generator/generator.py
@@ -689,7 +689,7 @@ class Generator(QObject):
     ):
         # For enum-class relations, if we have an extended domain, get its child name
         # but only when it's created with ids or all the enums are stored in a single table (t_ili2db_enum)
-        child_domain_name = None
+        child_domain_name = []
         if referenced_column_name != referenced_layer.provider_names_map.get(
             "ilicodename"
         ) or referenced_layer.name == referenced_layer.provider_names_map.get(

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -90,7 +90,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "t_id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": "CIAF_LADM.Avaluo_UsoTipo",
+                "child_domain_name": [{"CIAF_LADM.Avaluo_UsoTipo": "avaluo"}],
             }
         )
         # Domain inherited from superclass and from another model
@@ -101,7 +101,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_DerechoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.COL_DerechoTipo": "derecho"}
+                ],
             }
         )
         # Domain from another model
@@ -112,7 +114,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "t_id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo": "persona"}
+                ],
             }
         )
         # Domain from another model
@@ -123,7 +127,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "t_id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_Genero",
+                "child_domain_name": [{"Catastro_COL_ES_V2_1_6.COL_Genero": "persona"}],
             }
         )
         # Domain inherited from abstract class
@@ -134,7 +138,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_InteresadoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.LA_InteresadoTipo": "persona"}
+                ],
             }
         )
         # Domain inherited from abstract class
@@ -145,7 +151,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "t_id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_BAUnitTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.LA_BAUnitTipo": "predio"}
+                ],
             }
         )
 
@@ -308,7 +316,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "colortype",
                 "referenced_field": "t_id",
                 "name": "childcolor_colortype_fkey",
-                "child_domain_name": "Colors.DomChildColorType",
+                "child_domain_name": [{"Colors.DomChildColorType": "childcolor"}],
             }
         )
 
@@ -395,7 +403,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "T_Id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": "CIAF_LADM.Avaluo_UsoTipo",
+                "child_domain_name": [{"CIAF_LADM.Avaluo_UsoTipo": "avaluo"}],
             }
         )
         # Domain inherited from superclass and from another model
@@ -406,7 +414,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_DerechoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.COL_DerechoTipo": "derecho"}
+                ],
             }
         )
         # Domain from another model
@@ -417,7 +427,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo": "persona"}
+                ],
             }
         )
         # Domain from another model
@@ -428,7 +440,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "T_Id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_Genero",
+                "child_domain_name": [{"Catastro_COL_ES_V2_1_6.COL_Genero": "persona"}],
             }
         )
         # Domain inherited from abstract class
@@ -439,7 +451,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_InteresadoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.LA_InteresadoTipo": "persona"}
+                ],
             }
         )
         # Domain inherited from abstract class
@@ -450,7 +464,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_BAUnitTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.LA_BAUnitTipo": "predio"}
+                ],
             }
         )
         for expected_relation in expected_relations:
@@ -614,7 +630,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "colortype",
                 "referenced_field": "T_Id",
                 "name": "childcolor_colortype_fkey",
-                "child_domain_name": "Colors.DomChildColorType",
+                "child_domain_name": [{"Colors.DomChildColorType": "childcolor"}],
             }
         )
 
@@ -707,7 +723,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "uso",
                 "referenced_field": "T_Id",
                 "name": "avaluo_uso_fkey",
-                "child_domain_name": "CIAF_LADM.Avaluo_UsoTipo",
+                "child_domain_name": [
+                    {"CIAF_LADM.Avaluo_UsoTipo": None}
+                ],  # multi enum not integrated in mssql
             }
         )
         # Domain inherited from superclass and from another model
@@ -718,7 +736,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "derecho_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_DerechoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.COL_DerechoTipo": None}
+                ],  # multi enum not integrated in mssql
             }
         )
         # Domain from another model
@@ -729,7 +749,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "documento_tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_documento_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.COL_InteresadoDocumentoTipo": None}
+                ],  # multi enum not integrated in mssql
             }
         )
         # Domain from another model
@@ -740,7 +762,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "genero",
                 "referenced_field": "T_Id",
                 "name": "persona_genero_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.COL_Genero",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.COL_Genero": None}
+                ],  # multi enum not integrated in mssql
             }
         )
         # Domain inherited from abstract class
@@ -751,7 +775,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "persona_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_InteresadoTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.LA_InteresadoTipo": None}
+                ],  # multi enum not integrated in mssql
             }
         )
         # Domain inherited from abstract class
@@ -762,7 +788,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "tipo",
                 "referenced_field": "T_Id",
                 "name": "predio_tipo_fkey",
-                "child_domain_name": "Catastro_COL_ES_V2_1_6.LA_BAUnitTipo",
+                "child_domain_name": [
+                    {"Catastro_COL_ES_V2_1_6.LA_BAUnitTipo": None}
+                ],  # multi enum not integrated in mssql
             }
         )
 
@@ -938,7 +966,9 @@ class TestDomainClassRelation(unittest.TestCase):
                 "referencing_field": "colortype",
                 "referenced_field": "T_Id",
                 "name": "childcolor_colortype_fkey",
-                "child_domain_name": "Colors.DomChildColorType",
+                "child_domain_name": [
+                    {"Colors.DomChildColorType": None}
+                ],  # multi enum not integrated in mssql
             }
         )
 
@@ -4132,14 +4162,27 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
 
                 assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
-                # This is still a bug https://github.com/opengisch/QgisModelBaker/issues/1120
-                # assert (
-                #    config["FilterExpression"]
-                #    == "\"thisclass\" = 'Colors_V2.ColorType'"
-                # )
+                assert (
+                    config["FilterExpression"]
+                    == """CASE\n    WHEN current_value('t_type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('t_type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('t_type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                )
 
-                # bagofcolortype
+                # there are two equal fields
+                # bagofcolortype for for bluechild
                 field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert config["AllowMulti"]
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                )
+
+                # bagofcolortype1 for for greenchild
+                field = layer.layer.fields().field("bagofcolortype1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -4150,6 +4193,7 @@ class TestDomainClassRelation(unittest.TestCase):
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
                 )
+
                 count += 1
 
             if layer.alias == "UninheritedCMYColor":
@@ -4236,14 +4280,27 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
 
                 assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
-                # This is still a bug https://github.com/opengisch/QgisModelBaker/issues/1120
-                # assert (
-                #    config["FilterExpression"]
-                #    == "\"thisclass\" = 'Colors_V2.ColorType'"
-                # )
+                assert (
+                    config["FilterExpression"]
+                    == """CASE\n    WHEN current_value('T_Type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('T_Type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('T_Type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                )
 
-                # bagofcolortype
+                # there are two equal fields
+                # bagofcolortype for for bluechild
                 field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert config["AllowMulti"]
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                )
+
+                # bagofcolortype for for greenchild
+                field = layer.layer.fields().field("bagofcolortype1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -4254,6 +4311,7 @@ class TestDomainClassRelation(unittest.TestCase):
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
                 )
+
                 count += 1
 
             if layer.alias == "UninheritedCMYColor":
@@ -4977,14 +5035,26 @@ class TestDomainClassRelation(unittest.TestCase):
 
                 config = field.editorWidgetSetup().config()
                 assert qgis_project.mapLayer(config["Layer"]).name() == "t_ili2db_enum"
-                # This is still a bug https://github.com/opengisch/QgisModelBaker/issues/1120
-                # assert (
-                #    config["FilterExpression"]
-                #    == "\"thisclass\" = 'Colors_V2.ColorType'"
-                # )
+                assert (
+                    config["FilterExpression"]
+                    == """CASE\n    WHEN current_value('t_type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('t_type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('t_type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                )
 
-                # bagofcolortype
+                # there are two equal fields
+                # bagofcolortype for for bluechild
                 field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "t_ili2db_enum"
+                assert config["AllowMulti"]
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                )
+                # bagofcolortype for for greenchild
+                field = layer.layer.fields().field("bagofcolortype1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5077,14 +5147,26 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
 
                 assert qgis_project.mapLayer(config["Layer"]).name() == "T_ILI2DB_ENUM"
-                # This is still a bug https://github.com/opengisch/QgisModelBaker/issues/1120
-                # assert (
-                #    config["FilterExpression"]
-                #    == "\"thisclass\" = 'Colors_V2.ColorType'"
-                # )
+                assert (
+                    config["FilterExpression"]
+                    == """CASE\n    WHEN current_value('T_Type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('T_Type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('T_Type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                )
 
-                # bagofcolortype
+                # there are two equal fields
+                # bagofcolortype for for bluechild
                 field = layer.layer.fields().field("bagofcolortype")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "T_ILI2DB_ENUM"
+                assert config["AllowMulti"]
+                assert (
+                    config["FilterExpression"]
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                )
+                # bagofcolortype for for greenchild
+                field = layer.layer.fields().field("bagofcolortype1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -312,11 +312,11 @@ class TestDomainClassRelation(unittest.TestCase):
         expected_relations.append(
             {
                 "referencing_layer": "childcolor",
-                "referenced_layer": "dombasecolortype",
-                "referencing_field": "colortype",
+                "referenced_layer": "dombasecolorclasss",
+                "referencing_field": "colors",
                 "referenced_field": "t_id",
-                "name": "childcolor_colortype_fkey",
-                "child_domain_name": [{"Colors.DomChildColorType": "childcolor"}],
+                "name": "childcolor_colors_fkey",
+                "child_domain_name": [{"Colors.DomChildColors": "childcolor"}],
             }
         )
 
@@ -340,11 +340,11 @@ class TestDomainClassRelation(unittest.TestCase):
         for layer in available_layers:
             if layer.name == "childcolor":
                 config = (
-                    layer.layer.fields().field("colortype").editorWidgetSetup().config()
+                    layer.layer.fields().field("colors").editorWidgetSetup().config()
                 )
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors.DomChildColorType'"
+                    == "\"thisclass\" = 'Colors.DomChildColors'"
                 )
                 count += 1
 
@@ -626,11 +626,11 @@ class TestDomainClassRelation(unittest.TestCase):
         expected_relations.append(
             {
                 "referencing_layer": "childcolor",
-                "referenced_layer": "dombasecolortype",
-                "referencing_field": "colortype",
+                "referenced_layer": "dombasecolorclasss",
+                "referencing_field": "colors",
                 "referenced_field": "T_Id",
-                "name": "childcolor_colortype_fkey",
-                "child_domain_name": [{"Colors.DomChildColorType": "childcolor"}],
+                "name": "childcolor_colors_fkey",
+                "child_domain_name": [{"Colors.DomChildColors": "childcolor"}],
             }
         )
 
@@ -654,11 +654,11 @@ class TestDomainClassRelation(unittest.TestCase):
         for layer in available_layers:
             if layer.name == "childcolor":
                 config = (
-                    layer.layer.fields().field("colortype").editorWidgetSetup().config()
+                    layer.layer.fields().field("colors").editorWidgetSetup().config()
                 )
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors.DomChildColorType'"
+                    == "\"thisclass\" = 'Colors.DomChildColors'"
                 )
                 count += 1
 
@@ -962,12 +962,12 @@ class TestDomainClassRelation(unittest.TestCase):
         expected_relations.append(
             {
                 "referencing_layer": "childcolor",
-                "referenced_layer": "dombasecolortype",
-                "referencing_field": "colortype",
+                "referenced_layer": "dombasecolorclasss",
+                "referencing_field": "colors",
                 "referenced_field": "T_Id",
-                "name": "childcolor_colortype_fkey",
+                "name": "childcolor_colors_fkey",
                 "child_domain_name": [
-                    {"Colors.DomChildColorType": None}
+                    {"Colors.DomChildColors": None}
                 ],  # multi enum not integrated in mssql
             }
         )
@@ -992,11 +992,11 @@ class TestDomainClassRelation(unittest.TestCase):
         for layer in available_layers:
             if layer.name == "childcolor":
                 config = (
-                    layer.layer.fields().field("colortype").editorWidgetSetup().config()
+                    layer.layer.fields().field("colors").editorWidgetSetup().config()
                 )
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors.DomChildColorType'"
+                    == "\"thisclass\" = 'Colors.DomChildColors'"
                 )
                 count += 1
 
@@ -4154,79 +4154,79 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
 
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
                     config["FilterExpression"]
-                    == """CASE\n    WHEN current_value('t_type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('t_type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('t_type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                    == """CASE\n    WHEN current_value('t_type') = 'basecolorclass' THEN\n        "thisclass" = 'Colors_V2.Colors'\n    WHEN current_value('t_type') = 'greenchildcolorclass' THEN\n        "thisclass" = 'Colors_V2.GreenChildColors'\n    WHEN current_value('t_type') = 'bluechildcolorclass' THEN\n        "thisclass" = 'Colors_V2.BlueChildColors'\nEND"""
                 )
 
                 # there are two equal fields
-                # bagofcolortype for for bluechild
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors for for bluechild
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
 
-                # bagofcolortype1 for for greenchild
-                field = layer.layer.fields().field("bagofcolortype1")
+                # bagofcolors1 for for greenchild
+                field = layer.layer.fields().field("bagofcolors1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
 
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                # colortype
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                # colors
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
                 count += 1
@@ -4272,78 +4272,78 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
 
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
                     config["FilterExpression"]
-                    == """CASE\n    WHEN current_value('T_Type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('T_Type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('T_Type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                    == """CASE\n    WHEN current_value('T_Type') = 'basecolorclass' THEN\n        "thisclass" = 'Colors_V2.Colors'\n    WHEN current_value('T_Type') = 'greenchildcolorclass' THEN\n        "thisclass" = 'Colors_V2.GreenChildColors'\n    WHEN current_value('T_Type') = 'bluechildcolorclass' THEN\n        "thisclass" = 'Colors_V2.BlueChildColors'\nEND"""
                 )
 
                 # there are two equal fields
-                # bagofcolortype for for bluechild
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors for for bluechild
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
 
-                # bagofcolortype for for greenchild
-                field = layer.layer.fields().field("bagofcolortype1")
+                # bagofcolors for for greenchild
+                field = layer.layer.fields().field("bagofcolors1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
 
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
                 count += 1
@@ -4388,90 +4388,89 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
 
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.ColorType'"
+                    config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
                 )
                 count += 1
 
-            if layer.alias == "BlueChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BlueChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
 
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
                 count += 1
 
-            if layer.alias == "GreenChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "GreenChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
                 count += 1
 
@@ -4517,87 +4516,86 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.ColorType'"
+                    config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
                 )
                 count += 1
 
-            if layer.alias == "BlueChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BlueChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
                 count += 1
 
-            if layer.alias == "GreenChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "GreenChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
                 count += 1
 
@@ -4644,11 +4642,11 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
+            if layer.alias == "BaseColorClass":
                 # It's technically not possible to have a sollution here, because the enumeration types are in a different table
                 count += 1
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -4656,20 +4654,20 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert not (config["AllowMulti"])
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["FilterExpression"] == ""
                 assert not (config["AllowMulti"])
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["FilterExpression"] == ""
                 assert config["AllowMulti"]
@@ -4718,31 +4716,31 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
+            if layer.alias == "BaseColorClass":
                 # It's technically not possible to have a sollution here, because the enumeration types are in a different table
                 count += 1
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert not (config["AllowMulti"])
                 assert config["FilterExpression"] == ""
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
@@ -4790,77 +4788,74 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["FilterExpression"] == ""
                 count += 1
 
-            if layer.alias == "BlueChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BlueChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    qgis_project.mapLayer(config["Layer"]).name()
-                    == "BlueChildColorType"
+                    qgis_project.mapLayer(config["Layer"]).name() == "BlueChildColors"
                 )
                 assert config["FilterExpression"] == ""
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert not (config["AllowMulti"])
                 assert config["FilterExpression"] == ""
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
                 count += 1
 
-            if layer.alias == "GreenChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "GreenChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    qgis_project.mapLayer(config["Layer"]).name()
-                    == "GreenChildColorType"
+                    qgis_project.mapLayer(config["Layer"]).name() == "GreenChildColors"
                 )
                 assert config["FilterExpression"] == ""
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    qgis_project.mapLayer(config["Layer"]).name()
-                    == "GreenChildColorType"
+                    qgis_project.mapLayer(config["Layer"]).name() == "GreenChildColors"
                 )
                 assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
@@ -4909,77 +4904,74 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "ColorType"
+                assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["FilterExpression"] == ""
                 count += 1
 
-            if layer.alias == "BlueChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BlueChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    qgis_project.mapLayer(config["Layer"]).name()
-                    == "BlueChildColorType"
+                    qgis_project.mapLayer(config["Layer"]).name() == "BlueChildColors"
                 )
                 assert config["FilterExpression"] == ""
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert not (config["AllowMulti"])
                 assert config["FilterExpression"] == ""
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
                     qgis_project.mapLayer(config["Layer"]).name()
-                    == "UninheritedCMYColorType"
+                    == "UninheritedCMYColors"
                 )
                 assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
                 count += 1
 
-            if layer.alias == "GreenChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "GreenChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    qgis_project.mapLayer(config["Layer"]).name()
-                    == "GreenChildColorType"
+                    qgis_project.mapLayer(config["Layer"]).name() == "GreenChildColors"
                 )
                 assert config["FilterExpression"] == ""
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
                 config = field.editorWidgetSetup().config()
                 assert (
-                    qgis_project.mapLayer(config["Layer"]).name()
-                    == "GreenChildColorType"
+                    qgis_project.mapLayer(config["Layer"]).name() == "GreenChildColors"
                 )
                 assert config["AllowMulti"]
                 assert config["FilterExpression"] == ""
@@ -5028,8 +5020,8 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5037,12 +5029,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert qgis_project.mapLayer(config["Layer"]).name() == "t_ili2db_enum"
                 assert (
                     config["FilterExpression"]
-                    == """CASE\n    WHEN current_value('t_type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('t_type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('t_type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                    == """CASE\n    WHEN current_value('t_type') = 'basecolorclass' THEN\n        "thisclass" = 'Colors_V2.Colors'\n    WHEN current_value('t_type') = 'greenchildcolorclass' THEN\n        "thisclass" = 'Colors_V2.GreenChildColors'\n    WHEN current_value('t_type') = 'bluechildcolorclass' THEN\n        "thisclass" = 'Colors_V2.BlueChildColors'\nEND"""
                 )
 
                 # there are two equal fields
-                # bagofcolortype for for bluechild
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors for for bluechild
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5051,10 +5043,10 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
-                # bagofcolortype for for greenchild
-                field = layer.layer.fields().field("bagofcolortype1")
+                # bagofcolors for for greenchild
+                field = layer.layer.fields().field("bagofcolors1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5063,13 +5055,13 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                # colortype
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                # colors
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5078,11 +5070,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5091,7 +5083,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
                 count += 1
@@ -5139,8 +5131,8 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5149,12 +5141,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert qgis_project.mapLayer(config["Layer"]).name() == "T_ILI2DB_ENUM"
                 assert (
                     config["FilterExpression"]
-                    == """CASE\n    WHEN current_value('T_Type') = 'greenchildcolor' THEN\n        "thisclass" = 'Colors_V2.GreenChildColorType'\n    WHEN current_value('T_Type') = 'basecolor' THEN\n        "thisclass" = 'Colors_V2.ColorType'\n    WHEN current_value('T_Type') = 'bluechildcolor' THEN\n        "thisclass" = 'Colors_V2.BlueChildColorType'\nEND"""
+                    == """CASE\n    WHEN current_value('T_Type') = 'basecolorclass' THEN\n        "thisclass" = 'Colors_V2.Colors'\n    WHEN current_value('T_Type') = 'greenchildcolorclass' THEN\n        "thisclass" = 'Colors_V2.GreenChildColors'\n    WHEN current_value('T_Type') = 'bluechildcolorclass' THEN\n        "thisclass" = 'Colors_V2.BlueChildColors'\nEND"""
                 )
 
                 # there are two equal fields
-                # bagofcolortype for for bluechild
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors for for bluechild
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5163,10 +5155,10 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
-                # bagofcolortype for for greenchild
-                field = layer.layer.fields().field("bagofcolortype1")
+                # bagofcolors for for greenchild
+                field = layer.layer.fields().field("bagofcolors1")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5175,12 +5167,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
                 count += 1
 
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5189,11 +5181,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5202,7 +5194,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
                 count += 1
@@ -5249,8 +5241,21 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+
+                assert qgis_project.mapLayer(config["Layer"]).name() == "t_ili2db_enum"
+                assert (
+                    config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
+                )
+                count += 1
+
+            if layer.alias == "BlueChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5259,26 +5264,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert qgis_project.mapLayer(config["Layer"]).name() == "t_ili2db_enum"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.ColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
                 count += 1
 
-            if layer.alias == "BlueChildColor":
-                field = layer.layer.fields().field("colortype")
-                type = field.editorWidgetSetup().type()
-                self.assertEqual(type, "ValueRelation")
-
-                config = field.editorWidgetSetup().config()
-
-                assert qgis_project.mapLayer(config["Layer"]).name() == "t_ili2db_enum"
-                assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
-                )
-                count += 1
-
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5287,11 +5278,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5300,12 +5291,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
                 count += 1
 
-            if layer.alias == "GreenChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "GreenChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5313,11 +5304,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert qgis_project.mapLayer(config["Layer"]).name() == "t_ili2db_enum"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5326,7 +5317,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
                 count += 1
 
@@ -5374,8 +5365,20 @@ class TestDomainClassRelation(unittest.TestCase):
 
         count = 0
         for layer in available_layers:
-            if layer.alias == "BaseColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "BaseColorClass":
+                field = layer.layer.fields().field("colors")
+                type = field.editorWidgetSetup().type()
+                self.assertEqual(type, "ValueRelation")
+
+                config = field.editorWidgetSetup().config()
+                assert qgis_project.mapLayer(config["Layer"]).name() == "T_ILI2DB_ENUM"
+                assert (
+                    config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
+                )
+                count += 1
+
+            if layer.alias == "BlueChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5383,25 +5386,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert qgis_project.mapLayer(config["Layer"]).name() == "T_ILI2DB_ENUM"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.ColorType'"
+                    == "\"thisclass\" = 'Colors_V2.BlueChildColors'"
                 )
                 count += 1
 
-            if layer.alias == "BlueChildColor":
-                field = layer.layer.fields().field("colortype")
-                type = field.editorWidgetSetup().type()
-                self.assertEqual(type, "ValueRelation")
-
-                config = field.editorWidgetSetup().config()
-                assert qgis_project.mapLayer(config["Layer"]).name() == "T_ILI2DB_ENUM"
-                assert (
-                    config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.BlueChildColorType'"
-                )
-                count += 1
-
-            if layer.alias == "UninheritedCMYColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "UninheritedCMYColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5410,11 +5400,11 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert not (config["AllowMulti"])
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
 
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5423,12 +5413,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColorType'"
+                    == "\"thisclass\" = 'Colors_V2.UninheritedCMYColors'"
                 )
                 count += 1
 
-            if layer.alias == "GreenChildColor":
-                field = layer.layer.fields().field("colortype")
+            if layer.alias == "GreenChildColorClass":
+                field = layer.layer.fields().field("colors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5436,10 +5426,10 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert qgis_project.mapLayer(config["Layer"]).name() == "T_ILI2DB_ENUM"
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
-                # bagofcolortype
-                field = layer.layer.fields().field("bagofcolortype")
+                # bagofcolors
+                field = layer.layer.fields().field("bagofcolors")
                 type = field.editorWidgetSetup().type()
                 self.assertEqual(type, "ValueRelation")
 
@@ -5448,7 +5438,7 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert config["AllowMulti"]
                 assert (
                     config["FilterExpression"]
-                    == "\"thisclass\" = 'Colors_V2.GreenChildColorType'"
+                    == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
                 count += 1
 

--- a/tests/testdata/ilimodels/ColorsParentChildDomain.ili
+++ b/tests/testdata/ilimodels/ColorsParentChildDomain.ili
@@ -6,14 +6,14 @@ VERSION "2020-08-26"  =
 
   DOMAIN
 
-    DomBaseColorType = (
+    DomBaseColorClasss = (
       Green,
       Red,
       Blue
     );
 
-    DomChildColorType
-    EXTENDS DomBaseColorType = (
+    DomChildColors
+    EXTENDS DomBaseColorClasss = (
       Blue(
         Dark_Blue,
         Light_Blue,
@@ -23,13 +23,13 @@ VERSION "2020-08-26"  =
 
   TOPIC Colors =
 
-    CLASS BaseColor (ABSTRACT) =
-      ColorType : Colors.DomBaseColorType;
-    END BaseColor;
+    CLASS BaseColorClass (ABSTRACT) =
+      Colors : Colors.DomBaseColorClasss;
+    END BaseColorClass;
 
     CLASS ChildColor
-    EXTENDS BaseColor =
-      ColorType (EXTENDED) : Colors.DomChildColorType;
+    EXTENDS BaseColorClass =
+      Colors (EXTENDED) : Colors.DomChildColors;
     END ChildColor;
 
   END Colors;

--- a/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
+++ b/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
@@ -38,6 +38,7 @@ VERSION "2020-08-26"  =
 
     STRUCTURE UninheritedCMYColorTypeStruct = value : MANDATORY UninheritedCMYColorType; END UninheritedCMYColorTypeStruct;
     STRUCTURE GreenChildColorTypeStruct = value : MANDATORY GreenChildColorType; END GreenChildColorTypeStruct;
+    STRUCTURE BlueChildColorTypeStruct = value : MANDATORY BlueChildColorType; END BlueChildColorTypeStruct;
 
   TOPIC Colors =
 
@@ -48,6 +49,8 @@ VERSION "2020-08-26"  =
     CLASS BlueChildColor
     EXTENDS BaseColor =
       ColorType (EXTENDED) : Colors_V2.BlueChildColorType;
+      !!@ili2db.mapping="ARRAY"
+      BagOfColorType : BAG {0..*} OF Colors_V2.BlueChildColorTypeStruct;
     END BlueChildColor;
 
     CLASS UninheritedCMYColor =

--- a/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
+++ b/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
@@ -6,14 +6,14 @@ VERSION "2020-08-26"  =
 
   DOMAIN
 
-    ColorType = (
+    Colors = (
       Green,
       Red,
       Blue
     );
 
-    BlueChildColorType
-    EXTENDS ColorType = (
+    BlueChildColors
+    EXTENDS Colors = (
       Blue(
         Dark_Blue,
         Light_Blue,
@@ -21,8 +21,8 @@ VERSION "2020-08-26"  =
       )
     );
 
-    GreenChildColorType
-    EXTENDS ColorType = (
+    GreenChildColors
+    EXTENDS Colors = (
       Green(
         Dark_Green,
         Light_Green,
@@ -30,42 +30,42 @@ VERSION "2020-08-26"  =
       )
     );
 
-    UninheritedCMYColorType = (
+    UninheritedCMYColors = (
       Cyan,
       Magenta,
       Yello
     );
 
-    STRUCTURE UninheritedCMYColorTypeStruct = value : MANDATORY UninheritedCMYColorType; END UninheritedCMYColorTypeStruct;
-    STRUCTURE GreenChildColorTypeStruct = value : MANDATORY GreenChildColorType; END GreenChildColorTypeStruct;
-    STRUCTURE BlueChildColorTypeStruct = value : MANDATORY BlueChildColorType; END BlueChildColorTypeStruct;
+    STRUCTURE UninheritedCMYColorsStruct = value : MANDATORY UninheritedCMYColors; END UninheritedCMYColorsStruct;
+    STRUCTURE GreenChildColorsStruct = value : MANDATORY GreenChildColors; END GreenChildColorsStruct;
+    STRUCTURE BlueChildColorsStruct = value : MANDATORY BlueChildColors; END BlueChildColorsStruct;
 
-  TOPIC Colors =
+  TOPIC SomeColors =
 
-    CLASS BaseColor =
-      ColorType : Colors_V2.ColorType;
-    END BaseColor;
+    CLASS BaseColorClass =
+      Colors : Colors_V2.Colors;
+    END BaseColorClass;
 
-    CLASS BlueChildColor
-    EXTENDS BaseColor =
-      ColorType (EXTENDED) : Colors_V2.BlueChildColorType;
+    CLASS BlueChildColorClass
+    EXTENDS BaseColorClass =
+      Colors (EXTENDED) : Colors_V2.BlueChildColors;
       !!@ili2db.mapping="ARRAY"
-      BagOfColorType : BAG {0..*} OF Colors_V2.BlueChildColorTypeStruct;
-    END BlueChildColor;
+      BagOfColors : BAG {0..*} OF Colors_V2.BlueChildColorsStruct;
+    END BlueChildColorClass;
 
-    CLASS UninheritedCMYColor =
-      ColorType : Colors_V2.UninheritedCMYColorType;
+    CLASS UninheritedCMYColorClass =
+      Colors : Colors_V2.UninheritedCMYColors;
       !!@ili2db.mapping="ARRAY"
-      BagOfColorType : BAG {0..*} OF Colors_V2.UninheritedCMYColorTypeStruct;
-    END UninheritedCMYColor;
+      BagOfColors : BAG {0..*} OF Colors_V2.UninheritedCMYColorsStruct;
+    END UninheritedCMYColorClass;
 
-    CLASS GreenChildColor
-    EXTENDS BaseColor =
-      ColorType (EXTENDED) : Colors_V2.GreenChildColorType;
+    CLASS GreenChildColorClass
+    EXTENDS BaseColorClass =
+      Colors (EXTENDED) : Colors_V2.GreenChildColors;
       !!@ili2db.mapping="ARRAY"
-      BagOfColorType : BAG {0..*} OF Colors_V2.GreenChildColorTypeStruct;
-    END GreenChildColor;
+      BagOfColors : BAG {0..*} OF Colors_V2.GreenChildColorsStruct;
+    END GreenChildColorClass;
 
-  END Colors;
+  END SomeColors;
 
 END Colors_V2.


### PR DESCRIPTION
When having extended enumerations on `createEnumTabsWithId`  (default) and *createEnumSingleTab* we do have stored them in the same table, what makes it possible to use `smart1`. This implementation concerns this use case. On `createEnumTabs` this is technically not possible because a value relation would need to connect multiple tables (maybe this would be possible with polymorphic QGIS relations, but not sure at all and way too much complexity).

<table border="1" cellpadding="10" cellspacing="0" style="border-collapse: collapse; width: 100%;">
    <thead>
        <tr bgcolor="#f2f2f2">
            <th align="left" valign="top">use case</th>
            <th align="left" valign="top">createEnumTabsWithId</th>
            <th align="left" valign="top">createEnumTabs</th>
            <th align="left" valign="top">createEnumSingleTab</th>
        </tr>
    </thead>
    <tbody>
        <tr>
            <td valign="top">extended enums on <em>smart1</em></td>
            <td valign="top">
                  ili2db creates one table per enum-domain <em>including child-enums</em> and link via fk to it
                  <hr>
                  model baker reads the fk and creates <em>filtered</em> (depending on <code>t_type</code>) value-relations to it<br><br><b><i>handled by this implementation</i></b></td>
            <td valign="top">
                  ili2db creates a table per enum-domain and child-domain without fks to it
                  <hr>
                  model baker can evaluate the relations, but not create value relations (because depending on the <code>t_type</code> it would need to link to different tables) <br><br><b><i>won't be implemented</i></b></td>
            <td valign="top">
                  ili2db creates one table for all the enum-domains
                  <hr>
                  model baker evaluates the "soft" relations and creates <em>filtered</em> (depending on <code>t_type</code>) value-relations to it<br><br><b><i>handled by this implementation</i></b></td>
        </tr>
    </tbody>
</table>

## Example

Having enum `Colors` and `BlueChildColors` (extending `Colors`) and `GreenChildColors` (extending `Colors`).

### Enums

#### Colors
- Green
- Red
- Blue

#### BlueChildColors (extending `Colors`)
- Green
- Red
- Blue
  - Dark_Blue
  - Light_Blue
  - Medium_Blue

#### GreenChildColors (extending `GreenColors`)
- Green
  - Dark_Green
  - Light_Green
  - Medium_Green
- Red
- Blue
 
### Classes

- BaseColorClass with `Colors : Colors`
- BlueChildColorClass (extending `BaseColorClass`) with `Colors : BlueChildColors`
- GreenChildColorClass (extending `BaseColorClass`) with `Colors : GreenChildColors`

It will lead to one table (called `basecolorclass`) and an attribute (called `colors`) and a `t_type` field with the options:
- `basecolorclass`
- `bluechildcolorclass`
- `greenchildcolorclass`

Now what this implementation does is to set the filter for the field `color`:
```
CASE
    WHEN current_value('T_Type') = 'basecolorclass' THEN
        "thisclass" = 'Colors_V2.Colors'
    WHEN current_value('T_Type') = 'bluechildcolorclass' THEN
        "thisclass" = 'Colors_V2.BlueChildColors'
    WHEN current_value('T_Type') = 'greenchildcolorclass' THEN
        "thisclass" = 'Colors_V2.GreenChildColors'
END
```

This would resolve #https://github.com/opengisch/QgisModelBaker/issues/1120

### Compatibility break

This would break backwards compatibility with `class relation :: child_domain_name`, means it needs a new major version. 

### Financed 
by the QGIS Model Baker Group
