### PR TITLE
Fix that booleans are wrongly detected as enumerations (well they are…

### DIFF
--- a/modelbaker/dbconnector/gpkg_connector.py
+++ b/modelbaker/dbconnector/gpkg_connector.py
@@ -549,7 +549,7 @@ class GPKGConnector(DBConnector):
                         """SELECT '{GPKG_ENUM_TABLE}' as 'table', p.columnname as 'from'
                         FROM T_ILI2DB_COLUMN_PROP p
                         WHERE tablename = ?
-                        and tag = 'ch.ehi.ili2db.enumDomain'
+                        and tag = 'ch.ehi.ili2db.enumDomain' AND setting != 'INTERLIS.BOOLEAN'
                     """.format(  # nosec
                             GPKG_ENUM_TABLE=GPKG_ENUM_TABLE
                         ),
@@ -569,6 +569,7 @@ class GPKGConnector(DBConnector):
                         ON c.iliname=p.setting
                         WHERE tablename = ?
                         and tag = 'ch.ehi.ili2db.enumDomain'
+                        and c.iliname != 'INTERLIS.BOOLEAN'
                     """,
                         (table_info_name,),
                     )

--- a/modelbaker/dbconnector/pg_connector.py
+++ b/modelbaker/dbconnector/pg_connector.py
@@ -824,7 +824,7 @@ class PGConnector(DBConnector):
                     UNION SELECT CONCAT( p.tablename, '_', p.columnname, '_enumkey') AS constraint_name, p.tablename AS referencing_table, p.columnname AS referencing_column, '{schema}' AS constraint_schema, {target_table} AS referenced_table, 'ilicode' AS referenced_column, 1 AS ordinal_position,
                     NULL AS strength, NULL AS cardinality_max, NULL AS cardinality_min, NULL AS assoc_cardinality_max, NULL AS assoc_cardinality_min{translate}
                     FROM {schema}.T_ILI2DB_COLUMN_PROP p
-                    {target_table_join} tag = 'ch.ehi.ili2db.enumDomain'
+                    {target_table_join} tag = 'ch.ehi.ili2db.enumDomain' AND setting != 'INTERLIS.BOOLEAN'
                     ) all_relations
                     ORDER BY referencing_table, referencing_column, referenced_column DESC
                     ) relations_without_duplicates """.format(  # nosec

--- a/tests/test_domain_class_relations.py
+++ b/tests/test_domain_class_relations.py
@@ -4194,6 +4194,10 @@ class TestDomainClassRelation(unittest.TestCase):
                     == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
 
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
                 count += 1
 
             if layer.alias == "UninheritedCMYColorClass":
@@ -4312,6 +4316,11 @@ class TestDomainClassRelation(unittest.TestCase):
                     == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
 
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "UninheritedCMYColorClass":
@@ -4399,6 +4408,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert (
                     config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
                 )
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "BlueChildColorClass":
@@ -4526,6 +4541,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert (
                     config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
                 )
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "BlueChildColorClass":
@@ -4644,6 +4665,12 @@ class TestDomainClassRelation(unittest.TestCase):
         for layer in available_layers:
             if layer.alias == "BaseColorClass":
                 # It's technically not possible to have a sollution here, because the enumeration types are in a different table
+
+                # But we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
             if layer.alias == "UninheritedCMYColorClass":
                 field = layer.layer.fields().field("colors")
@@ -4718,6 +4745,12 @@ class TestDomainClassRelation(unittest.TestCase):
         for layer in available_layers:
             if layer.alias == "BaseColorClass":
                 # It's technically not possible to have a sollution here, because the enumeration types are in a different table
+
+                # But we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
             if layer.alias == "UninheritedCMYColorClass":
                 field = layer.layer.fields().field("colors")
@@ -4796,6 +4829,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["FilterExpression"] == ""
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "BlueChildColorClass":
@@ -4912,6 +4951,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 config = field.editorWidgetSetup().config()
                 assert qgis_project.mapLayer(config["Layer"]).name() == "Colors"
                 assert config["FilterExpression"] == ""
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "BlueChildColorClass":
@@ -5057,6 +5102,12 @@ class TestDomainClassRelation(unittest.TestCase):
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "UninheritedCMYColorClass":
@@ -5169,6 +5220,12 @@ class TestDomainClassRelation(unittest.TestCase):
                     config["FilterExpression"]
                     == "\"thisclass\" = 'Colors_V2.GreenChildColors'"
                 )
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "UninheritedCMYColorClass":
@@ -5252,6 +5309,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert (
                     config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
                 )
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "BlueChildColorClass":
@@ -5375,6 +5438,12 @@ class TestDomainClassRelation(unittest.TestCase):
                 assert (
                     config["FilterExpression"] == "\"thisclass\" = 'Colors_V2.Colors'"
                 )
+
+                # And we test whether booleans are not handled as enumerations (special case: INTERLIS.BOOLEAN is an enumeration, but should be handled as boolean)
+                field = layer.layer.fields().field("abooleanisanenum")
+                type = field.editorWidgetSetup().type()
+                self.assertNotEqual(type, "ValueRelation")
+
                 count += 1
 
             if layer.alias == "BlueChildColorClass":

--- a/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
+++ b/tests/testdata/ilimodels/ColorsParentChildDomain_V2.ili
@@ -44,6 +44,7 @@ VERSION "2020-08-26"  =
 
     CLASS BaseColorClass =
       Colors : Colors_V2.Colors;
+      ABooleanIsAnEnum : BOOLEAN;
     END BaseColorClass;
 
     CLASS BlueChildColorClass


### PR DESCRIPTION
… enumerations (INTERLIS.BOOLEAN) but ili2db creates them as boolean) so we should not detect it as a relation (or fake relation)