### PR TITLE
Settings prophet to get information of model via ili2py

### DIFF
--- a/modelbaker/ili2pytools/prophets.py
+++ b/modelbaker/ili2pytools/prophets.py
@@ -71,11 +71,7 @@ class ModelProphet(QObject):
         return False
 
     def has_enumerations(self) -> bool:
-        """Returns whether the relevant models/topics contain enumerations.
-
-        This is relevant because without enumerations the enumeration ili2db option
-        makes no sense.
-        """
+        """Returns whether the relevant models/topics contain enumerations."""
         relevant_enums = self.index.relevant_enumeration_definitions(
             self.relevant_topics
         )
@@ -84,11 +80,7 @@ class ModelProphet(QObject):
         return False
 
     def has_extended_enumerations(self) -> bool:
-        """Returns whether the relevant models/topics contain extended enumerations.
-
-        This is relevant because ``--createEnumTabs`` does not work with smart1
-        inheritance when extended enumerations exist.
-        """
+        """Returns whether the relevant models/topics contain extended enumerations."""
         supers = self.index.enumeration_supers
         if not supers:
             return False
@@ -102,10 +94,7 @@ class ModelProphet(QObject):
         return False
 
     def has_arcs(self) -> bool:
-        """Returns whether any class in the relevant topics uses arcs.
-
-        This is relevant because without arcs the stroke arcs option makes no sense.
-        """
+        """Returns whether any class in the relevant topics uses arcs."""
         # get all the geometric attributes of the relevant classes
         relevant_geometric_attributes = self._relevant_geometric_attributes()
 
@@ -122,11 +111,7 @@ class ModelProphet(QObject):
         )
 
     def has_multiple_geometry_columns(self) -> bool:
-        """Returns whether any class in the relevant topics has multiple geometry columns.
-
-        This is relevant because without them the GeoPackage multi geometry option
-        makes no sense.
-        """
+        """Returns whether any class in the relevant topics has multiple geometry columns."""
         relevant_geometric_attributes_per_class = (
             self.index.relevant_geometric_attributes_per_class(self.relevant_topics)
         )
@@ -194,65 +179,135 @@ class ModelProphet(QObject):
         return languages
 
 
-class SettingsProphet(ModelProphet):
-    """Suggests ili2db command settings based on the model properties."""
+class SettingsProphet(QObject):
+    """Suggests ili2db command settings based on the models properties.
+    This Prophet can handle multiple models and will return the union of all relevant settings.
+    It uses the ModelProphet to get the relevant information for each model."""
 
     def __init__(
         self,
-        index: BakerPyIndex,
-        model_name: str = None,
+        model_indexes: dict[str, BakerPyIndex],
         model_blacklist: list = None,
         log_function=None,
     ) -> None:
         """Initializes the settings prophet.
 
         Args:
-            index: The index.
-            model_name: The model we require the settings for. If None, all models are considered.
+            model_indexes: A dictionary of model indexes, based on str (model_name) -> BakerPyIndex.
             model_blacklist: Model names to exclude (e.g. technical models).
             log_function: Optional logging callback.
         """
-        super().__init__(index, model_name, model_blacklist, log_function)
+        self.model_prophets = {}
+        for model_name in model_indexes.keys():
+            index = model_indexes[model_name]
+            model_prophet = ModelProphet(
+                index=index,
+                model_name=model_name,
+                model_blacklist=model_blacklist,
+                log_function=log_function,
+            )
+            self.model_prophets[model_name] = model_prophet
+
+    def contains_enumerations(self) -> bool:
+        """Returns whether any relevant model/topic of one model contains enumerations.
+
+        This is relevant because without enumerations the enumeration ili2db option
+        makes no sense.
+        """
+        for model_prophet in self.model_prophets.values():
+            if model_prophet.has_enumerations():
+                return True
+        return False
+
+    def contains_extended_enumerations(self) -> bool:
+        """Returns whether the relevant models/topics of one model contain extended enumerations.
+
+        This is relevant because ``--createEnumTabs`` does not work with smart1
+        inheritance when extended enumerations exist.
+        """
+        for model_prophet in self.model_prophets.values():
+            if model_prophet.has_extended_enumerations():
+                return True
+        return False
+
+    def contains_arcs(self) -> bool:
+        """Returns whether any class in the relevant topics of one model uses arcs.
+
+        This is relevant because without arcs the stroke arcs option makes no sense.
+        """
+        for model_prophet in self.model_prophets.values():
+            if model_prophet.has_arcs():
+                return True
+        return False
+
+    def contains_multiple_geometry_columns(self) -> bool:
+        """Returns whether any class in the relevant topics of one model has multiple geometry columns.
+
+        This is relevant because without them the GeoPackage multi geometry option
+        makes no sense.
+        """
+        for model_prophet in self.model_prophets.values():
+            if model_prophet.has_multiple_geometry_columns():
+                return True
+        return False
 
     def needs_basket_column(self) -> bool:
-        """Returns whether a basket column is required.
+        """Returns whether a basket column is required in one of the models.
 
         A basket column is required when a relevant topic defines a basket OID
         or extends another topic.
         This is relevant to know because when one of those is true, the
         ``--createBasketColumn`` option is then not optional.
         """
-        return self.has_basket_oids() or self.has_extended_topics()
+        for model_prophet in self.model_prophets.values():
+            if model_prophet.has_basket_oids() or model_prophet.has_extended_topics():
+                return True
+        return False
 
     def language_infos(self) -> tuple[bool, list[str], str | None]:
         """Detects translation state and returns language information.
 
         Detection is based on comparing all (blacklist-filtered) models and
         languages against the relevant ones. If additional models/languages
-        exist, the model is treated as a translation model.
+        exist, the model is treated as a translation model. If there is more than one
+        translated model (what rarely makes sense), the last one is assumed to be the original language.
         This is a heuristic and may not be accurate in all cases.
 
         Returns:
             A tuple of (is_translation, languages, preferred_language), where
             preferred_language is the assumed original language.
         """
-        filtered_models = self.filtered_models()
-        relevant_models = self.relevant_models()
-        languages_of_relevant_models = self.available_languages(relevant_models)
-        languages = self.available_languages(filtered_models)
+        is_translation = False
+        all_languages = []
+        preferred_language = None
 
-        if len(filtered_models) == len(relevant_models):
-            # when there are not more models than the relevant ones, then it is not a translation model.
-            return False, languages, languages_of_relevant_models[0]
-        if len(languages) == len(languages_of_relevant_models):
-            # when there are not more languages than the relevant ones, then it is not a translation model.
-            return False, languages, languages_of_relevant_models[0]
+        for model_prophet in self.model_prophets.values():
+            filtered_models = model_prophet.filtered_models()
+            relevant_models = model_prophet.relevant_models()
+            languages_of_relevant_models = model_prophet.available_languages(
+                relevant_models
+            )
+            languages = model_prophet.available_languages(filtered_models)
 
-        # otherwise we assume it's a translation model and we return the languages
-        # and the preferred language (the first one of the ones that are not relevant (because this might be the original)).
-        original_languages = []
-        for lang in languages:
-            if lang not in languages_of_relevant_models:
-                original_languages.append(lang)
+            if len(filtered_models) == len(relevant_models) or len(languages) == len(
+                languages_of_relevant_models
+            ):
+                # when there are not more models than the relevant ones, then it is not a translation model.
+                # when there are not more languages than the relevant ones, then it is not a translation model.
+                is_translation = False
+                all_languages.extend(languages)
+                preferred_language = None
+            else:
+                # otherwise we assume it's a translation model and we return the languages
+                # and the preferred language (the first one of the ones that are not relevant (because this might be the original)).
+                original_languages = []
+                for lang in languages:
+                    if lang not in languages_of_relevant_models:
+                        original_languages.append(lang)
+                is_translation = True
+                all_languages.extend(languages)
+                preferred_language = (
+                    original_languages[0] if original_languages else None
+                )
 
-        return True, languages, original_languages[0] if original_languages else None
+        return is_translation, all_languages, preferred_language

--- a/modelbaker/ili2pytools/prophets.py
+++ b/modelbaker/ili2pytools/prophets.py
@@ -294,9 +294,10 @@ class SettingsProphet(QObject):
             ):
                 # when there are not more models than the relevant ones, then it is not a translation model.
                 # when there are not more languages than the relevant ones, then it is not a translation model.
-                is_translation = False
-                all_languages.extend(languages)
-                preferred_language = None
+                for language in languages:
+                    if language not in all_languages:
+                        all_languages.append(language)
+                # we don't update the preferred language and the is_translation flag, because when we already found a translation model.
             else:
                 # otherwise we assume it's a translation model and we return the languages
                 # and the preferred language (the first one of the ones that are not relevant (because this might be the original)).
@@ -305,7 +306,9 @@ class SettingsProphet(QObject):
                     if lang not in languages_of_relevant_models:
                         original_languages.append(lang)
                 is_translation = True
-                all_languages.extend(languages)
+                for language in languages:
+                    if language not in all_languages:
+                        all_languages.append(language)
                 preferred_language = (
                     original_languages[0] if original_languages else None
                 )

--- a/modelbaker/ili2pytools/prophets.py
+++ b/modelbaker/ili2pytools/prophets.py
@@ -1,0 +1,258 @@
+"""
+Metadata:
+    Creation Date: 2026-07-07
+    Copyright: (C) 2026 by Dave Signer
+    Contact: david@opengis.ch
+
+License:
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the **GNU General Public License** as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+"""
+
+from qgis.PyQt.QtCore import QObject
+
+from modelbaker.ili2pytools.pythonizer import BakerPyIndex
+
+from ..utils.globals import default_log_function
+
+
+class ModelProphet(QObject):
+    """Provides model insights derived from a ``BakerPyIndex`` for a given model."""
+
+    def __init__(
+        self,
+        index: BakerPyIndex,
+        model_name: str = None,
+        model_blacklist: list = None,
+        log_function=None,
+    ) -> None:
+        """Initializes the prophet.
+
+        Args:
+            index: The index.
+            model_name: The model we require the info for. If None, all models are considered.
+            model_blacklist: Model names to exclude (e.g. technical models).
+            log_function: Optional logging callback.
+        """
+        QObject.__init__(self)
+
+        self.log_function = log_function if log_function else default_log_function
+        if not log_function:
+            self.log_function = default_log_function
+
+        self.index = index
+        self.model_name = model_name
+        self.model_blacklist = model_blacklist
+        self.relevant_topics = self.index.relevant_topics(model_name=self.model_name)
+
+    def has_basket_oids(self) -> bool:
+        """Returns whether any relevant topic defines a basket OID."""
+        bid_in_topics = self.index.basket_oid_in_submodel
+
+        bid_in_relevant_topics = {
+            topic: bid_in_topics[topic]
+            for topic in self.relevant_topics
+            if topic in bid_in_topics
+        }
+        if len(bid_in_relevant_topics.keys()):
+            return True
+        return False
+
+    def has_extended_topics(self) -> bool:
+        """Returns whether any relevant topic extends another topic."""
+        # check if one of the relevant topics is a parent topic of an extension
+        supers = self.index.data_unit_supers
+        for topic in self.relevant_topics:
+            basket = self.index.topic_basket.get(topic)
+            if basket and basket in supers:
+                return True
+        return False
+
+    def has_enumerations(self) -> bool:
+        """Returns whether the relevant models/topics contain enumerations.
+
+        This is relevant because without enumerations the enumeration ili2db option
+        makes no sense.
+        """
+        relevant_enums = self.index.relevant_enumeration_definitions(
+            self.relevant_topics
+        )
+        if relevant_enums:
+            return True
+        return False
+
+    def has_extended_enumerations(self) -> bool:
+        """Returns whether the relevant models/topics contain extended enumerations.
+
+        This is relevant because ``--createEnumTabs`` does not work with smart1
+        inheritance when extended enumerations exist.
+        """
+        supers = self.index.enumeration_supers
+        if not supers:
+            return False
+
+        relevant_enums = self.index.relevant_enumeration_definitions(
+            self.relevant_topics
+        )
+        for tid in relevant_enums:
+            if tid in supers.keys():
+                return True
+        return False
+
+    def has_arcs(self) -> bool:
+        """Returns whether any class in the relevant topics uses arcs.
+
+        This is relevant because without arcs the stroke arcs option makes no sense.
+        """
+        # get all the geometric attributes of the relevant classes
+        relevant_geometric_attributes = self._relevant_geometric_attributes()
+
+        # get the line form of the relevant geometry attributes
+        line_forms = self.index.geometric_attributes_line_form
+        line_forms_of_interest = []
+        for attribute in line_forms.keys():
+            if attribute in relevant_geometric_attributes:
+                line_forms_of_interest += line_forms[attribute]
+
+        return bool(
+            "INTERLIS.ARCS" in line_forms_of_interest
+            or "ARCS" in line_forms_of_interest
+        )
+
+    def has_multiple_geometry_columns(self) -> bool:
+        """Returns whether any class in the relevant topics has multiple geometry columns.
+
+        This is relevant because without them the GeoPackage multi geometry option
+        makes no sense.
+        """
+        relevant_geometric_attributes_per_class = (
+            self.index.relevant_geometric_attributes_per_class(self.relevant_topics)
+        )
+        if any(
+            len(columns) > 1
+            for columns in relevant_geometric_attributes_per_class.values()
+        ):
+            return True
+        return False
+
+    def filtered_models(self) -> set:
+        """Returns the models excluding the blacklisted ones.
+
+        Returns:
+            A set of model names.
+        """
+        return set(self.index.models) - set(self.model_blacklist or [])
+
+    def relevant_models(self) -> set:
+        """Returns the models according to the relevant topics.
+
+        Returns:
+            A set of model names.
+        """
+        return self.index.relevant_models(self.relevant_topics)
+
+    def filtered_relevant_models(self) -> set:
+        """Returns the relevant models according to the relevant topics excluding the blacklisted models.
+
+        Returns:
+            A set of model names.
+        """
+        return set(self.index.relevant_models(self.relevant_topics)) - set(
+            self.model_blacklist or []
+        )
+
+    def _relevant_geometric_attributes(self) -> list:
+        """Returns a flat list of geometric attributes for the relevant topics.
+
+        Returns:
+            A list of geometric attribute tids.
+        """
+        relevant_geometric_attributes = []
+        relevant_geometric_attributes_per_class = (
+            self.index.relevant_geometric_attributes_per_class(self.relevant_topics)
+        )
+        for relevant_classname in relevant_geometric_attributes_per_class.keys():
+            relevant_geometric_attributes += relevant_geometric_attributes_per_class[
+                relevant_classname
+            ]
+        return relevant_geometric_attributes
+
+    def available_languages(self, models: list = None) -> list:
+        """Returns all the found languages of the given models.
+
+        This is relevant when one model is a translation model.
+
+        Args:
+            models: The models to consider. If None, all models are considered.
+
+        Returns:
+            A list of language codes.
+        """
+        languages = self.index.languages(models)
+        return languages
+
+
+class SettingsProphet(ModelProphet):
+    """Suggests ili2db command settings based on the model properties."""
+
+    def __init__(
+        self,
+        index: BakerPyIndex,
+        model_name: str = None,
+        model_blacklist: list = None,
+        log_function=None,
+    ) -> None:
+        """Initializes the settings prophet.
+
+        Args:
+            index: The index.
+            model_name: The model we require the settings for. If None, all models are considered.
+            model_blacklist: Model names to exclude (e.g. technical models).
+            log_function: Optional logging callback.
+        """
+        super().__init__(index, model_name, model_blacklist, log_function)
+
+    def needs_basket_column(self) -> bool:
+        """Returns whether a basket column is required.
+
+        A basket column is required when a relevant topic defines a basket OID
+        or extends another topic.
+        This is relevant to know because when one of those is true, the
+        ``--createBasketColumn`` option is then not optional.
+        """
+        return self.has_basket_oids() or self.has_extended_topics()
+
+    def language_infos(self) -> tuple[bool, list[str], str | None]:
+        """Detects translation state and returns language information.
+
+        Detection is based on comparing all (blacklist-filtered) models and
+        languages against the relevant ones. If additional models/languages
+        exist, the model is treated as a translation model.
+        This is a heuristic and may not be accurate in all cases.
+
+        Returns:
+            A tuple of (is_translation, languages, preferred_language), where
+            preferred_language is the assumed original language.
+        """
+        filtered_models = self.filtered_models()
+        relevant_models = self.relevant_models()
+        languages_of_relevant_models = self.available_languages(relevant_models)
+        languages = self.available_languages(filtered_models)
+
+        if len(filtered_models) == len(relevant_models):
+            # when there are not more models than the relevant ones, then it is not a translation model.
+            return False, languages, languages_of_relevant_models[0]
+        if len(languages) == len(languages_of_relevant_models):
+            # when there are not more languages than the relevant ones, then it is not a translation model.
+            return False, languages, languages_of_relevant_models[0]
+
+        # otherwise we assume it's a translation model and we return the languages
+        # and the preferred language (the first one of the ones that are not relevant (because this might be the original)).
+        original_languages = []
+        for lang in languages:
+            if lang not in languages_of_relevant_models:
+                original_languages.append(lang)
+
+        return True, languages, original_languages[0] if original_languages else None

--- a/modelbaker/ili2pytools/prophets.py
+++ b/modelbaker/ili2pytools/prophets.py
@@ -182,7 +182,8 @@ class ModelProphet(QObject):
 class SettingsProphet(QObject):
     """Suggests ili2db command settings based on the models properties.
     This Prophet can handle multiple models and will return the union of all relevant settings.
-    It uses the ModelProphet to get the relevant information for each model."""
+    It uses the ModelProphet to get the relevant information for each model.
+    """
 
     def __init__(
         self,

--- a/modelbaker/ili2pytools/pythonizer.py
+++ b/modelbaker/ili2pytools/pythonizer.py
@@ -1,0 +1,331 @@
+"""
+Metadata:
+    Creation Date: 2026-07-07
+    Copyright: (C) 2026 by Dave Signer
+    Contact: david@opengis.ch
+
+License:
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the **GNU General Public License** as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+"""
+import os
+
+from modelbaker.libs.ili2py.interfaces.interlis.interlis_24.ilismeta.ilismeta16_2022_10_10.enum_type import (
+    EnumType,
+)
+from modelbaker.libs.ili2py.mappers.helpers import Index
+from modelbaker.libs.ili2py.readers.interlis_24.ilismeta16.xsdata import Imd16Reader
+from modelbaker.libs.ili2py.writers.py.python_structure import Enumeration, Library
+
+
+class BakerPyIndex(Index):
+    """Bridge to ili2py, subclassing the ili2py ``Index`` class.
+
+    Provides methods to return objects such as the library or enumerations,
+    as well as convenience methods. Does not override any base class behavior.
+    """
+
+    def __init__(self, metamodel):
+        self.metamodel = metamodel
+        super().__init__(self.metamodel.datasection)
+
+    @classmethod
+    def from_imd(cls, imd_path: str):
+        """Factory method to parse and instantiate itself.
+
+        Raises:
+            FileNotFoundError: If the file doesn't exist.
+            ValueError: If the file is empty or invalid to read.
+        """
+        if not os.path.exists(imd_path):
+            raise FileNotFoundError(f"IMD file not found at: {imd_path}")
+
+        if os.path.getsize(imd_path) == 0:
+            raise ValueError(f"IMD file is empty: {imd_path}")
+
+        try:
+            reader = Imd16Reader()
+            metamodel = reader.read(imd_path)
+
+            if not metamodel or not hasattr(metamodel, "datasection"):
+                raise ValueError("Invalid IMD structure: missing datasection.")
+            return cls(metamodel)
+
+        except Exception as e:
+            raise ValueError(f"Failed to parse IMD file: {e}") from e
+
+    # get object functions
+    def base_index_object(
+        self,
+    ) -> Index:
+        """Returns a plain ``Index`` built from the metamodel data section.
+
+        Returns:
+            The base index object.
+        """
+        return Index(self.metamodel.datasection)
+
+    def library_object(
+        self,
+    ) -> Library:
+        """Returns the ``Library`` object built from the metamodel.
+
+        Returns:
+            The library object.
+        """
+        library_name = self.types_bucket["Model"][-1].name
+        library = Library.from_imd(
+            self.metamodel.datasection.ModelData, self, library_name
+        )
+        return library
+
+    def enumeration_object(self, type_object: EnumType) -> Enumeration:
+        """Returns the enumeration for the given enum type.
+
+        Args:
+            type_object: The enum type to build the enumeration from.
+
+        Returns:
+            The corresponding enumeration object.
+        """
+        enumeration = Enumeration.from_imd(type_object, self)
+        return enumeration
+
+    @property
+    def data_unit_supers(self) -> dict:
+        """Maps basket tids to their parents via ``<IlisMeta16:Super>``.
+
+        Returns:
+            A dict mapping a basket tid to its parent basket tid.
+        """
+        return self._supers("DataUnit")
+
+    @property
+    def enumeration_supers(self) -> dict:
+        """Maps object tids to their parents via ``<IlisMeta16:Super>``.
+
+        Returns:
+            A dict mapping an object tid to its parent object tid.
+        """
+        return self._supers("EnumType")
+
+    def _supers(self, type_name: str, package_elements_only: bool = True) -> dict:
+        """Maps an element tid to its parent tid via ``<IlisMeta16:Super>``.
+
+        Args:
+            type_name: The type to inspect (e.g. ``DataUnit`` or ``EnumType``).
+            package_elements_only: If True, only elements assigned to a package are considered.
+
+        Returns:
+            A dict mapping an element tid to its parent tid.
+        """
+        result = {}
+        for element in self.types_bucket.get(type_name, []):
+            in_package = getattr(element, "element_in_package", None)
+            if package_elements_only and not in_package:
+                continue
+            super_ref = getattr(element, "super", None) or getattr(
+                element, "super_value", None
+            )
+            if super_ref:
+                result[element.tid] = super_ref.ref
+        return result
+
+    def languages(self, model_names: list = None) -> list:
+        """Returns the languages of the given models.
+
+        Args:
+            model_names: The models to consider. If None, all models are considered.
+
+        Returns:
+            A list of language codes.
+        """
+        languages = []
+        for model in self.types_bucket.get("Model", []):
+            if model_names and model.name not in model_names:
+                continue
+            languages.append(model.language)
+        return languages
+
+    def attribute_type(self, attribute_iliname: str) -> object:
+        """Returns the type object for the given attribute.
+
+        Args:
+            attribute_iliname: The ili name of the attribute.
+
+        Returns:
+            The attribute's type object.
+        """
+        attribute_object = self.index.get(attribute_iliname)
+        attribute_type_oid = attribute_object.type_value.ref
+        return self.index.get(attribute_type_oid)
+
+    def relevant_topics(self, model_name: str = None) -> set:
+        """Returns the relevant topics, including extended and dependent topics.
+
+        Args:
+            model_name: The model to limit to. If None, all topics are returned.
+
+        Returns:
+            A set of topic names.
+        """
+        relevant_topics_set = set()
+        if not model_name:
+            # if not limited to the relevant topics, get all the topics
+            relevant_topics_set = {
+                topic
+                for topics in self.submodel_in_package.values()
+                for topic in topics
+            }
+        else:
+            relevant_topics_set = set(self.submodel_in_package.get(model_name, []))
+
+        # get the super and dependency mappings
+        supers = self.data_unit_supers
+        dependencies = self.dependency_depends_on
+
+        # make a mapping from baskets to topics
+        basket_topic_map = {
+            basket: topic for topic, basket in self.topic_basket.items()
+        }
+
+        # get topics recursively starting with the topics of the model
+        self._collect_relevant_topics_recursively(
+            relevant_topics_set, supers, dependencies, basket_topic_map
+        )
+
+        return relevant_topics_set
+
+    def _collect_relevant_topics_recursively(
+        self,
+        relevant_topics_set: set,
+        supers: dict,
+        dependencies: dict,
+        basket_topic_map: dict,
+    ):
+        """Recursively adds relevant topics from super and dependency relationships.
+
+        Updates ``relevant_topics_set`` in place. Following parent topics (via ``supers``)
+        and dependency topics (via ``dependencies``).
+
+        Args:
+            relevant_topics_set: The set of topics to extend in place.
+            supers: Mapping of basket tid to parent basket tid.
+            dependencies: Mapping of basket tid to dependency basket tids.
+            basket_topic_map: Mapping of basket tid to topic name.
+        """
+        found_topics = set()
+        for topic in relevant_topics_set:
+            basket = self.topic_basket.get(topic)
+            if not basket:
+                continue
+            if basket in supers:
+                # only one super topic
+                found_topics.add(basket_topic_map.get(supers[basket]))
+            # mulitple dependencies possible
+            dependency_topics = {
+                basket_topic_map.get(dependency_basket)
+                for dependency_basket in dependencies.get(basket, [])
+            }
+            found_topics.update(dependency_topics)
+
+        if found_topics:
+            self._collect_relevant_topics_recursively(
+                found_topics, supers, dependencies, basket_topic_map
+            )
+            relevant_topics_set.update(found_topics)
+
+    def relevant_models(self, relevant_topics: set = None) -> set:
+        """Returns the relevant models for the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all models are returned.
+
+        Returns:
+            A set of model names.
+        """
+        # if not limited to the relevant topics, get all the models directly
+        if not relevant_topics:
+            return set(self.models)
+
+        relevant_models = {
+            model
+            for model, topics in self.submodel_in_package.items()
+            if any(topic in relevant_topics for topic in topics)
+        }
+        return relevant_models
+
+    def relevant_classes(self, relevant_topics: set = None) -> set:
+        """Returns the relevant classes for the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all classes are returned.
+
+        Returns:
+            A set of class tids.
+        """
+        # if not limited to the relevant topics, get all the topics
+        if not relevant_topics:
+            relevant_topics = {
+                topic
+                for topics in self.submodel_in_package.values()
+                for topic in topics
+            }
+
+        topic_baskets_map = self.topic_basket
+        relevant_baskets = [topic_baskets_map.get(topic) for topic in relevant_topics]
+
+        # get all the relevant classes by checking if they are allowed in the data unit
+        relevant_classes = set()
+        all_elements = self.allowed_in_basket_of_data_unit
+        for element_basket in all_elements.keys():
+            if element_basket in relevant_baskets:
+                relevant_classes.update(all_elements[element_basket])
+        return relevant_classes
+
+    def relevant_geometric_attributes_per_class(
+        self, relevant_topics: set = None
+    ) -> dict:
+        """Returns the geometric attributes per class for the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all classes are considered.
+
+        Returns:
+            A dict mapping a class tid to a list of its geometric attribute tids.
+        """
+        relevant_classes = self.relevant_classes(relevant_topics)
+        geometric_classes = self.geometric_classes
+        relevant_geometric_attributes_per_class = {}
+        for geometric_classname in geometric_classes.keys():
+            if geometric_classname in relevant_classes:
+                relevant_geometric_attributes_per_class[
+                    geometric_classname
+                ] = geometric_classes[geometric_classname]
+        return relevant_geometric_attributes_per_class
+
+    def relevant_enumeration_definitions(self, relevant_topics: set = None) -> set:
+        """Returns the tids of enum types used as attribute types in the given topics.
+
+        Args:
+            relevant_topics: The topics to consider. If None, all classes are considered.
+
+        Returns:
+            A set of enum type tids.
+        """
+        relevant_classes = self.relevant_classes(relevant_topics)
+
+        enum_tids = {
+            enum_type.tid for enum_type in self.types_bucket.get("EnumType", [])
+        }
+        result = set()
+        for attribute in self.types_bucket.get("AttrOrParam", []):
+            attr_parent = getattr(attribute, "attr_parent", None)
+            if not attr_parent or attr_parent.ref not in relevant_classes:
+                continue
+            type_ref = getattr(attribute, "type_value", None)
+            if type_ref and type_ref.ref in enum_tids:
+                result.add(type_ref.ref)
+        return result

--- a/modelbaker/ili2pytools/pythonizer.py
+++ b/modelbaker/ili2pytools/pythonizer.py
@@ -146,7 +146,8 @@ class BakerPyIndex(Index):
         for model in self.types_bucket.get("Model", []):
             if model_names and model.name not in model_names:
                 continue
-            languages.append(model.language)
+            if model.language and model.language not in languages:
+                languages.append(model.language)
         return languages
 
     def attribute_type(self, attribute_iliname: str) -> object:

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -265,6 +265,7 @@ class IliCache(QObject):
                         or ""
                     )
                     model["repository"] = netloc
+                    model["url"] = url
                     repo_models.append(model)
 
         for repo in root.iter(
@@ -288,6 +289,7 @@ class IliCache(QObject):
                         or ""
                     )
                     model["repository"] = netloc
+                    model["url"] = url
                     repo_models.append(model)
 
         self.repositories[netloc] = sorted(
@@ -401,7 +403,8 @@ class IliModelItemModel(QStandardItemModel):
     class Roles(Enum):
         ILIREPO = Qt.ItemDataRole.UserRole + 1
         VERSION = Qt.ItemDataRole.UserRole + 2
-        FILE = Qt.ItemDataRole.UserRole + 3
+        URL = Qt.ItemDataRole.UserRole + 3
+        FILE = Qt.ItemDataRole.UserRole + 4
 
         def __int__(self):
             return self.value
@@ -434,6 +437,7 @@ class IliModelItemModel(QStandardItemModel):
                 item.setData(
                     model.get("version", ""), int(IliModelItemModel.Roles.VERSION)
                 )
+                item.setData(model.get("url", ""), int(IliModelItemModel.Roles.URL))
                 item.setData(model.get("file", ""), int(IliModelItemModel.Roles.FILE))
                 names.append(name)
                 self.appendRow(item)

--- a/modelbaker/iliwrapper/ilicache.py
+++ b/modelbaker/iliwrapper/ilicache.py
@@ -43,6 +43,16 @@ if TYPE_CHECKING:
 
 
 class IliCache(QObject):
+    """
+    Parses repositories connected via ilisites.xml (or local repository folders) for ilimodels.xml information files,
+    then downloads and stores them in the .ilicache folder.
+    It keeps information about the models (such as name, location, etc.) in an IliModelItemModel().
+    It does not download the actual model files when processing the information files
+    (if model files exist, they may have been downloaded by ili2db or the Model Baker plugin frontend, but not by IliCache).
+
+    :var ilidata: Description
+    """
+
     ns = {"ili23": "http://www.interlis.ch/INTERLIS2.3"}
 
     new_message = pyqtSignal(int, str)
@@ -477,6 +487,14 @@ class ModelCompleterDelegate(QItemDelegate):
 
 
 class IliDataCache(IliCache):
+    """
+    Parses repositories connected via ilisites.xml (or local repository folders) for ilidata.xml information files,
+    then downloads and stores them in the .ilidatacache folder.
+    It collects data objects based on the passed models and types (filtering by the category element) and stores their
+    details (such as ID, description, location, etc.) in an IliDataItemModel().
+    It does not download the actual data files when processing the information files, but it provides a download_file function
+    to be called externally (by IliToppingFileCache or the Model Baker frontend, but not by IliCache).
+    """
 
     file_download_succeeded = pyqtSignal(str, str)
     file_download_failed = pyqtSignal(str, str)
@@ -885,6 +903,13 @@ class IliDataFileCompleterDelegate(QItemDelegate):
 
 
 class IliToppingFileCache(IliDataCache):
+
+    """
+    IliTopping parses repositories connected via ilisites.xml (or local repository folders) for ilidata.xml information files,
+    then downloads and stores them in the .ilitoppingfilescache folder.
+    It collects data objects based on passed IDs and stores their details (such as local_file_path) in an IliToppingFileItemModel()
+    because it DOES download the actual data files when processing the information files (unlike IliDataCache and IliCache).
+    """
 
     download_finished_and_model_fresh = pyqtSignal()
     """

--- a/modelbaker/utils/db_utils.py
+++ b/modelbaker/utils/db_utils.py
@@ -14,6 +14,8 @@ License:
 
 from __future__ import annotations
 
+import os
+from datetime import datetime
 from typing import TYPE_CHECKING
 
 from qgis.core import (
@@ -23,6 +25,7 @@ from qgis.core import (
     QgsDataSourceUri,
     QgsMessageLog,
 )
+from qgis.PyQt.QtCore import QFile, QStandardPaths
 
 from ..db_factory.db_simple_factory import DbSimpleFactory
 from ..dbconnector.db_connector import DBConnectorError
@@ -198,3 +201,32 @@ def get_service_config(servicename: str) -> tuple[dict[str, str], str]:
             {},
             f"The service {servicename} cannot be found in the service file.",
         )
+
+
+def model_files_generated_from_db(
+    configuration, model_list: list[str] | None = None
+) -> list[str]:
+    model_files: list[str] = []
+
+    db_connector = get_db_connector(configuration)
+    if not db_connector:
+        return model_files
+
+    model_records = db_connector.get_models()
+    for record in model_records:
+        name = record["modelname"].split("{")[0]
+        # on an empty model_list we create a file for every found model
+        if not model_list or name in model_list:
+            modelfilepath = os.path.join(
+                QStandardPaths.writableLocation(
+                    QStandardPaths.StandardLocation.TempLocation
+                ),
+                "temp_{}_{:%Y%m%d%H%M%S%f}.ili".format(name, datetime.now()),
+            )
+            file = QFile(modelfilepath)
+            if file.open(QFile.OpenModeFlag.WriteOnly):
+                file.write(record["content"].encode("utf-8"))
+                file.close()
+                model_files.append(modelfilepath)
+
+    return model_files

--- a/modelbaker/utils/globals.py
+++ b/modelbaker/utils/globals.py
@@ -80,6 +80,7 @@ MODELS_BLACKLIST = [
     "DictionariesCH_V2",
     "CatalogueObjects_V2",
     "CatalogueObjectTrees_V2",
+    "INTERLIS",
 ]
 
 

--- a/modelbaker/utils/ili2db_utils.py
+++ b/modelbaker/utils/ili2db_utils.py
@@ -13,17 +13,22 @@ License:
 
 from __future__ import annotations
 
+import datetime
+import os
 from typing import TYPE_CHECKING
 
-from qgis.PyQt.QtCore import QObject, Qt, pyqtSignal
+from qgis.PyQt.QtCore import QObject, QStandardPaths, Qt, pyqtSignal
 
 from ..iliwrapper import ilideleter, ilimetaconfigexporter
 from ..iliwrapper.ili2dbconfig import (
+    BaseConfiguration,
     DeleteConfiguration,
     ExportMetaConfigConfiguration,
+    Ili2CCommandConfiguration,
     Ili2DbCommandConfiguration,
 )
 from ..iliwrapper.ili2dbutils import JavaNotFoundError
+from ..iliwrapper.ilicompiler import IliCompiler
 from ..utils.qt_utils import OverrideCursor
 
 if TYPE_CHECKING:
@@ -160,6 +165,47 @@ class Ili2DbUtils(QObject):
             self._disconnect_ili_executable_signals(metaconfig_exporter)
 
         return res, msg
+
+    def compile(self, ili_file, base_configuration=None, imd_file=None):
+        if base_configuration is None:
+            base_configuration = BaseConfiguration()
+        compiler = IliCompiler()
+        compiler.configuration = Ili2CCommandConfiguration()
+        compiler.configuration.base_configuration = base_configuration
+        compiler.configuration.ilifile = ili_file
+        if imd_file:
+            compiler.configuration.imdfile = imd_file
+        else:
+            compiler.configuration.imdfile = os.path.join(
+                QStandardPaths.writableLocation(
+                    QStandardPaths.StandardLocation.TempLocation
+                ),
+                "temp_imd_{:%Y%m%d%H%M%S%f}.imd".format(datetime.datetime.now()),
+            )
+
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
+            self._connect_ili_executable_signals(compiler)
+            self._log = ""
+
+            result = True
+            msg = self.tr("Model file successfully compiled to '{}'!").format(
+                compiler.configuration.imdfile
+            )
+
+            try:
+                compiler_result = compiler.run()
+                if compiler_result != compiler.SUCCESS:
+                    msg = self.tr("An error occurred when compiling {}").format(
+                        ili_file
+                    )
+                    result = False
+            except JavaNotFoundError as e:
+                msg = e.error_string
+                result = False
+
+            self._disconnect_ili_executable_signals(compiler)
+
+        return result, compiler.configuration.imdfile, msg
 
     def _connect_ili_executable_signals(self, ili_executable: IliExecutable) -> None:
         ili_executable.process_started.connect(self.process_started)

--- a/scripts/package_pip_packages.sh
+++ b/scripts/package_pip_packages.sh
@@ -5,14 +5,20 @@ DEPRECATION=("deprecation" "2.1.0")
 PGSERVICEPARSER=("pgserviceparser" "2.2.1")
 TOPPINGMAKER=("toppingmaker" "1.6.0")
 
+XSDATA=("xsdata" "26.2")
+TYPINGEXTENSIONS=("typing-extensions" "4.16.0")
+
 PACKAGES=(
   DEPRECATION[@]
   PGSERVICEPARSER[@]
   TOPPINGMAKER[@]
+  XSDATA[@]
+  TYPINGEXTENSIONS[@]
 )
 
-#create lib folder
-mkdir -p $LIBS_DIR
+#recreate lib folder
+rm -rf "$LIBS_DIR"
+mkdir -p "$LIBS_DIR"
 
 for PACKAGE in ${PACKAGES[@]}; do
   echo download and unpack ${!PACKAGE:0:1} with version ${!PACKAGE:1:1}
@@ -24,9 +30,19 @@ for PACKAGE in ${PACKAGES[@]}; do
   unzip -o "temp/*.whl" -d $LIBS_DIR
   #remove temp folder
   rm -r temp
-  #set write rights to group (because qgis-plugin-ci needs it)
-  chmod -R g+w $LIBS_DIR
 done
+
+# ili2py not yet on pypi - we get it from the repo
+COMMIT="c0e815e2fec9b5a5410633c291098de393529160"
+echo get ili2py on commit "$COMMIT"
+git clone -q https://github.com/rudert-geoinformatik/ili2py.git temp_ili2py_git
+cd temp_ili2py_git && git checkout -q "$COMMIT" && cd - > /dev/null
+mv temp_ili2py_git/src/ili2py "$LIBS_DIR/"
+rm -rf temp_ili2py_git
+echo ili2py stored
+
+#set write rights to group (because qgis-plugin-ci needs it)
+chmod -R g+w $LIBS_DIR
 
 #create the __init__.py in libs folder
 cd $LIBS_DIR

--- a/tests/test_model_prophet.py
+++ b/tests/test_model_prophet.py
@@ -1,0 +1,234 @@
+"""
+Metadata:
+    Creation Date: 2026-07-07
+    Copyright: (C) 2026 by Dave Signer
+    Contact: david@opengis.ch
+
+License:
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the **GNU General Public License** as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+"""
+
+import os
+import sys
+import tempfile
+
+from qgis.testing import start_app, unittest
+
+from modelbaker.utils.globals import MODELS_BLACKLIST
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "modelbaker", "libs")
+)
+from modelbaker.ili2pytools.prophets import SettingsProphet
+from modelbaker.ili2pytools.pythonizer import BakerPyIndex
+from modelbaker.iliwrapper.ili2dbconfig import BaseConfiguration
+from modelbaker.utils.ili2db_utils import Ili2DbUtils
+from tests.utils import testdata_path
+
+start_app()
+
+
+class TestSettingsProphet(unittest.TestCase):
+    """Tests the SettingsProphet convenience functions.
+
+    Also covers its base class ModelProphet and the BakerPyIndex.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Runs before all tests."""
+        cls.basetestpath = tempfile.mkdtemp()
+        cls.base_config = BaseConfiguration()
+
+    def test_settings_prophet_nupla(self):
+        """
+        Test the SettingsProphet / ModelProphet with a model having:
+        - BASKET OIDs and no extended topics -> needs basket column
+        - ARCS
+        - No multiple geometry columns
+        - Enumerations
+        - No extended enumerations
+        - It's not translation and language is DE
+        """
+
+        ili_file = testdata_path("ilimodels/Nutzungsplanung_V1_2.ili")
+
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+        model_name = "Nutzungsplanung_V1_2"
+        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+
+        assert settings_prophet.has_basket_oids() is True
+        assert settings_prophet.has_extended_topics() is False
+        assert settings_prophet.needs_basket_column() is True
+        assert settings_prophet.has_arcs() is True
+        assert settings_prophet.has_multiple_geometry_columns() is False
+        assert settings_prophet.has_enumerations() is True
+        assert settings_prophet.has_extended_enumerations() is False
+
+        is_translation, languages, _ = settings_prophet.language_infos()
+        assert is_translation is False
+        assert set(languages) == {"de"}
+
+    def test_settings_prophet_arcs(self):
+        """
+        Test the SettingsProphet / ModelProphet with a model having:
+        - No BASKET OIDs but extended topics -> needs basket column
+        - ARCS
+        - Multiple geometry columns
+        - No Enumerations
+        - No extended enumerations
+        - It's not translation and language is EO (and the parent (not original) is DE)
+        """
+
+        ili_file = testdata_path("ilimodels/KT_ArcInfrastruktur_V1.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+        model_name = "KT_ArcInfrastruktur_V1"
+
+        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+
+        assert settings_prophet.has_basket_oids() is False
+        assert settings_prophet.has_extended_topics() is True
+        assert settings_prophet.needs_basket_column() is True
+        assert settings_prophet.has_arcs() is True
+        assert settings_prophet.has_multiple_geometry_columns() is True
+        assert settings_prophet.has_enumerations() is False
+        assert settings_prophet.has_extended_enumerations() is False
+
+        is_translation, languages, _ = settings_prophet.language_infos()
+        assert is_translation is False
+        assert set(languages) == {"de", "eo"}
+
+    def test_settings_prophet_kbs(self):
+        """
+        Test the SettingsProphet / ModelProphet with a model having:
+        - No BASKET OIDs and no extended topics -> needs no basket column
+        - No ARCS
+        - Multiple geometry columns
+        - Enumerations
+        - No extended enumerations
+        - It's not translation and language is DE
+        """
+
+        ili_file = testdata_path("ilimodels/KbS_V1_5.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+        model_name = "KbS_V1_5"
+
+        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+
+        assert settings_prophet.has_basket_oids() is False
+        assert settings_prophet.has_extended_topics() is False
+        assert settings_prophet.needs_basket_column() is False
+        assert settings_prophet.has_arcs() is False
+        assert settings_prophet.has_multiple_geometry_columns() is True
+        assert settings_prophet.has_enumerations() is True
+        assert settings_prophet.has_extended_enumerations() is False
+
+        is_translation, languages, _ = settings_prophet.language_infos()
+        assert is_translation is False
+        assert set(languages) == {"de"}
+
+    def test_settings_prophet_color_enums(self):
+        """
+        Test the SettingsProphet / ModelProphet with a model having:
+        - No BASKET OIDs and no extended topics -> needs no basket column
+        - No ARCS
+        - No Multiple geometry columns
+        - Enumerations
+        - Extended enumerations
+        - It's not translation and language is ES
+        """
+        ili_file = testdata_path("ilimodels/ColorsParentChildDomain_V2.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+        model_name = "Colors_V2"
+
+        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+
+        assert settings_prophet.has_basket_oids() is False
+        assert settings_prophet.has_extended_topics() is False
+        assert settings_prophet.needs_basket_column() is False
+
+        assert settings_prophet.has_arcs() is False
+        assert settings_prophet.has_multiple_geometry_columns() is False
+        assert settings_prophet.has_enumerations() is True
+        assert settings_prophet.has_extended_enumerations() is True
+
+        is_translation, languages, _ = settings_prophet.language_infos()
+        assert is_translation is False
+        assert set(languages) == {"es"}
+
+    def test_settings_prophet_nupla_fr(self):
+        """
+        Test the SettingsProphet / ModelProphet with a model having:
+        - BASKET OIDs and no extended topics -> needs basket column
+        - ARCS
+        - No multiple geometry columns
+        - Enumerations
+        - No extended enumerations
+        - It's a translation and language is FR
+        """
+
+        ili_file = testdata_path("ilimodels/PlansDAffectation_V1_2.ili")
+
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+        model_name = "PlansDAffectation_V1_2"
+        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+
+        assert settings_prophet.has_basket_oids() is True
+        assert settings_prophet.has_extended_topics() is False
+        assert settings_prophet.needs_basket_column() is True
+        assert settings_prophet.has_arcs() is True
+        assert settings_prophet.has_multiple_geometry_columns() is False
+        assert settings_prophet.has_enumerations() is True
+        assert settings_prophet.has_extended_enumerations() is False
+
+        (
+            is_translation,
+            languages,
+            preferred_language,
+        ) = settings_prophet.language_infos()
+        assert is_translation is True
+        assert set(languages) == {"de", "fr"}
+        assert preferred_language == "de"  # original language
+
+    def test_settings_prophet_nupla_it(self):
+        """
+        Test the SettingsProphet / ModelProphet with a model having:
+        - BASKET OIDs and no extended topics -> needs basket column
+        - ARCS
+        - No multiple geometry columns
+        - Enumerations
+        - No extended enumerations
+        - It's a translation and language is IT
+        """
+
+        ili_file = testdata_path("ilimodels/PianiDiUtilizzazione_V1_2.ili")
+
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+        model_name = "PianiDiUtilizzazione_V1_2"
+        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+
+        assert settings_prophet.has_basket_oids() is True
+        assert settings_prophet.has_extended_topics() is False
+        assert settings_prophet.needs_basket_column() is True
+        assert settings_prophet.has_arcs() is True
+        assert settings_prophet.has_multiple_geometry_columns() is False
+        assert settings_prophet.has_enumerations() is True
+        assert settings_prophet.has_extended_enumerations() is False
+
+        (
+            is_translation,
+            languages,
+            preferred_language,
+        ) = settings_prophet.language_infos()
+        assert is_translation is True
+        assert set(languages) == {"de", "it"}
+        assert preferred_language == "de"  # original language

--- a/tests/test_model_prophet.py
+++ b/tests/test_model_prophet.py
@@ -22,7 +22,7 @@ from modelbaker.utils.globals import MODELS_BLACKLIST
 sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "modelbaker", "libs")
 )
-from modelbaker.ili2pytools.prophets import SettingsProphet
+from modelbaker.ili2pytools.prophets import ModelProphet, SettingsProphet
 from modelbaker.ili2pytools.pythonizer import BakerPyIndex
 from modelbaker.iliwrapper.ili2dbconfig import BaseConfiguration
 from modelbaker.utils.ili2db_utils import Ili2DbUtils
@@ -59,15 +59,17 @@ class TestSettingsProphet(unittest.TestCase):
         _, imd_file, _ = Ili2DbUtils().compile(ili_file)
         index = BakerPyIndex.from_imd(imd_file)
         model_name = "Nutzungsplanung_V1_2"
-        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
 
-        assert settings_prophet.has_basket_oids() is True
-        assert settings_prophet.has_extended_topics() is False
+        model_prophet = ModelProphet(index, model_name, MODELS_BLACKLIST)
+        settings_prophet = SettingsProphet({model_name: index}, MODELS_BLACKLIST)
+
+        assert model_prophet.has_basket_oids() is True
+        assert model_prophet.has_extended_topics() is False
         assert settings_prophet.needs_basket_column() is True
-        assert settings_prophet.has_arcs() is True
-        assert settings_prophet.has_multiple_geometry_columns() is False
-        assert settings_prophet.has_enumerations() is True
-        assert settings_prophet.has_extended_enumerations() is False
+        assert settings_prophet.contains_arcs() is True
+        assert settings_prophet.contains_multiple_geometry_columns() is False
+        assert settings_prophet.contains_arcs() is True
+        assert settings_prophet.contains_extended_enumerations() is False
 
         is_translation, languages, _ = settings_prophet.language_infos()
         assert is_translation is False
@@ -89,15 +91,16 @@ class TestSettingsProphet(unittest.TestCase):
         index = BakerPyIndex.from_imd(imd_file)
         model_name = "KT_ArcInfrastruktur_V1"
 
-        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+        model_prophet = ModelProphet(index, model_name, MODELS_BLACKLIST)
+        settings_prophet = SettingsProphet({model_name: index}, MODELS_BLACKLIST)
 
-        assert settings_prophet.has_basket_oids() is False
-        assert settings_prophet.has_extended_topics() is True
+        assert model_prophet.has_basket_oids() is False
+        assert model_prophet.has_extended_topics() is True
         assert settings_prophet.needs_basket_column() is True
-        assert settings_prophet.has_arcs() is True
-        assert settings_prophet.has_multiple_geometry_columns() is True
-        assert settings_prophet.has_enumerations() is False
-        assert settings_prophet.has_extended_enumerations() is False
+        assert settings_prophet.contains_arcs() is True
+        assert settings_prophet.contains_multiple_geometry_columns() is True
+        assert settings_prophet.contains_enumerations() is False
+        assert settings_prophet.contains_extended_enumerations() is False
 
         is_translation, languages, _ = settings_prophet.language_infos()
         assert is_translation is False
@@ -119,15 +122,16 @@ class TestSettingsProphet(unittest.TestCase):
         index = BakerPyIndex.from_imd(imd_file)
         model_name = "KbS_V1_5"
 
-        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+        model_prophet = ModelProphet(index, model_name, MODELS_BLACKLIST)
+        settings_prophet = SettingsProphet({model_name: index}, MODELS_BLACKLIST)
 
-        assert settings_prophet.has_basket_oids() is False
-        assert settings_prophet.has_extended_topics() is False
+        assert model_prophet.has_basket_oids() is False
+        assert model_prophet.has_extended_topics() is False
         assert settings_prophet.needs_basket_column() is False
-        assert settings_prophet.has_arcs() is False
-        assert settings_prophet.has_multiple_geometry_columns() is True
-        assert settings_prophet.has_enumerations() is True
-        assert settings_prophet.has_extended_enumerations() is False
+        assert settings_prophet.contains_arcs() is False
+        assert settings_prophet.contains_multiple_geometry_columns() is True
+        assert settings_prophet.contains_enumerations() is True
+        assert settings_prophet.contains_extended_enumerations() is False
 
         is_translation, languages, _ = settings_prophet.language_infos()
         assert is_translation is False
@@ -148,16 +152,17 @@ class TestSettingsProphet(unittest.TestCase):
         index = BakerPyIndex.from_imd(imd_file)
         model_name = "Colors_V2"
 
-        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+        model_prophet = ModelProphet(index, model_name, MODELS_BLACKLIST)
+        settings_prophet = SettingsProphet({model_name: index}, MODELS_BLACKLIST)
 
-        assert settings_prophet.has_basket_oids() is False
-        assert settings_prophet.has_extended_topics() is False
+        assert model_prophet.has_basket_oids() is False
+        assert model_prophet.has_extended_topics() is False
         assert settings_prophet.needs_basket_column() is False
 
-        assert settings_prophet.has_arcs() is False
-        assert settings_prophet.has_multiple_geometry_columns() is False
-        assert settings_prophet.has_enumerations() is True
-        assert settings_prophet.has_extended_enumerations() is True
+        assert settings_prophet.contains_arcs() is False
+        assert settings_prophet.contains_multiple_geometry_columns() is False
+        assert settings_prophet.contains_enumerations() is True
+        assert settings_prophet.contains_extended_enumerations() is True
 
         is_translation, languages, _ = settings_prophet.language_infos()
         assert is_translation is False
@@ -179,15 +184,17 @@ class TestSettingsProphet(unittest.TestCase):
         _, imd_file, _ = Ili2DbUtils().compile(ili_file)
         index = BakerPyIndex.from_imd(imd_file)
         model_name = "PlansDAffectation_V1_2"
-        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
 
-        assert settings_prophet.has_basket_oids() is True
-        assert settings_prophet.has_extended_topics() is False
+        model_prophet = ModelProphet(index, model_name, MODELS_BLACKLIST)
+        settings_prophet = SettingsProphet({model_name: index}, MODELS_BLACKLIST)
+
+        assert model_prophet.has_basket_oids() is True
+        assert model_prophet.has_extended_topics() is False
         assert settings_prophet.needs_basket_column() is True
-        assert settings_prophet.has_arcs() is True
-        assert settings_prophet.has_multiple_geometry_columns() is False
-        assert settings_prophet.has_enumerations() is True
-        assert settings_prophet.has_extended_enumerations() is False
+        assert settings_prophet.contains_arcs() is True
+        assert settings_prophet.contains_multiple_geometry_columns() is False
+        assert settings_prophet.contains_enumerations() is True
+        assert settings_prophet.contains_extended_enumerations() is False
 
         (
             is_translation,
@@ -214,15 +221,16 @@ class TestSettingsProphet(unittest.TestCase):
         _, imd_file, _ = Ili2DbUtils().compile(ili_file)
         index = BakerPyIndex.from_imd(imd_file)
         model_name = "PianiDiUtilizzazione_V1_2"
-        settings_prophet = SettingsProphet(index, model_name, MODELS_BLACKLIST)
+        model_prophet = ModelProphet(index, model_name, MODELS_BLACKLIST)
+        settings_prophet = SettingsProphet({model_name: index}, MODELS_BLACKLIST)
 
-        assert settings_prophet.has_basket_oids() is True
-        assert settings_prophet.has_extended_topics() is False
+        assert model_prophet.has_basket_oids() is True
+        assert model_prophet.has_extended_topics() is False
         assert settings_prophet.needs_basket_column() is True
-        assert settings_prophet.has_arcs() is True
-        assert settings_prophet.has_multiple_geometry_columns() is False
-        assert settings_prophet.has_enumerations() is True
-        assert settings_prophet.has_extended_enumerations() is False
+        assert settings_prophet.contains_arcs() is True
+        assert settings_prophet.contains_multiple_geometry_columns() is False
+        assert settings_prophet.contains_enumerations() is True
+        assert settings_prophet.contains_extended_enumerations() is False
 
         (
             is_translation,

--- a/tests/test_pythonizer.py
+++ b/tests/test_pythonizer.py
@@ -1,0 +1,538 @@
+"""
+Metadata:
+    Creation Date: 2026-07-07
+    Copyright: (C) 2026 by Dave Signer
+    Contact: david@opengis.ch
+
+License:
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the **GNU General Public License** as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+"""
+
+import os
+import sys
+import tempfile
+
+from qgis.testing import start_app, unittest
+
+sys.path.insert(
+    0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "modelbaker", "libs")
+)
+import modelbaker.libs.ili2py.interfaces.interlis.interlis_24.ilismeta.ilismeta16_2022_10_10 as ilismeta16
+from modelbaker.ili2pytools.pythonizer import BakerPyIndex
+from modelbaker.iliwrapper.ili2dbconfig import BaseConfiguration
+from modelbaker.utils.ili2db_utils import Ili2DbUtils
+from tests.utils import testdata_path
+
+start_app()
+
+
+class TestPythonizer(unittest.TestCase):
+    """
+    These tests are to check if the Index and the Library are correctly read by ili2db via the Pythonizer tools.
+    As well they should check the available functions of the extensions BakerPyIndex.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests."""
+        cls.basetestpath = tempfile.mkdtemp()
+        cls.base_config = BaseConfiguration()
+
+    def test_pythonizer_index_nupla(self):
+        """Tests index generation and queries with Nutzungsplanung_V1_2.
+
+        - Some BASKET OIDs in specific topics
+        - Some geometries
+        - Some enumerations
+        """
+        ili_file = testdata_path("ilimodels/Nutzungsplanung_V1_2.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+
+        model_name = "Nutzungsplanung_V1_2"
+
+        # some base index functions
+        # check the topics of Nutzungsplanung_V1_2
+        all_topics = index.submodel_in_package
+        nupla_topics = all_topics.get(model_name)
+        assert set(nupla_topics) == {
+            "Nutzungsplanung_V1_2.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Geobasisdaten",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften",
+            "Nutzungsplanung_V1_2.TransferMetadaten",
+        }
+
+        # check the index for basket oid definition in topics
+        bid_in_topics = index.basket_oid_in_submodel
+        # - has some in Catalogue_CH and Geobasisdaten
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.Catalogue_CH")
+        assert bid_definition
+        assert bid_definition == "Nutzungsplanung_V1_2.Catalogue_CH.BASKET"
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.Geobasisdaten")
+        assert bid_definition
+        assert bid_definition == "Nutzungsplanung_V1_2.Geobasisdaten.BASKET"
+        # - has none in Rechtsvorschriften and TransferMetadaten
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.Rechtsvorschriften")
+        assert not bid_definition
+        bid_definition = bid_in_topics.get("Nutzungsplanung_V1_2.TransferMetadaten")
+        assert not bid_definition
+
+        # some baker py index functions
+        # check the relevant topics and classes (means includingt supers and dependencies)
+        all_topics = index.relevant_topics()
+        assert all_topics == {
+            "AdministrativeUnitsCH_V1.CHDistricts",
+            "AdministrativeUnitsCH_V1.CHCantons",
+            "AdministrativeUnits_V1.CountryNames",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften",
+            "Nutzungsplanung_V1_2.TransferMetadaten",
+            "AdministrativeUnits_V1.Countries",
+            "CoordSys.CoordsysTopic",
+            "AdministrativeUnitsCH_V1.CHAgencies",
+            "Nutzungsplanung_V1_2.Geobasisdaten",
+            "AdministrativeUnits_V1.AdministrativeUnits",
+            "AdministrativeUnits_V1.Agencies",
+            "INTERLIS.TIMESYSTEMS",
+            "DictionariesCH_V1.Dictionaries",
+            "AdministrativeUnitsCH_V1.CHAdministrativeUnions",
+            "Nutzungsplanung_V1_2.Catalogue_CH",
+            "Dictionaries_V1.Dictionaries",
+            "AdministrativeUnitsCH_V1.CHMunicipalities",
+        }
+        relevant_topics = index.relevant_topics(model_name)
+        assert relevant_topics == {
+            "Nutzungsplanung_V1_2.Rechtsvorschriften",
+            "Nutzungsplanung_V1_2.TransferMetadaten",
+            "Nutzungsplanung_V1_2.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Geobasisdaten",
+        }
+
+        all_models = index.relevant_models()
+        assert all_models == {
+            "Units",
+            "InternationalCodes_V1",
+            "GeometryCHLV03_V1",
+            "GeometryCHLV95_V1",
+            "Localisation_V1",
+            "LocalisationCH_V1",
+            "CHAdminCodes_V1",
+            "AdministrativeUnitsCH_V1",
+            "AdministrativeUnits_V1",
+            "CoordSys",
+            "DictionariesCH_V1",
+            "Dictionaries_V1",
+            "INTERLIS",
+            "Nutzungsplanung_V1_2",
+        }
+        relevant_models = index.relevant_models(relevant_topics)
+        assert relevant_models == {"Nutzungsplanung_V1_2"}
+
+        all_classes = index.relevant_classes()
+        assert all_classes == {
+            "INTERLIS.TIMESYSTEMS.CALENDAR",
+            "INTERLIS.TIMESYSTEMS.TIMEOFDAYSYS",
+            "Dictionaries_V1.Dictionaries.Dictionary",
+            "DictionariesCH_V1.Dictionaries.Dictionary",
+            "CoordSys.CoordsysTopic.Ellipsoid",
+            "CoordSys.CoordsysTopic.GravityModel",
+            "CoordSys.CoordsysTopic.GeoidModel",
+            "CoordSys.CoordsysTopic.GeoCartesian1D",
+            "CoordSys.CoordsysTopic.GeoHeight",
+            "CoordSys.CoordsysTopic.GeoCartesian2D",
+            "CoordSys.CoordsysTopic.GeoCartesian3D",
+            "CoordSys.CoordsysTopic.GeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian2D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.TransverseMercator",
+            "CoordSys.CoordsysTopic.SwissProjection",
+            "CoordSys.CoordsysTopic.Mercator",
+            "CoordSys.CoordsysTopic.ObliqueMercator",
+            "CoordSys.CoordsysTopic.Lambert",
+            "CoordSys.CoordsysTopic.Polyconic",
+            "CoordSys.CoordsysTopic.Albus",
+            "CoordSys.CoordsysTopic.Azimutal",
+            "CoordSys.CoordsysTopic.Stereographic",
+            "CoordSys.CoordsysTopic.HeightConversion",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnits_V1.Countries.Country",
+            "Dictionaries_V1.Dictionaries.Dictionary",
+            "AdministrativeUnits_V1.CountryNames.CountryNamesTranslation",
+            "AdministrativeUnits_V1.Agencies.Organisation",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHCantons.CHCanton",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHDistricts.CHDistrict",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnion",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHMunicipalities.CHMunicipality",
+            "AdministrativeUnits_V1.AdministrativeUnits.AdministrativeUnit",
+            "AdministrativeUnits_V1.AdministrativeUnits.UnionMembers",
+            "AdministrativeUnitsCH_V1.CHAdministrativeUnions.AdministrativeUnion",
+            "AdministrativeUnits_V1.Agencies.Organisation",
+            "AdministrativeUnitsCH_V1.CHAgencies.Agency",
+            "Nutzungsplanung_V1_2.Catalogue_CH.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Kt",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Linienbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Objektbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Geometrie_Dokument",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Amt",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Datenbestand",
+        }
+
+        relevant_classes = index.relevant_classes(relevant_topics)
+        assert relevant_classes == {
+            "Nutzungsplanung_V1_2.Catalogue_CH.Catalogue_CH",
+            "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Kt",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Linienbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Objektbezogene_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Typ_Dokument",
+            "Nutzungsplanung_V1_2.Geobasisdaten.Geometrie_Dokument",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Amt",
+            "Nutzungsplanung_V1_2.TransferMetadaten.Datenbestand",
+        }
+        relevant_geometric_attributes = index.relevant_geometric_attributes_per_class(
+            list(relevant_topics)
+        )
+        assert relevant_geometric_attributes[
+            "Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche"
+        ] == ["Nutzungsplanung_V1_2.Geobasisdaten.Grundnutzung_Zonenflaeche.Geometrie"]
+        assert relevant_geometric_attributes[
+            "Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung"
+        ] == ["Nutzungsplanung_V1_2.Geobasisdaten.Ueberlagernde_Festlegung.Geometrie"]
+
+        # check if it returns a library object (if not none)
+        library = index.library_object()
+        assert library
+
+        # check some attribute types
+        assert isinstance(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Geobasisdaten.Typ.Nutzungsziffer"
+            ),
+            ilismeta16.NumType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument.Rechtsstatus"
+            ),
+            ilismeta16.EnumType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument.TextImWeb"
+            ),
+            ilismeta16.MultiValue,
+        )
+
+        # and enumerations
+        enumeration_object = index.enumeration_object(
+            index.attribute_type(
+                "Nutzungsplanung_V1_2.Rechtsvorschriften.Dokument.Rechtsstatus"
+            )
+        )
+        assert set(enumeration_object.values) == {
+            "inKraft",
+            "AenderungMitVorwirkung",
+            "AenderungOhneVorwirkung",
+        }
+
+    def test_pythonizer_index_kbs(self):
+        """Tests index generation and queries with KbS_V1_5.
+
+        - No BASKET OIDs
+        - Some geometries
+        - Some enumerations
+        """
+
+        ili_file = testdata_path("ilimodels/KbS_V1_5.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+
+        model_name = "KbS_V1_5"
+        # some base index functions
+        # check the topics of KbS_V1_5
+        all_topics = index.submodel_in_package
+        kbs_topics = all_topics.get(model_name)
+        assert set(kbs_topics) == {
+            "KbS_V1_5.Codelisten",
+            "KbS_V1_5.Belastete_Standorte",
+        }
+
+        # check the index for basket oid definition in topics
+        bid_in_topics = index.basket_oid_in_submodel
+        # - has none in Codelisten and Belastete_Standorte
+        bid_definition = bid_in_topics.get("KbS_V1_5.Codelisten")
+        assert not bid_definition
+        bid_definition = bid_in_topics.get("KbS_V1_5.Belastete_Standorte")
+        assert not bid_definition
+
+        # some baker py index convenience functions
+        # check the relevant topics and classes (means includingt supers and dependencies)
+        all_topics = index.relevant_topics()
+        assert all_topics == {
+            "Dictionaries_V1.Dictionaries",
+            "DictionariesCH_V1.Dictionaries",
+            "INTERLIS.TIMESYSTEMS",
+            "KbS_V1_5.Belastete_Standorte",
+            "KbS_V1_5.Codelisten",
+            "CoordSys.CoordsysTopic",
+        }
+        relevant_topics = index.relevant_topics(model_name)
+        assert relevant_topics == {
+            "KbS_V1_5.Codelisten",
+            "KbS_V1_5.Belastete_Standorte",
+        }
+
+        all_models = index.relevant_models()
+        assert all_models == {
+            "Units",
+            "InternationalCodes_V1",
+            "GeometryCHLV03_V1",
+            "GeometryCHLV95_V1",
+            "LocalisationCH_V1",
+            "Localisation_V1",
+            "CoordSys",
+            "DictionariesCH_V1",
+            "Dictionaries_V1",
+            "INTERLIS",
+            "KbS_V1_5",
+        }
+        relevant_models = index.relevant_models(relevant_topics)
+        assert relevant_models == {"KbS_V1_5"}
+
+        all_classes = index.relevant_classes()
+        assert all_classes == {
+            "INTERLIS.TIMESYSTEMS.CALENDAR",
+            "INTERLIS.TIMESYSTEMS.TIMEOFDAYSYS",
+            "Dictionaries_V1.Dictionaries.Dictionary",
+            "DictionariesCH_V1.Dictionaries.Dictionary",
+            "CoordSys.CoordsysTopic.Ellipsoid",
+            "CoordSys.CoordsysTopic.GravityModel",
+            "CoordSys.CoordsysTopic.GeoidModel",
+            "CoordSys.CoordsysTopic.GeoCartesian1D",
+            "CoordSys.CoordsysTopic.GeoHeight",
+            "CoordSys.CoordsysTopic.GeoCartesian2D",
+            "CoordSys.CoordsysTopic.GeoCartesian3D",
+            "CoordSys.CoordsysTopic.GeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.ToGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian2D",
+            "CoordSys.CoordsysTopic.BidirectGeoCartesian3D",
+            "CoordSys.CoordsysTopic.BidirectGeoEllipsoidal",
+            "CoordSys.CoordsysTopic.TransverseMercator",
+            "CoordSys.CoordsysTopic.SwissProjection",
+            "CoordSys.CoordsysTopic.Mercator",
+            "CoordSys.CoordsysTopic.ObliqueMercator",
+            "CoordSys.CoordsysTopic.Lambert",
+            "CoordSys.CoordsysTopic.Polyconic",
+            "CoordSys.CoordsysTopic.Albus",
+            "CoordSys.CoordsysTopic.Azimutal",
+            "CoordSys.CoordsysTopic.Stereographic",
+            "CoordSys.CoordsysTopic.HeightConversion",
+            "KbS_V1_5.Codelisten.Deponietyp_Definition",
+            "KbS_V1_5.Codelisten.Standorttyp_Definition",
+            "KbS_V1_5.Codelisten.StatusAltlV_Definition",
+            "KbS_V1_5.Codelisten.Untersuchungsmassnahmen_Definition",
+            "KbS_V1_5.Belastete_Standorte.ZustaendigkeitKataster",
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort",
+        }
+        relevant_classes = index.relevant_classes(relevant_topics)
+        assert relevant_classes == {
+            "KbS_V1_5.Codelisten.Deponietyp_Definition",
+            "KbS_V1_5.Codelisten.Standorttyp_Definition",
+            "KbS_V1_5.Codelisten.StatusAltlV_Definition",
+            "KbS_V1_5.Codelisten.Untersuchungsmassnahmen_Definition",
+            "KbS_V1_5.Belastete_Standorte.ZustaendigkeitKataster",
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort",
+        }
+        relevant_geometric_attributes = index.relevant_geometric_attributes_per_class(
+            relevant_topics
+        )
+        assert relevant_geometric_attributes[
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort"
+        ] == [
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Geo_Lage_Polygon",
+            "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Geo_Lage_Punkt",
+        ]
+
+        # check some attribute types
+        assert isinstance(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.InBetrieb"
+            ),
+            ilismeta16.BooleanType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Katasternummer"
+            ),
+            ilismeta16.TextType,
+        )
+        assert isinstance(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Standorttyp"
+            ),
+            ilismeta16.EnumType,
+        )
+
+        # check if it returns a library object (if not none)
+        library = index.library_object()
+        assert library
+
+        # and enumerations
+        enumeration_object = index.enumeration_object(
+            index.attribute_type(
+                "KbS_V1_5.Belastete_Standorte.Belasteter_Standort.Standorttyp"
+            )
+        )
+        assert set(enumeration_object.values) == {
+            "StaoTyp1",
+            "StaoTyp2",
+            "StaoTyp3",
+            "StaoTyp4",
+        }
+
+    def test_pythonizer_index_color_enums(self):
+        """Tests index generation and queries with Colors_V2.
+
+        - No BASKET OIDs
+        - Some geometries
+        - Some enumerations
+        """
+
+        ili_file = testdata_path("ilimodels/ColorsParentChildDomain_V2.ili")
+        _, imd_file, _ = Ili2DbUtils().compile(ili_file)
+        index = BakerPyIndex.from_imd(imd_file)
+
+        model_name = "Colors_V2"
+        # some base index functions
+        # check the topics of Colors_V2
+        all_topics = index.submodel_in_package
+        colors_topics = all_topics.get(model_name)
+        assert set(colors_topics) == {"Colors_V2.SomeColors"}
+
+        # check the index for basket oid definition in topics
+        bid_in_topics = index.basket_oid_in_submodel
+        # - has none in Colors_V2
+        bid_definition = bid_in_topics.get("Colors_V2.SomeColors")
+        assert not bid_definition
+
+        # some baker py index convenience functions
+        # check the relevant topics and classes (means includingt supers and dependencies)
+        all_topics = index.relevant_topics()
+        assert all_topics == {"INTERLIS.TIMESYSTEMS", "Colors_V2.SomeColors"}
+        relevant_topics = index.relevant_topics(model_name)
+        assert relevant_topics == {
+            "Colors_V2.SomeColors",
+        }
+
+        all_models = index.relevant_models()
+        assert all_models == {
+            "INTERLIS",
+            "Colors_V2",
+        }
+        relevant_models = index.relevant_models(relevant_topics)
+        assert relevant_models == {"Colors_V2"}
+
+        all_classes = index.relevant_classes()
+        assert all_classes == {
+            "INTERLIS.TIMESYSTEMS.CALENDAR",
+            "INTERLIS.TIMESYSTEMS.TIMEOFDAYSYS",
+            "Colors_V2.SomeColors.BaseColorClass",
+            "Colors_V2.SomeColors.BlueChildColorClass",
+            "Colors_V2.SomeColors.UninheritedCMYColorClass",
+            "Colors_V2.SomeColors.GreenChildColorClass",
+        }
+        relevant_classes = index.relevant_classes(relevant_topics)
+        assert relevant_classes == {
+            "Colors_V2.SomeColors.BaseColorClass",
+            "Colors_V2.SomeColors.BlueChildColorClass",
+            "Colors_V2.SomeColors.UninheritedCMYColorClass",
+            "Colors_V2.SomeColors.GreenChildColorClass",
+        }
+        relevant_geometric_attributes = index.relevant_geometric_attributes_per_class(
+            relevant_topics
+        )
+        assert relevant_geometric_attributes == {}
+
+        # check some attribute types - all enums - this is the interresting part of this test case.
+        base_type = index.attribute_type("Colors_V2.SomeColors.BaseColorClass.Colors")
+        assert isinstance(
+            base_type,
+            ilismeta16.EnumType,
+        )
+        assert base_type.name == "Colors"
+        assert base_type.tid == "Colors_V2.Colors"
+
+        blue_type = index.attribute_type(
+            "Colors_V2.SomeColors.BlueChildColorClass.Colors"
+        )
+        assert isinstance(
+            blue_type,
+            ilismeta16.EnumType,
+        )
+        assert blue_type.name == "BlueChildColors"
+        assert blue_type.tid == "Colors_V2.BlueChildColors"
+
+        green_type = index.attribute_type(
+            "Colors_V2.SomeColors.GreenChildColorClass.Colors"
+        )
+        assert isinstance(
+            green_type,
+            ilismeta16.EnumType,
+        )
+        assert green_type.name == "GreenChildColors"
+        assert green_type.tid == "Colors_V2.GreenChildColors"
+
+        # check if it returns a library object (if not none)
+        library = index.library_object()
+        assert library
+
+        # and enumerations
+        base_enumeration_object = index.enumeration_object(
+            index.attribute_type("Colors_V2.SomeColors.BaseColorClass.Colors")
+        )
+        assert set(base_enumeration_object.values) == {"Green", "Red", "Blue"}
+
+        blue_enumeration_object = index.enumeration_object(
+            index.attribute_type("Colors_V2.SomeColors.BlueChildColorClass.Colors")
+        )
+        assert set(blue_enumeration_object.values) == {
+            "Blue.Dark_Blue",
+            "Blue.Light_Blue",
+            "Blue.Medium_Blue",
+        }
+
+        green_enumeration_object = index.enumeration_object(
+            index.attribute_type("Colors_V2.SomeColors.GreenChildColorClass.Colors")
+        )
+        assert set(green_enumeration_object.values) == {
+            "Green.Dark_Green",
+            "Green.Light_Green",
+            "Green.Medium_Green",
+        }

--- a/tests/testdata/ilimodels/ArcInfrastruktur_V1.ili
+++ b/tests/testdata/ilimodels/ArcInfrastruktur_V1.ili
@@ -1,0 +1,36 @@
+INTERLIS 2.3;
+
+MODEL ArcInfrastruktur_V1 (de) AT "https://modelbaker.ch" VERSION "2023-03-29" =
+  IMPORTS GeometryCHLV95_V1;
+
+  DOMAIN
+    Line = POLYLINE WITH (STRAIGHTS) VERTEX GeometryCHLV95_V1.Coord2;
+    Surface = SURFACE WITH (STRAIGHTS) VERTEX GeometryCHLV95_V1.Coord2 WITHOUT OVERLAPS > 0.001;
+    LineArcs = POLYLINE WITH (STRAIGHTS, ARCS) VERTEX GeometryCHLV95_V1.Coord2;
+    SurfaceArcs = SURFACE WITH (STRAIGHTS, ARCS) VERTEX GeometryCHLV95_V1.Coord2 WITHOUT OVERLAPS > 0.001;
+
+  TOPIC StrassenEtc =
+    CLASS Strasse =
+        Name : MANDATORY TEXT*99;
+        Geometrie : MANDATORY ArcInfrastruktur_V1.Line;
+    END Strasse;
+
+    CLASS Haus =
+        Name : MANDATORY TEXT*99;
+        Geometrie : MANDATORY ArcInfrastruktur_V1.SurfaceArcs;
+    END Haus;
+  END StrassenEtc;
+
+  TOPIC Natur =
+    CLASS Pfad =
+        Name : MANDATORY TEXT*99;
+        Geometrie : MANDATORY ArcInfrastruktur_V1.LineArcs;
+    END Pfad;
+
+    CLASS Park =
+        Name : MANDATORY TEXT*99;
+        Geometrie : MANDATORY ArcInfrastruktur_V1.Surface;
+    END Park;
+  END Natur;
+
+END ArcInfrastruktur_V1.

--- a/tests/testdata/ilimodels/KT_ArcInfrastruktur_V1.ili
+++ b/tests/testdata/ilimodels/KT_ArcInfrastruktur_V1.ili
@@ -1,0 +1,18 @@
+
+INTERLIS 2.3;
+
+MODEL KT_ArcInfrastruktur_V1 (eo) AT "https://modelbaker.ch" VERSION "2023-03-29" =
+  IMPORTS ArcInfrastruktur_V1;
+
+  TOPIC StrassenEtc EXTENDS ArcInfrastruktur_V1.StrassenEtc =
+    CLASS Strasse (EXTENDED) =
+        Priskribo : MANDATORY TEXT*99;
+    END Strasse;
+
+    CLASS Konstruktion =
+        Nomo : TEXT;
+        Linio : MANDATORY ArcInfrastruktur_V1.Line;
+        Poligono : MANDATORY ArcInfrastruktur_V1.Surface;
+    END Konstruktion;
+  END StrassenEtc;
+END KT_ArcInfrastruktur_V1.

--- a/tests/testdata/ilimodels/PianiDiUtilizzazione_V1_2.ili
+++ b/tests/testdata/ilimodels/PianiDiUtilizzazione_V1_2.ili
@@ -1,0 +1,225 @@
+INTERLIS 2.3;
+
+/** Modello di geodati minimale
+ * Piani di utilizzazione (cantonali/communali)
+ * Geodati di base No 73
+ */
+
+!! Version    | Who   | Modification
+!!------------------------------------------------------------------------------
+!! 2023-03-20 | ARE   | - DOMAIN PartizioneComprensorio viene omessa
+!!                    | - CLASS UtilizzazioneDiBase_SuperficieDiZoni: geometria del tipo SuperficieIndividuale (SURFACE)
+!!                    | - CLASS UtilizzazioneDiBase_SuperficieDiZoni: CONSTRAINT per garantire la topologia AREA
+!!                    | - CLASS Tipo et Tipo_Ct: Attributo Codice, lunghezza campo 40 caratteri
+!!------------------------------------------------------------------------------
+!! 2021-11-19 | KOGIS | Localisation_V1 replaced by LocalisationCH_V1
+!!------------------------------------------------------------------------------
+!! 2021-09-01 | ARE   | Version 1.2
+!!                    | Adaption au modèle-cadre RDPPF version 2.0 du 14 avril 2021 :
+!!                    | - DOMAIN StatoGiuridico adapté, TipoDocumento nouveau
+!!                    | - STRUCTURE LocalisedBlob et MultilingualBlob nouveaux
+!!                    | - CLASS Geometria: nouvel attribut pubblicataFinoAl
+!!                    | - CLASS Documento adapté au modèle-cadre RDPPF
+!!                    | - CLASS Servizio adapté au modèle-cadre RDPPF
+!!                    | Modifications techniques ultérieures
+!!                    | - MODEL PianiDiUtilizzazione_V1_2 : qu’un modèle, les deux modèles separés pour MN03 et le catalogue ne sont plus nécessaires
+!!                    | - CLASS UtilizzazionePrincipale_CH s’appelle maintenant Catalogue_CH, elle est multilingue (Designation comme MultilingualText).
+!!                    | - ASSOCIATION Geometria_Documento inséré additionellement pour permettre un lien direct entre les classes Geometria et Documento
+!!                    | - TOPIC GeodatiDiBase maintenant avec BASKET OID du type TypeID
+!!                    | - CLASS SetDiDati : Attribut BasketID maintenant du type TypeID, nouvel méta-attribut pour la vérification de l’ID
+!!------------------------------------------------------------------------------
+
+!!@ technicalContact=mailto:info@are.admin.ch
+!!@ furtherInformation=https://www.are.admin.ch/mgm
+!!@ IDGeoIV=73
+MODEL PianiDiUtilizzazione_V1_2 (it)
+AT "https://models.geo.admin.ch/ARE/"
+VERSION "2023-03-20"
+TRANSLATION OF Nutzungsplanung_V1_2 ["2023-03-20"] =
+  IMPORTS CHAdminCodes_V1,InternationalCodes_V1,LocalisationCH_V1,GeometryCHLV95_V1;
+
+  DOMAIN
+
+    SuperficieIndividuale = SURFACE WITH (ARCS,STRAIGHTS) VERTEX GeometryCHLV95_V1.Coord2 WITHOUT OVERLAPS>0.05;
+
+    TypeID = OID TEXT*60;
+
+    StatoGiuridico = (
+      inVigore,
+      ModificazioneConEffettoAnticipato,
+      ModificazioneSenzaEffettoAnticipato
+    );
+
+    TipoDocumento = (
+      PrescrizionLegale,
+      BaseLegale,
+      Indicazione
+    );
+
+    ForzaVincolante = (
+      Vincolo_PianoDiUtilizzazione,
+      Contenuto_orientativo,
+      Contenuto_indicativo,
+      Contenuto_direttivo
+    );
+
+  STRUCTURE LocalisedUri =
+    Language : InternationalCodes_V1.LanguageCode_ISO639_1;
+    Text : MANDATORY URI;
+  END LocalisedUri;
+
+  STRUCTURE MultilingualUri =
+    LocalisedText : BAG {1..*} OF PianiDiUtilizzazione_V1_2.LocalisedUri;
+    UNIQUE (LOCAL) LocalisedText: Language;
+  END MultilingualUri;
+
+  STRUCTURE LocalisedBlob =
+    Language : InternationalCodes_V1.LanguageCode_ISO639_1;
+    Blob : MANDATORY BLACKBOX BINARY;
+  END LocalisedBlob;
+
+  STRUCTURE MultilingualBlob =
+    LocalisedBlob : BAG {1..*} OF PianiDiUtilizzazione_V1_2.LocalisedBlob;
+    UNIQUE (LOCAL) LocalisedBlob: Language;
+  END MultilingualBlob;
+
+  TOPIC Catalogue_CH =
+    BASKET OID AS TypeID;
+
+    CLASS Catalogue_CH (FINAL) =
+      OID AS TypeID;
+      Code : MANDATORY 11 .. 99;
+      Designation : MANDATORY LocalisationCH_V1.MultilingualText;
+    END Catalogue_CH;
+
+  END Catalogue_CH;
+
+  TOPIC PrescrizioniLegali =
+    DEPENDS ON PianiDiUtilizzazione_V1_2.Catalogue_CH;
+
+    CLASS Documento =
+      Tipo : MANDATORY PianiDiUtilizzazione_V1_2.TipoDocumento;
+      Titolo : MANDATORY LocalisationCH_V1.MultilingualText;
+      Abbreviazione : LocalisationCH_V1.MultilingualText;
+      NoUfficiale : LocalisationCH_V1.MultilingualText;
+      SoloNelComune : CHAdminCodes_V1.CHMunicipalityCode;
+      TestoNelWeb : PianiDiUtilizzazione_V1_2.MultilingualUri;
+      Documento : PianiDiUtilizzazione_V1_2.MultilingualBlob;
+      IndiceEstratto : MANDATORY -1000 .. 1000;
+      StatoGiuridico : MANDATORY PianiDiUtilizzazione_V1_2.StatoGiuridico;
+      pubblicataDal : MANDATORY INTERLIS.XMLDate;
+      pubblicataFinoAl : INTERLIS.XMLDate;
+    END Documento;
+
+  END PrescrizioniLegali;
+
+  TOPIC GeodatiDiBase =
+    BASKET OID AS TypeID;
+    DEPENDS ON PianiDiUtilizzazione_V1_2.Catalogue_CH,PianiDiUtilizzazione_V1_2.PrescrizioniLegali;
+
+    CLASS Geometria (ABSTRACT) =
+      pubblicataDal : MANDATORY INTERLIS.XMLDate;
+      pubblicataFinoAl : INTERLIS.XMLDate;
+      StatoGiuridico : MANDATORY PianiDiUtilizzazione_V1_2.StatoGiuridico;
+      Osservazioni : MTEXT;
+    END Geometria;
+
+    CLASS Tipo =
+      Codice : MANDATORY TEXT*40;
+      Designazione : MANDATORY TEXT*80;
+      Abbreviazione : TEXT*12;
+      ForzaVincolante : MANDATORY PianiDiUtilizzazione_V1_2.ForzaVincolante;
+      IndiceSfruttamento : 0.00 .. 9.00;
+      IndiceSfruttamentoTipo : TEXT*40;
+      Osservazioni : MTEXT;
+      Simbolo : BLACKBOX BINARY;
+    END Tipo;
+
+    CLASS Tipo_Ct =
+      Codice : MANDATORY TEXT*40;
+      Designazione : MANDATORY TEXT*80;
+      Abbreviazione : TEXT*12;
+      Osservazioni : MTEXT;
+    END Tipo_Ct;
+
+    CLASS UtilizzazioneDiBase_SuperficieDiZoni
+    EXTENDS Geometria =
+      Geometria : MANDATORY PianiDiUtilizzazione_V1_2.SuperficieIndividuale;
+    SET CONSTRAINT WHERE StatoGiuridico == #inVigore:
+      INTERLIS.areAreas(ALL, UNDEFINED, >> Geometria);
+    END UtilizzazioneDiBase_SuperficieDiZoni;
+
+    CLASS ContenutoLineare
+    EXTENDS Geometria =
+      Geometria : MANDATORY GeometryCHLV95_V1.Line;
+    END ContenutoLineare;
+
+    CLASS ContenutoPuntuale
+    EXTENDS Geometria =
+      Geometria : MANDATORY GeometryCHLV95_V1.Coord2;
+    END ContenutoPuntuale;
+
+    CLASS ZonaSovrapposta
+    EXTENDS Geometria =
+      Geometria : MANDATORY PianiDiUtilizzazione_V1_2.SuperficieIndividuale;
+    END ZonaSovrapposta;
+
+    ASSOCIATION Tipo_Documento =
+      Tipo (EXTERNAL) -- {0..*} Tipo;
+      Documento (EXTERNAL) -- {0..*} PianiDiUtilizzazione_V1_2.PrescrizioniLegali.Documento;
+    END Tipo_Documento;
+
+    ASSOCIATION Geometria_Documento =
+      Geometria (EXTERNAL) -- {0..*} Geometria;
+      Documento (EXTERNAL) -- {0..*} PianiDiUtilizzazione_V1_2.PrescrizioniLegali.Documento;
+    END Geometria_Documento;
+
+    ASSOCIATION Tipo_Geometria =
+      Geometria -- {0..*} Geometria;
+      Tipo -<> {1} Tipo;
+    END Tipo_Geometria;
+
+    ASSOCIATION Tipo_Tipo_Ct =
+      Tipo -- {0..*} Tipo;
+      Tipo_Ct (EXTERNAL) -<> {1} Tipo_Ct;
+    END Tipo_Tipo_Ct;
+
+    ASSOCIATION TipoCt_CatalogueCH =
+      Tipo_Ct -- {0..*} Tipo_Ct;
+      Catalogue_CH (EXTERNAL) -- {1} PianiDiUtilizzazione_V1_2.Catalogue_CH.Catalogue_CH;
+    END TipoCt_CatalogueCH;
+
+  END GeodatiDiBase;
+
+  TOPIC MetadatiTrasferimento =
+    DEPENDS ON PianiDiUtilizzazione_V1_2.PrescrizioniLegali;
+
+    CLASS Servizio =
+      Nome : MANDATORY LocalisationCH_V1.MultilingualText;
+      ServizioNelWeb : PianiDiUtilizzazione_V1_2.MultilingualUri;
+      IDI : TEXT*12;
+      Riga1 : TEXT*80;
+      Riga2 : TEXT*80;
+      Via : TEXT*100;
+      Numero : TEXT*7;
+      CAP : TEXT*4;
+      Localita : TEXT*40;
+      UNIQUE IDI;
+    END Servizio;
+
+    CLASS SetDiDati =
+      !!@ basketRef=PianiDiUtilizzazione_V1_2.GeodatiDiBase
+      BasketID : MANDATORY TypeID;
+      Versione : MANDATORY INTERLIS.XMLDate;
+      DataDellaConsegna : INTERLIS.XMLDate;
+      Osservazioni : MTEXT;
+    END SetDiDati;
+
+    ASSOCIATION Dati_servComp =
+      ServizioCompetente -<> {1} Servizio;
+      SetDiDati -- {0..*} SetDiDati;
+    END Dati_servComp;
+
+  END MetadatiTrasferimento;
+
+END PianiDiUtilizzazione_V1_2.


### PR DESCRIPTION
***Follow-up of https://github.com/opengisch/QgisModelBakerLibrary/pull/171 - do not merge before***


## Model Prophet / Settings Prophet

Kind of utility classes to get information from the model via the _BakerPyIndex_ based on the `ili2py` `Index` class. 

While `ModelProphet` is the general base, `SettingsProphet` is convenient to read the settings that should be activated when creating a database from a specific INTERLIS model and (mainly) the `SettingProphet` can handle multiple `ModelProphets` handling multiple models / BakerPyIndexes.

SettingsProphet could have very specific classes in the future as well, like the one described here: https://github.com/opengisch/QgisModelBaker/issues/1150. ModelProphet is intended to be able to be used later on as well (e.g., when reading enumeration values or at basket / OID configuration).

## Structure
```
├── ili2pytools
│   ├── init.py
│   ├── pythonizer.py
│   ├── prophets.py
|   |   - ModelProphet (with functions answering all the questions about one model (and it's parents))
|   |      - Provides relevant stuff (by reading the current model's topics, all the super-topics and the dependent topics)
|   |      - Answers questions (like has_basketoid_definition etc.)
|   |      - Filters models according to a static model blacklist
|   |   - SettingsProphet (with functions answering all the settings questions of multiple models in a convenient way)
|   |      - Answers questions (like needs_basket_column, which calls methods of ModelProphet and combines them to know if it needs the column-setting or not, or contains heuristics like in language_info, and contains_arcs in one of the passed models / BackerPyIndexes).
├── [...]
├── libs
│   ├── [...]
│   ├── ili2py
```

## SettingsProphet
- contains_enumerations: Returns whether any relevant model/topic of one model contains enumerations.
- contains_extended_enumerations: Returns whether the relevant models/topics of one model contain extended enumerations.
- contains_arcs: Returns whether any class in the relevant topics of one model uses arcs.
- contains_multiple_geometry_columns: Returns whether any class in the relevant topics of one model has multiple geometry columns.
- needs_basket_column: Returns whether a basket column is required in one of the models.
- language_infos: Detects translation state and returns language information.

## Not part of this integration
- Setting Prophet: multi_geometry_structures_on_23 and Build my extra-meta-attr-file -> See https://github.com/opengisch/QgisModelBaker/issues/1150
- Setting Prophet: smart_suggestion 
- Setting Prophet: enumeration suggestion (enumTabsWithId/enumTabs/singleEnumTab)

## Info 

To run in the plugin, this is needed: https://github.com/opengisch/QgisModelBaker/pull/1148

## Sponsors

QGIS Model Baker Group :v: