### PR TITLE
BakerPyIndex: ili2py Integration

### DIFF
--- a/modelbaker/ili2pytools/pythonizer.py
+++ b/modelbaker/ili2pytools/pythonizer.py
@@ -1,0 +1,331 @@
+"""
+Metadata:
+    Creation Date: 2026-07-07
+    Copyright: (C) 2026 by Dave Signer
+    Contact: david@opengis.ch
+
+License:
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the **GNU General Public License** as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+"""
+import os
+
+from modelbaker.libs.ili2py.interfaces.interlis.interlis_24.ilismeta.ilismeta16_2022_10_10.enum_type import (
+    EnumType,
+)
+from modelbaker.libs.ili2py.mappers.helpers import Index
+from modelbaker.libs.ili2py.readers.interlis_24.ilismeta16.xsdata import Imd16Reader
+from modelbaker.libs.ili2py.writers.py.python_structure import Enumeration, Library
+
+
+class BakerPyIndex(Index):
+    """Bridge to ili2py, subclassing the ili2py ``Index`` class.
+
+    Provides methods to return objects such as the library or enumerations,
+    as well as convenience methods. Does not override any base class behavior.
+    """
+
+    def __init__(self, metamodel):
+        self.metamodel = metamodel
+        super().__init__(self.metamodel.datasection)
+
+    @classmethod
+    def from_imd(cls, imd_path: str):
+        """Factory method to parse and instantiate itself.
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist.
+            ValueError: If the file is empty or invalid to read.
+        """
+        if not os.path.exists(imd_path):
+            raise FileNotFoundError(f"IMD file not found at: {imd_path}")
+
+        if os.path.getsize(imd_path) == 0:
+            raise ValueError(f"IMD file is empty: {imd_path}")
+
+        try:
+            reader = Imd16Reader()
+            metamodel = reader.read(imd_path)
+
+            if not metamodel or not hasattr(metamodel, "datasection"):
+                raise ValueError("Invalid IMD structure: missing datasection.")
+            return cls(metamodel)
+
+        except Exception as e:
+            raise ValueError(f"Failed to parse IMD file: {e}") from e
+
+    # get object functions
+    def base_index_object(
+        self,
+    ) -> Index:
+        """Returns a plain ``Index`` built from the metamodel data section.
+
+        Returns:
+            The base index object.
+        """
+        return Index(self.metamodel.datasection)
+
+    def library_object(
+        self,
+    ) -> Library:
+        """Returns the ``Library`` object built from the metamodel.
+
+        Returns:
+            The library object.
+        """
+        library_name = self.types_bucket["Model"][-1].name
+        library = Library.from_imd(
+            self.metamodel.datasection.ModelData, self, library_name
+        )
+        return library
+
+    def enumeration_object(self, type_object: EnumType) -> Enumeration:
+        """Returns the enumeration for the given enum type.
+
+        Args:
+            type_object: The enum type to build the enumeration from.
+
+        Returns:
+            The corresponding enumeration object.
+        """
+        enumeration = Enumeration.from_imd(type_object, self)
+        return enumeration
+
+    @property
+    def data_unit_supers(self) -> dict:
+        """Maps basket tids to their parents via ``<IlisMeta16:Super>``.
+
+        Returns:
+            A dict mapping a basket tid to its parent basket tid.
+        """
+        return self._supers("DataUnit")
+
+    @property
+    def enumeration_supers(self) -> dict:
+        """Maps object tids to their parents via ``<IlisMeta16:Super>``.
+
+        Returns:
+            A dict mapping an object tid to its parent object tid.
+        """
+        return self._supers("EnumType")
+
+    def _supers(self, type_name: str, package_elements_only: bool = True) -> dict:
+        """Maps an element tid to its parent tid via ``<IlisMeta16:Super>``.
+
+        Args:
+            type_name: The type to inspect (e.g. ``DataUnit`` or ``EnumType``).
+            package_elements_only: If True, only elements assigned to a package are considered.
+
+        Returns:
+            A dict mapping an element tid to its parent tid.
+        """
+        result = {}
+        for element in self.types_bucket.get(type_name, []):
+            in_package = getattr(element, "element_in_package", None)
+            if package_elements_only and not in_package:
+                continue
+            super_ref = getattr(element, "super", None) or getattr(
+                element, "super_value", None
+            )
+            if super_ref:
+                result[element.tid] = super_ref.ref
+        return result
+
+    def languages(self, model_names: list = None) -> list:
+        """Returns the languages of the given models.
+
+        Args:
+            model_names: The models to consider. If None, all models are considered.
+
+        Returns:
+            A list of language codes.
+        """
+        languages = []
+        for model in self.types_bucket.get("Model", []):
+            if model_names and model.name not in model_names:
+                continue
+            languages.append(model.language)
+        return languages
+
+    def attribute_type(self, attribute_iliname: str) -> object:
+        """Returns the type object for the given attribute.
+
+        Args:
+            attribute_iliname: The ili name of the attribute.
+
+        Returns:
+            The attribute's type object.
+        """
+        attribute_object = self.index.get(attribute_iliname)
+        attribute_type_oid = attribute_object.type_value.ref
+        return self.index.get(attribute_type_oid)
+
+    def relevant_topics(self, model_name: str = None) -> set:
+        """Returns the relevant topics, including extended and dependent topics.
+
+        Args:
+            model_name: The model to limit to. If None, all topics are returned.
+
+        Returns:
+            A set of topic names.
+        """
+        relevant_topics_set = set()
+        if not model_name:
+            # if not limited to the relevant topics, get all the topics
+            relevant_topics_set = {
+                topic
+                for topics in self.submodel_in_package.values()
+                for topic in topics
+            }
+        else:
+            relevant_topics_set = set(self.submodel_in_package.get(model_name, []))
+
+        # get the super and dependency mappings
+        supers = self.data_unit_supers
+        dependencies = self.dependency_depends_on
+
+        # make a mapping from baskets to topics
+        basket_topic_map = {
+            basket: topic for topic, basket in self.topic_basket.items()
+        }
+
+        # get topics recursively starting with the topics of the model
+        self._collect_relevant_topics_recursively(
+            relevant_topics_set, supers, dependencies, basket_topic_map
+        )
+
+        return relevant_topics_set
+
+    def _collect_relevant_topics_recursively(
+        self,
+        relevant_topics_set: set,
+        supers: dict,
+        dependencies: dict,
+        basket_topic_map: dict,
+    ):
+        """Recursively adds relevant topics from super and dependency relationships.
+
+        Updates ``relevant_topics_set`` in place. Following parent topics (via ``supers``)
+        and dependency topics (via ``dependencies``).
+
+        Args:
+            relevant_topics_set: The set of topics to extend in place.
+            supers: Mapping of basket tid to parent basket tid.
+            dependencies: Mapping of basket tid to dependency basket tids.
+            basket_topic_map: Mapping of basket tid to topic name.
+        """
+        found_topics = set()
+        for topic in relevant_topics_set:
+            basket = self.topic_basket.get(topic)
+            if not basket:
+                continue
+            if basket in supers:
+                # only one super topic
+                found_topics.add(basket_topic_map.get(supers[basket]))
+            # mulitple dependencies possible
+            dependency_topics = {
+                basket_topic_map.get(dependency_basket)
+                for dependency_basket in dependencies.get(basket, [])
+            }
+            found_topics.update(dependency_topics)
+
+        if found_topics:
+            self._collect_relevant_topics_recursively(
+                found_topics, supers, dependencies, basket_topic_map
+            )
+            relevant_topics_set.update(found_topics)
+
+    def relevant_models(self, relevant_topics: set = None) -> set:
+        """Returns the relevant models for the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all models are returned.
+
+        Returns:
+            A set of model names.
+        """
+        # if not limited to the relevant topics, get all the models directly
+        if not relevant_topics:
+            return set(self.models)
+
+        relevant_models = {
+            model
+            for model, topics in self.submodel_in_package.items()
+            if any(topic in relevant_topics for topic in topics)
+        }
+        return relevant_models
+
+    def relevant_classes(self, relevant_topics: set = None) -> set:
+        """Returns the relevant classes for the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all classes are returned.
+
+        Returns:
+            A set of class tids.
+        """
+        # if not limited to the relevant topics, get all the topics
+        if not relevant_topics:
+            relevant_topics = {
+                topic
+                for topics in self.submodel_in_package.values()
+                for topic in topics
+            }
+
+        topic_baskets_map = self.topic_basket
+        relevant_baskets = [topic_baskets_map.get(topic) for topic in relevant_topics]
+
+        # get all the relevant classes by checking if they are allowed in the data unit
+        relevant_classes = set()
+        all_elements = self.allowed_in_basket_of_data_unit
+        for element_basket in all_elements.keys():
+            if element_basket in relevant_baskets:
+                relevant_classes.update(all_elements[element_basket])
+        return relevant_classes
+
+    def relevant_geometric_attributes_per_class(
+        self, relevant_topics: set = None
+    ) -> dict:
+        """Returns the geometric attributes per class for the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all classes are considered.
+
+        Returns:
+            A dict mapping a class tid to a list of its geometric attribute tids.
+        """
+        relevant_classes = self.relevant_classes(relevant_topics)
+        geometric_classes = self.geometric_classes
+        relevant_geometric_attributes_per_class = {}
+        for geometric_classname in geometric_classes.keys():
+            if geometric_classname in relevant_classes:
+                relevant_geometric_attributes_per_class[
+                    geometric_classname
+                ] = geometric_classes[geometric_classname]
+        return relevant_geometric_attributes_per_class
+
+    def relevant_enumeration_definitions(self, relevant_topics: set = None) -> set:
+        """Returns the tids of enum types used as attribute types in the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all classes are considered.
+
+        Returns:
+            A set of enum type tids.
+        """
+        relevant_classes = self.relevant_classes(relevant_topics)
+
+        enum_tids = {
+            enum_type.tid for enum_type in self.types_bucket.get("EnumType", [])
+        }
+        result = set()
+        for attribute in self.types_bucket.get("AttrOrParam", []):
+            attr_parent = getattr(attribute, "attr_parent", None)
+            if not attr_parent or attr_parent.ref not in relevant_classes:
+                continue
+            type_ref = getattr(attribute, "type_value", None)
+            if type_ref and type_ref.ref in enum_tids:
+                result.add(type_ref.ref)
+        return result

--- a/modelbaker/utils/db_utils.py
+++ b/modelbaker/utils/db_utils.py
@@ -14,6 +14,8 @@ License:
 
 from __future__ import annotations
 
+import os
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from qgis.core import (
@@ -23,6 +25,7 @@ from qgis.core import (
     QgsDataSourceUri,
     QgsMessageLog,
 )
+from qgis.PyQt.QtCore import QFile, QStandardPaths
 
 from ..db_factory.db_simple_factory import DbSimpleFactory
 from ..dbconnector.db_connector import DBConnectorError
@@ -198,3 +201,32 @@ def get_service_config(servicename: str) -> tuple[dict[str, str], str]:
             {},
             f"The service {servicename} cannot be found in the service file.",
         )
+
+
+def model_files_generated_from_db(
+    configuration, model_list: list[str] | None = None
+) -> list[str]:
+    model_files: list[str] = []
+
+    db_connector = get_db_connector(configuration)
+    if not db_connector:
+        return model_files
+
+    model_records = db_connector.get_models()
+    for record in model_records:
+        name = record["modelname"].split("{")[0]
+        # on an empty model_list we create a file for every found model
+        if not model_list or name in model_list:
+            modelfilepath = os.path.join(
+                QStandardPaths.writableLocation(
+                    QStandardPaths.StandardLocation.TempLocation
+                ),
+                "temp_{}_{:%Y%m%d%H%M%S%f}.ili".format(name, datetime.now()),
+            )
+            file = QFile(modelfilepath)
+            if file.open(QFile.OpenModeFlag.WriteOnly):
+                file.write(record["content"].encode("utf-8"))
+                file.close()
+                model_files.append(modelfilepath)
+
+    return model_files

--- a/modelbaker/utils/globals.py
+++ b/modelbaker/utils/globals.py
@@ -80,6 +80,7 @@ MODELS_BLACKLIST = [
     "DictionariesCH_V2",
     "CatalogueObjects_V2",
     "CatalogueObjectTrees_V2",
+    "INTERLIS",
 ]
 
 

--- a/modelbaker/utils/ili2db_utils.py
+++ b/modelbaker/utils/ili2db_utils.py
@@ -13,17 +13,22 @@ License:
 
 from __future__ import annotations
 
+import datetime
+import os
 from typing import TYPE_CHECKING
 
-from qgis.PyQt.QtCore import QObject, Qt, pyqtSignal
+from qgis.PyQt.QtCore import QObject, QStandardPaths, Qt, pyqtSignal
 
 from ..iliwrapper import ilideleter, ilimetaconfigexporter
 from ..iliwrapper.ili2dbconfig import (
+    BaseConfiguration,
     DeleteConfiguration,
     ExportMetaConfigConfiguration,
+    Ili2CCommandConfiguration,
     Ili2DbCommandConfiguration,
 )
 from ..iliwrapper.ili2dbutils import JavaNotFoundError
+from ..iliwrapper.ilicompiler import IliCompiler
 from ..utils.qt_utils import OverrideCursor
 
 if TYPE_CHECKING:
@@ -160,6 +165,47 @@ class Ili2DbUtils(QObject):
             self._disconnect_ili_executable_signals(metaconfig_exporter)
 
         return res, msg
+
+    def compile(self, ili_file, base_configuration=None, imd_file=None):
+        if base_configuration is None:
+            base_configuration = BaseConfiguration()
+        compiler = IliCompiler()
+        compiler.configuration = Ili2CCommandConfiguration()
+        compiler.configuration.base_configuration = base_configuration
+        compiler.configuration.ilifile = ili_file
+        if imd_file:
+            compiler.configuration.imdfile = imd_file
+        else:
+            compiler.configuration.imdfile = os.path.join(
+                QStandardPaths.writableLocation(
+                    QStandardPaths.StandardLocation.TempLocation
+                ),
+                "temp_imd_{:%Y%m%d%H%M%S%f}.imd".format(datetime.datetime.now()),
+            )
+
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self._connect_ili_executable_signals(compiler)
+            self._log = ""
+
+            result = True
+            msg = self.tr("Model file successfully compiled to '{}'!").format(
+                compiler.configuration.imdfile
+            )
+
+            try:
+                compiler_result = compiler.run()
+                if compiler_result != compiler.SUCCESS:
+                    msg = self.tr("An error occurred when compiling {}").format(
+                        ili_file
+                    )
+                    result = False
+            except JavaNotFoundError as e:
+                msg = e.error_string
+                result = False
+
+            self._disconnect_ili_executable_signals(compiler)
+
+        return result, compiler.configuration.imdfile, msg
 
     def _connect_ili_executable_signals(self, ili_executable: IliExecutable) -> None:
         ili_executable.process_started.connect(self.process_started)

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -5,14 +5,20 @@ DEPRECATION=("deprecation" "2.1.0")
 PGSERVICEPARSER=("pgserviceparser" "2.2.1")
 TOPPINGMAKER=("toppingmaker" "1.6.0")
 
+XSDATA=("xsdata" "26.2")
+TYPINGEXTENSIONS=("typing-extensions" "4.16.0")
+
 PACKAGES=(
   DEPRECATION[@]
   PGSERVICEPARSER[@]
   TOPPINGMAKER[@]
+  XSDATA[@]
+  TYPINGEXTENSIONS[@]
 )
 
-#create lib folder
-mkdir -p $LIBS_DIR
+#recreate lib folder
+rm -rf "$LIBS_DIR"
+mkdir -p "$LIBS_DIR"
 
 for PACKAGE in ${PACKAGES[@]}; do
   echo download and unpack ${!PACKAGE:0:1} with version ${!PACKAGE:1:1}
@@ -24,9 +30,19 @@ for PACKAGE in ${PACKAGES[@]}; do
   unzip -o "temp/*.whl" -d $LIBS_DIR
   #remove temp folder
   rm -r temp
-  #set write rights to group (because qgis-plugin-ci needs it)
-  chmod -R g+w $LIBS_DIR
 done
+
+# ili2py not yet on pypi - we get it from the repo
+COMMIT="c0e815e2fec9b5a5410633c291098de393529160"
+echo get ili2py on commit "$COMMIT"
+git clone -q https://github.com/rudert-geoinformatik/ili2py.git temp_ili2py_git
+cd temp_ili2py_git && git checkout -q "$COMMIT" && cd - > /dev/null
+mv temp_ili2py_git/src/ili2py "$LIBS_DIR/"
+rm -rf temp_ili2py_git
+echo ili2py stored
+
+#set write rights to group (because qgis-plugin-ci needs it)
+chmod -R g+w $LIBS_DIR
 
 #create the __init__.py in libs folder
 cd $LIBS_DIR

--- a/tests/test_pythonizer.py
+++ b/tests/test_pythonizer.py
@@ -1,0 +1,538 @@
+"""
+Metadata:
+    Creation Date: 2026-07-07
+    Copyright: (C) 2026 by Dave Signer
+    Contact: david@opengis.ch
+
+License:
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the **GNU General Public License** as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+"""
+
+import os
+import sys
+import tempfile
+
+from qgis.testing import start_app, unittest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "modelbaker", "libs")
+)
+import modelbaker.libs.ili2py.interfaces.interlis.interlis_24.ilismeta.ilismeta16_2022_10_10 as ilismeta16
+from modelbaker.ili2pytools.pythonizer import BakerPyIndex
+from modelbaker.iliwrapper.ili2dbconfig import BaseConfiguration
+from modelbaker.utils.ili2db_utils import Ili2DbUtils
+from tests.utils import testdata_path
+
+start_app()
+
+
+class TestPythonizer(unittest.TestCase):
+    """
+    These tests are to check if the Index and the Library are correctly read by ili2db via the Pythonizer tools.
+    As well they should check the available functions of the extensions BakerPyIndex.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.basetestpath = tempfile.mkdtemp()
+        cls.base_config = BaseConfiguration()
+
+    def test_pythonizer_index_nupla(self):
+        """Tests index generation and queries with Nutzungsplanung_V1_2.
+
+        - Some BASKET OIDs in specific topics
+        - Some geometries
+        - Some enumerations
+        """
+        ili_file = testdata_path("ilimodels/Nutzungsplanung_V1_2.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+
+        model_name = "Nutzungsplanung_V1_2"
+
+        # some base index functions
+        # check the topics of Nutzungsplanung_V1_2
+        all_topics = index.submodel_in_package
+        nupla_topics = all_topics.get(model_name)
+        assert set(nupla_topics) == {
+            "Nutzungsplanung_V1_2.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Geobasisdaten",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften",
+            "Nutzungsplanung_V1_2.TransferMetadaten",
+        }
+
+        # check the index for basket oid definition in topics
+        bid_in_topics = index.basket_oid_in_submodel
+        # - has some in Catalogue_CH and Geobasisdaten
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.Catalogue_CH")
+        assert bid_definition
+        assert bid_definition == "Nutzungsplanung_V1_2.Catalogue_CH.BASKET"
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.Geobasisdaten")
+        assert bid_definition
+        assert bid_definition == "Nutzungsplanung_V1_2.Geobasisdaten.BASKET"
+        # - has none in Rechtsvorschriften and TransferMetadaten
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.Rechtsvorschriften")
+        assert not bid_definition
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.TransferMetadaten")
+        assert not bid_definition
+
+        # some baker py index functions
+        # check the relevant topics and classes (means includingt supers and dependencies)
+        all_topics = index.relevant_topics()
+        assert all_topics == {
+            "AdministrativeUnitsCH_V1.CHDistricts",
+            "AdministrativeUnitsCH_V1.CHCantons",
+            "AdministrativeUnits_V1.CountryNames",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften",
+            "Nutzungsplanung_V1_2.TransferMetadaten",
+            "AdministrativeUnits_V1.Countries",
+            "CoordSys.CoordsysTopic",
+            "AdministrativeUnitsCH_V1.CHAgencies",
+            "Nutzungsplanung_V1_2.Geobasisdaten",
+            "AdministrativeUnits_V1.AdministrativeUnits",
+            "AdministrativeUnits_V1.Agencies",
+            "INTERLIS.TIMESYSTEMS",
+            "DictionariesCH_V1.Dictionaries",
+            "AdministrativeUnitsCH_V1.CHAdministrativeUnions",
+            "Nutzungsplanung_V1_2.Catalogue_CH",
+            "Dictionaries_V1.Dictionaries",
+            "AdministrativeUnitsCH_V1.CHMunicipalities",
+        }
+        relevant_topics = index.relevant_topics(model_name)
+        assert relevant_topics == {
+            "Nutzungsplanung_V1_2.Rechtsvorschriften",
+            "Nutzungsplanung_V1_2.TransferMetadaten",
+            "Nutzungsplanung_V1_2.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Geobasisdaten",
+        }
+
+        all_models = index.relevant_models()
+        assert all_models == {
+            "Units",
+            "InternationalCodes_V1",
+            "GeometryCHLV03_V1",
+            "GeometryCHLV95_V1",
+            "Localisation_V1",
+            "LocalisationCH_V1",
+            "CHAdminCodes_V1",
+            "AdministrativeUnitsCH_V1",
+            "AdministrativeUnits_V1",
+            "CoordSys",
+            "DictionariesCH_V1",
+            "Dictionaries_V1",
+            "INTERLIS",
+            "Nutzungsplanung_V1_2",
+        }
+        relevant_models = index.relevant_models(relevant_topics)
+        assert relevant_models == {"Nutzungsplanung_V1_2"}
+
+        all_classes = index.relevant_classes()
+        assert all_classes == {
+            "INTERLIS.TIMESYSTEMS.CALENDAR",
+            "INTERLIS.TIMESYSTEMS.TIMEOFDAYSYS",
+            "Dictionaries_V1.Dictionaries.Dictionary",
+            "DictionariesCH_V1.Dictionaries.Dictionary",
+            "CoordSys.CoordsysTopic.Ellipsoid",
+            "CoordSys.CoordsysTopic.GravityModel",
+            "CoordSys.CoordsysTopic.GeoidModel",
+            "CoordSys.CoordsysTopic.GeoCartesian1D",
+            "CoordSys.CoordsysTopic.GeoHeight",
+            "CoordSys.CoordsysTopic.GeoCartesian2D",
+            "CoordSys.CoordsysTopic.GeoCartesian3D",
+            "CoordSys.CoordsysTopic.GeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian2D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.TransverseMercator",
+            "CoordSys.CoordsysTopic.SwissProjection",
+            "CoordSys.CoordsysTopic.Mercator",
+            "CoordSys.CoordsysTopic.ObliqueMercator",
+            "CoordSys.CoordsysTopic.Lambert",
+            "CoordSys.CoordsysTopic.Polyconic",
+            "CoordSys.CoordsysTopic.Albus",
+            "CoordSys.CoordsysTopic.Azimutal",
+            "CoordSys.CoordsysTopic.Stereographic",
+            "CoordSys.CoordsysTopic.HeightConversion",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnits_V1.Countries.Country",
+            "Dictionaries_V1.Dictionaries.Dictionary",
+            "AdministrativeUnits_V1.CountryNames.CountryNamesTranslation",
+            "AdministrativeUnits_V1.Agencies.Organisation",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHCantons.CHCanton",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHDistricts.CHDistrict",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHMunicipalities.CHMunicipality",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHAdministrativeUnions.AdministrativeUnion",
+            "AdministrativeUnits_V1.Agencies.Organisation",
+            "AdministrativeUnitsCH_V1.CHAgencies.Agency",
+            "Nutzungsplanung_V1_2.Catalogue_CH.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Kt",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Linienbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Objektbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Geometrie_Dokument",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Amt",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Datenbestand",
+        }
+
+        relevant_classes = index.relevant_classes(relevant_topics)
+        assert relevant_classes == {
+            "Nutzungsplanung_V1_2.Catalogue_CH.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Kt",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Linienbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Objektbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Geometrie_Dokument",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Amt",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Datenbestand",
+        }
+        relevant_geometric_attributes = index.relevant_geometric_attributes_per_class(
+            list(relevant_topics)
+        )
+        assert relevant_geometric_attributes[
+            "Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche"
+        ] == ["Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche.Geometrie"]
+        assert relevant_geometric_attributes[
+            "Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung"
+        ] == ["Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung.Geometrie"]
+
+        # check if it returns a library object (if not none)
+        library = index.library_object()
+        assert library
+
+        # check some attribute types
+        assert isinstance(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Geobasisdaten.Typ.Nutzungsziffer"
+            ),
+            ilismeta16.NumType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument.Rechtsstatus"
+            ),
+            ilismeta16.EnumType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument.TextImWeb"
+            ),
+            ilismeta16.MultiValue,
+        )
+
+        # and enumerations
+        enumeration_object = index.enumeration_object(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument.Rechtsstatus"
+            )
+        )
+        assert set(enumeration_object.values) == {
+            "inKraft",
+            "AenderungMitVorwirkung",
+            "AenderungOhneVorwirkung",
+        }
+
+    def test_pythonizer_index_kbs(self):
+        """Tests index generation and queries with KbS_V1_5.
+
+        - No BASKET OIDs
+        - Some geometries
+        - Some enumerations
+        """
+
+        ili_file = testdata_path("ilimodels/KbS_V1_5.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+
+        model_name = "KbS_V1_5"
+        # some base index functions
+        # check the topics of KbS_V1_5
+        all_topics = index.submodel_in_package
+        kbs_topics = all_topics.get(model_name)
+        assert set(kbs_topics) == {
+            "KbS_V1_5.Codelisten",
+            "KbS_V1_5.Belastete_Standorte",
+        }
+
+        # check the index for basket oid definition in topics
+        bid_in_topics = index.basket_oid_in_submodel
+        # - has none in Codelisten and Belastete_Standorte
+        bid_definition = bid_in_topics.get("KbS_V1_5.Codelisten")
+        assert not bid_definition
+        bid_definition = bid_in_topics.get("KbS_V1_5.Belastete_Standorte")
+        assert not bid_definition
+
+        # some baker py index convenience functions
+        # check the relevant topics and classes (means includingt supers and dependencies)
+        all_topics = index.relevant_topics()
+        assert all_topics == {
+            "Dictionaries_V1.Dictionaries",
+            "DictionariesCH_V1.Dictionaries",
+            "INTERLIS.TIMESYSTEMS",
+            "KbS_V1_5.Belastete_Standorte",
+            "KbS_V1_5.Codelisten",
+            "CoordSys.CoordsysTopic",
+        }
+        relevant_topics = index.relevant_topics(model_name)
+        assert relevant_topics == {
+            "KbS_V1_5.Codelisten",
+            "KbS_V1_5.Belastete_Standorte",
+        }
+
+        all_models = index.relevant_models()
+        assert all_models == {
+            "Units",
+            "InternationalCodes_V1",
+            "GeometryCHLV03_V1",
+            "GeometryCHLV95_V1",
+            "LocalisationCH_V1",
+            "Localisation_V1",
+            "CoordSys",
+            "DictionariesCH_V1",
+            "Dictionaries_V1",
+            "INTERLIS",
+            "KbS_V1_5",
+        }
+        relevant_models = index.relevant_models(relevant_topics)
+        assert relevant_models == {"KbS_V1_5"}
+
+        all_classes = index.relevant_classes()
+        assert all_classes == {
+            "INTERLIS.TIMESYSTEMS.CALENDAR",
+            "INTERLIS.TIMESYSTEMS.TIMEOFDAYSYS",
+            "Dictionaries_V1.Dictionaries.Dictionary",
+            "DictionariesCH_V1.Dictionaries.Dictionary",
+            "CoordSys.CoordsysTopic.Ellipsoid",
+            "CoordSys.CoordsysTopic.GravityModel",
+            "CoordSys.CoordsysTopic.GeoidModel",
+            "CoordSys.CoordsysTopic.GeoCartesian1D",
+            "CoordSys.CoordsysTopic.GeoHeight",
+            "CoordSys.CoordsysTopic.GeoCartesian2D",
+            "CoordSys.CoordsysTopic.GeoCartesian3D",
+            "CoordSys.CoordsysTopic.GeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian2D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.TransverseMercator",
+            "CoordSys.CoordsysTopic.SwissProjection",
+            "CoordSys.CoordsysTopic.Mercator",
+            "CoordSys.CoordsysTopic.ObliqueMercator",
+            "CoordSys.CoordsysTopic.Lambert",
+            "CoordSys.CoordsysTopic.Polyconic",
+            "CoordSys.CoordsysTopic.Albus",
+            "CoordSys.CoordsysTopic.Azimutal",
+            "CoordSys.CoordsysTopic.Stereographic",
+            "CoordSys.CoordsysTopic.HeightConversion",
+            "KbS_V1_5.Codelisten.Deponietyp_Definition",
+            "KbS_V1_5.Codelisten.Standorttyp_Definition",
+            "KbS_V1_5.Codelisten.StatusAltlV_Definition",
+            "KbS_V1_5.Codelisten.Untersuchungsmassnahmen_Definition",
+            "KbS_V1_5.Belastete_Standorte.ZustaendigkeitKataster",
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort",
+        }
+        relevant_classes = index.relevant_classes(relevant_topics)
+        assert relevant_classes == {
+            "KbS_V1_5.Codelisten.Deponietyp_Definition",
+            "KbS_V1_5.Codelisten.Standorttyp_Definition",
+            "KbS_V1_5.Codelisten.StatusAltlV_Definition",
+            "KbS_V1_5.Codelisten.Untersuchungsmassnahmen_Definition",
+            "KbS_V1_5.Belastete_Standorte.ZustaendigkeitKataster",
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort",
+        }
+        relevant_geometric_attributes = index.relevant_geometric_attributes_per_class(
+            relevant_topics
+        )
+        assert relevant_geometric_attributes[
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort"
+        ] == [
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Geo_Lage_Polygon",
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Geo_Lage_Punkt",
+        ]
+
+        # check some attribute types
+        assert isinstance(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.InBetrieb"
+            ),
+            ilismeta16.BooleanType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Katasternummer"
+            ),
+            ilismeta16.TextType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Standorttyp"
+            ),
+            ilismeta16.EnumType,
+        )
+
+        # check if it returns a library object (if not none)
+        library = index.library_object()
+        assert library
+
+        # and enumerations
+        enumeration_object = index.enumeration_object(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Standorttyp"
+            )
+        )
+        assert set(enumeration_object.values) == {
+            "StaoTyp1",
+            "StaoTyp2",
+            "StaoTyp3",
+            "StaoTyp4",
+        }
+
+    def test_pythonizer_index_color_enums(self):
+        """Tests index generation and queries with Colors_V2.
+
+        - No BASKET OIDs
+        - Some geometries
+        - Some enumerations
+        """
+
+        ili_file = testdata_path("ilimodels/ColorsParentChildDomain_V2.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+
+        model_name = "Colors_V2"
+        # some base index functions
+        # check the topics of Colors_V2
+        all_topics = index.submodel_in_package
+        colors_topics = all_topics.get(model_name)
+        assert set(colors_topics) == {"Colors_V2.SomeColors"}
+
+        # check the index for basket oid definition in topics
+        bid_in_topics = index.basket_oid_in_submodel
+        # - has none in Colors_V2
+        bid_definition = bid_in_topics.get("Colors_V2.SomeColors")
+        assert not bid_definition
+
+        # some baker py index convenience functions
+        # check the relevant topics and classes (means includingt supers and dependencies)
+        all_topics = index.relevant_topics()
+        assert all_topics == {"INTERLIS.TIMESYSTEMS", "Colors_V2.SomeColors"}
+        relevant_topics = index.relevant_topics(model_name)
+        assert relevant_topics == {
+            "Colors_V2.SomeColors",
+        }
+
+        all_models = index.relevant_models()
+        assert all_models == {
+            "INTERLIS",
+            "Colors_V2",
+        }
+        relevant_models = index.relevant_models(relevant_topics)
+        assert relevant_models == {"Colors_V2"}
+
+        all_classes = index.relevant_classes()
+        assert all_classes == {
+            "INTERLIS.TIMESYSTEMS.CALENDAR",
+            "INTERLIS.TIMESYSTEMS.TIMEOFDAYSYS",
+            "Colors_V2.SomeColors.BaseColorClass",
+            "Colors_V2.SomeColors.BlueChildColorClass",
+            "Colors_V2.SomeColors.UninheritedCMYColorClass",
+            "Colors_V2.SomeColors.GreenChildColorClass",
+        }
+        relevant_classes = index.relevant_classes(relevant_topics)
+        assert relevant_classes == {
+            "Colors_V2.SomeColors.BaseColorClass",
+            "Colors_V2.SomeColors.BlueChildColorClass",
+            "Colors_V2.SomeColors.UninheritedCMYColorClass",
+            "Colors_V2.SomeColors.GreenChildColorClass",
+        }
+        relevant_geometric_attributes = index.relevant_geometric_attributes_per_class(
+            relevant_topics
+        )
+        assert relevant_geometric_attributes == {}
+
+        # check some attribute types - all enums - this is the interresting part of this test case.
+        base_type = index.attribute_type("Colors_V2.SomeColors.BaseColorClass.Colors")
+        assert isinstance(
+            base_type,
+            ilismeta16.EnumType,
+        )
+        assert base_type.name == "Colors"
+        assert base_type.tid == "Colors_V2.Colors"
+
+        blue_type = index.attribute_type(
+            "Colors_V2.SomeColors.BlueChildColorClass.Colors"
+        )
+        assert isinstance(
+            blue_type,
+            ilismeta16.EnumType,
+        )
+        assert blue_type.name == "BlueChildColors"
+        assert blue_type.tid == "Colors_V2.BlueChildColors"
+
+        green_type = index.attribute_type(
+            "Colors_V2.SomeColors.GreenChildColorClass.Colors"
+        )
+        assert isinstance(
+            green_type,
+            ilismeta16.EnumType,
+        )
+        assert green_type.name == "GreenChildColors"
+        assert green_type.tid == "Colors_V2.GreenChildColors"
+
+        # check if it returns a library object (if not none)
+        library = index.library_object()
+        assert library
+
+        # and enumerations
+        base_enumeration_object = index.enumeration_object(
+            index.attribute_type("Colors_V2.SomeColors.BaseColorClass.Colors")
+        )
+        assert set(base_enumeration_object.values) == {"Green", "Red", "Blue"}
+
+        blue_enumeration_object = index.enumeration_object(
+            index.attribute_type("Colors_V2.SomeColors.BlueChildColorClass.Colors")
+        )
+        assert set(blue_enumeration_object.values) == {
+            "Blue.Dark_Blue",
+            "Blue.Light_Blue",
+            "Blue.Medium_Blue",
+        }
+
+        green_enumeration_object = index.enumeration_object(
+            index.attribute_type("Colors_V2.SomeColors.GreenChildColorClass.Colors")
+        )
+        assert set(green_enumeration_object.values) == {
+            "Green.Dark_Green",
+            "Green.Light_Green",
+            "Green.Medium_Green",
+        }


### PR DESCRIPTION
***Follow-up of https://github.com/opengisch/QgisModelBakerLibrary/pull/160 - do not merge before***


It's the base of the SettingProphet: #175

## ili2c utility in `utils` folder

5e67e7cd7ad9db46c425e79474d6144937dc7ebb

- Read the INTERLIS model from an existing database created with ili2db (from the meta-tables). 
- Compile function to quickly be able to create a metamodel-xml (IMD) from a model (ILI) file.

## ili2py integration

Integration of the `ili2py` library and a bridge class `BakerPyIndex` to get information from the metamodel and create the enumeration or the Python classes (via library) from it.

434d2dd8842bef14c21ea6aa287e6c4a578a2517

- Install scripts for `ili2py` (because ili2py is not published on PyPI at the moment, this is done over GitHub) and additional packages used by ili2py (like `xsdata` and via xsdata, `typing-extensions`). 
- Bridge class `BakerPyIndex` implemented in `ili2pytools.pythonizer`, extending ili2py `Index`, reading the metamodel from imd, and initializing itself.

## Structure
## Structure
```
├── ili2pytools
│   ├── init.py
│   ├── pythonizer.py
|   |   - BakerPyIndex()
|   |     - initializes itself and the base ili2py helper.Index via factory-method from_imd with the ili2py reader
|   |     - library_object returns Library
|   |     - enumeration_object returns Enumeration
|   |     - convenience functions to receive relevant classes and models, relevant geometry columns per class, attribute types and more (see method docstrings)
├── [...]
├── libs
│   ├── [...]
│   ├── ili2py
```

## Info 

To run in the plugin, this is needed: https://github.com/opengisch/QgisModelBaker/pull/1148

## Sponsors

QGIS Model Baker Group :v: